### PR TITLE
Implement keyboard event routing through compositor

### DIFF
--- a/userspace/drivers/keyboard/src/main.rs
+++ b/userspace/drivers/keyboard/src/main.rs
@@ -232,27 +232,25 @@ fn letter(base: u8, shift: bool, caps_lock: bool) -> u8 {
 
 struct KeyboardDriver {
     state: KeyboardState,
-    desktop_port: Option<PortId>,
+    compositor_port: PortId,
     event_count: u64,
 }
 
 impl KeyboardDriver {
-    fn new() -> Self {
+    fn new(compositor_port: PortId) -> Self {
         Self {
             state: KeyboardState::new(),
-            desktop_port: None,
+            compositor_port,
             event_count: 0,
         }
     }
 
     fn run(&mut self) -> ! {
         log("Keyboard Driver: Starting PS/2 keyboard driver");
+        log("Keyboard Driver: Connected to compositor event port");
 
-        // Create our own IPC port for receiving commands
+        // Create our own IPC port for receiving commands (for future use)
         let _our_port = create_port().ok();
-
-        // TODO: Discover desktop port via service registry
-        // For now, the desktop environment will poll directly from kernel buffer
 
         log("Keyboard Driver: Entering main loop");
 
@@ -269,16 +267,10 @@ impl KeyboardDriver {
                         modifiers: self.state.modifiers(),
                     };
 
-                    // Send to desktop environment if connected
-                    if let Some(port) = self.desktop_port {
-                        let msg_type = if pressed {
-                            MessageType::KeyDown
-                        } else {
-                            MessageType::KeyUp
-                        };
-
+                    // Send to compositor (only key press events to reduce traffic)
+                    if pressed {
                         let payload = event.to_bytes();
-                        let _ = send_message_async(port, msg_type, &payload);
+                        let _ = send_message_async(self.compositor_port, MessageType::KeyPress, &payload);
                     }
                 }
             }
@@ -298,7 +290,11 @@ pub extern "C" fn _start() -> ! {
 }
 
 fn main() -> ! {
-    let mut driver = KeyboardDriver::new();
+    // Well-known port: compositor event_port is always port 1
+    // (created first in Compositor::new())
+    const COMPOSITOR_EVENT_PORT: PortId = 1;
+
+    let mut driver = KeyboardDriver::new(COMPOSITOR_EVENT_PORT);
     driver.run()
 }
 

--- a/userspace/drivers/terminal/src/main.rs
+++ b/userspace/drivers/terminal/src/main.rs
@@ -98,7 +98,7 @@ use atom_syscall::ipc::{create_port, try_recv, send, PortId};
 use atom_syscall::thread::{exit, yield_now};
 use atom_syscall::debug::log;
 
-use libipc::messages::{MessageType, MessageHeader, SurfaceAssignMsg, TerminateRequestMsg, AppRegisterMsg, SurfacePresentMsg};
+use libipc::messages::{MessageType, MessageHeader, SurfaceAssignMsg, TerminateRequestMsg, AppRegisterMsg, SurfacePresentMsg, KeyEvent as IpcKeyEvent};
 
 
 
@@ -702,6 +702,40 @@ impl Terminal {
 
 
 
+    /// Convert IPC KeyEvent to Terminal KeyEvent
+    fn convert_ipc_key_event(&self, ipc_event: &IpcKeyEvent) -> Option<KeyEvent> {
+        let character = ipc_event.character;
+        let modifiers = &ipc_event.modifiers;
+
+        // Handle special keys first (backspace, enter, tab, etc.)
+        match character {
+            0x08 => return Some(KeyEvent::Backspace),   // Backspace
+            b'\n' => return Some(KeyEvent::Enter),       // Enter
+            b'\t' => return Some(KeyEvent::Tab),         // Tab
+            0x1B => return Some(KeyEvent::Escape),       // Escape
+            _ => {}
+        }
+
+        // Handle control characters (Ctrl+letter)
+        if modifiers.ctrl && character > 0 && character <= 0x1F {
+            return Some(KeyEvent::Control(character as char));
+        }
+
+        // Handle printable characters
+        if character >= 0x20 && character <= 0x7E {
+            // ASCII printable range
+            if modifiers.alt {
+                return Some(KeyEvent::Alt(character as char));
+            } else {
+                return Some(KeyEvent::Char(character as char));
+            }
+        }
+
+        // For now, ignore keys without ASCII representation
+        // TODO: Handle arrow keys, function keys, etc. via extended scancodes
+        None
+    }
+
     /// Main event loop
     fn run(&mut self, surface: &SharedSurface) {
         log("Terminal: Entering main event loop");
@@ -712,27 +746,34 @@ impl Terminal {
         while self.running {
             let mut had_events = false;
 
-            // Poll for IPC messages (terminate requests from compositor)
-            if let Ok(Some(len)) = try_recv(self.local_port, &mut msg_buffer) {
+            // Poll for IPC messages (keyboard input and compositor messages)
+            while let Ok(Some(len)) = try_recv(self.local_port, &mut msg_buffer) {
                 if len >= MessageHeader::SIZE {
                     if let Some(header) = MessageHeader::from_bytes(&msg_buffer) {
                         match header.msg_type {
                             MessageType::TerminateRequest => {
                                 log("Terminal: Received terminate request");
                                 self.running = false;
-                                continue;
+                                break;
                             }
-                            _ => {}
+                            MessageType::KeyPress => {
+                                // Process keyboard event from compositor
+                                let payload_start = MessageHeader::SIZE;
+                                if len >= payload_start + 3 {
+                                    if let Some(ipc_event) = IpcKeyEvent::from_bytes(&msg_buffer[payload_start..]) {
+                                        // Convert IPC event to terminal event and handle it
+                                        if let Some(event) = self.convert_ipc_key_event(&ipc_event) {
+                                            self.handle_key(event);
+                                        }
+                                    }
+                                }
+                            }
+                            _ => {
+                                // Ignore unknown message types
+                            }
                         }
                     }
                 }
-                had_events = true;
-                idle_count = 0;
-            }
-
-            // Poll for keyboard input - process ALL available events without limit
-            while let Some(event) = self.input_handler.poll() {
-                self.handle_key(event);
                 had_events = true;
                 idle_count = 0;
             }

--- a/userspace/drivers/ui_shell/src/main.rs
+++ b/userspace/drivers/ui_shell/src/main.rs
@@ -107,7 +107,8 @@ use atom_syscall::thread::{yield_now, exit};
 use atom_syscall::debug::log;
 use atom_syscall::process::{spawn_process, ProcessId};
 
-use libipc::messages::{MessageType, MessageHeader, WindowId, SurfaceAssignMsg, TerminateRequestMsg, AppRegisterMsg, SurfacePresentMsg};
+use libipc::messages::{MessageType, MessageHeader, WindowId, SurfaceAssignMsg, TerminateRequestMsg, AppRegisterMsg, SurfacePresentMsg, KeyEvent, KeyModifiers};
+use libipc::protocol::send_message_async;
 
 // ============================================================================
 // Theme Colors (Nord-inspired)
@@ -437,6 +438,12 @@ struct Compositor {
     /// Windows waiting for application to register
     pending_windows: Vec<PendingWindow>,
     dirty: bool,
+    /// Keyboard modifier state
+    keyboard_shift: bool,
+    keyboard_ctrl: bool,
+    keyboard_alt: bool,
+    keyboard_caps_lock: bool,
+    keyboard_extended: bool,
 }
 
 impl Compositor {
@@ -460,6 +467,11 @@ impl Compositor {
             register_port,
             pending_windows: Vec::new(),
             dirty: true,
+            keyboard_shift: false,
+            keyboard_ctrl: false,
+            keyboard_alt: false,
+            keyboard_caps_lock: false,
+            keyboard_extended: false,
         }
     }
 
@@ -594,7 +606,7 @@ impl Compositor {
         }
     }
 
-    /// Handle application event messages (e.g., SurfacePresent)
+    /// Handle application event messages (e.g., SurfacePresent, KeyPress from keyboard driver)
     fn handle_app_event(&mut self, data: &[u8]) {
         if data.len() < MessageHeader::SIZE {
             return;
@@ -618,6 +630,29 @@ impl Compositor {
                         }
                         // Trigger compositor redraw
                         self.dirty = true;
+                    }
+                }
+            }
+            MessageType::KeyPress => {
+                // Keyboard event from keyboard driver - route to focused window
+                let payload_start = MessageHeader::SIZE;
+                if data.len() >= payload_start + 3 {
+                    if let Some(key_event) = KeyEvent::from_bytes(&data[payload_start..]) {
+                        // Get focused window's event port
+                        let event_port = if let Some(focused_id) = self.wm.focused_id {
+                            if let Some(window) = self.wm.get_window(focused_id) {
+                                window.event_port
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        };
+
+                        // Forward to focused window
+                        if let Some(port) = event_port {
+                            let _ = send_message_async(port, MessageType::KeyPress, &key_event.to_bytes());
+                        }
                     }
                 }
             }
@@ -787,13 +822,172 @@ impl Compositor {
     }
 
     fn handle_key(&mut self, scancode: u8) {
-        // Handle escape to quit
-        if scancode == 0x01 {
+        // Handle extended prefix (0xE0)
+        if scancode == 0xE0 {
+            self.keyboard_extended = true;
+            return;
+        }
+
+        let is_extended = self.keyboard_extended;
+        self.keyboard_extended = false;
+
+        let is_release = (scancode & 0x80) != 0;
+        let code = scancode & 0x7F;
+
+        // Handle modifier keys
+        match code {
+            0x2A | 0x36 => {
+                // Left/Right Shift
+                self.keyboard_shift = !is_release;
+                return;
+            }
+            0x1D => {
+                // Ctrl
+                self.keyboard_ctrl = !is_release;
+                return;
+            }
+            0x38 => {
+                // Alt
+                self.keyboard_alt = !is_release;
+                return;
+            }
+            0x3A => {
+                // Caps Lock (toggle on press)
+                if !is_release {
+                    self.keyboard_caps_lock = !self.keyboard_caps_lock;
+                }
+                return;
+            }
+            _ => {}
+        }
+
+        // Handle escape to quit (compositor shortcut)
+        if code == 0x01 && !is_release {
             log("Desktop: Escape pressed, exiting");
             exit(0);
         }
 
-        // Route to focused window (TODO: IPC to application)
+        // Only route key press events (not releases) to focused window
+        if is_release {
+            return;
+        }
+
+        // Get focused window's event port
+        let event_port = if let Some(focused_id) = self.wm.focused_id {
+            if let Some(window) = self.wm.get_window(focused_id) {
+                window.event_port
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        // If no focused window with event port, ignore the key
+        if event_port.is_none() {
+            return;
+        }
+
+        // Translate scancode to ASCII character
+        let character = self.translate_scancode(code, is_extended);
+
+        // Create key event
+        let key_event = KeyEvent {
+            scancode,
+            character,
+            modifiers: KeyModifiers {
+                shift: self.keyboard_shift,
+                ctrl: self.keyboard_ctrl,
+                alt: self.keyboard_alt,
+                caps_lock: self.keyboard_caps_lock,
+            },
+        };
+
+        // Send KeyPress message to the focused window
+        if let Some(port) = event_port {
+            let payload = key_event.to_bytes();
+            let _ = send_message_async(port, MessageType::KeyPress, &payload);
+        }
+    }
+
+    /// Translate scancode to ASCII character
+    fn translate_scancode(&self, code: u8, _extended: bool) -> u8 {
+        let shift = self.keyboard_shift;
+        let caps = self.keyboard_caps_lock;
+
+        match code {
+            // Numbers
+            0x02 => if shift { b'!' } else { b'1' },
+            0x03 => if shift { b'@' } else { b'2' },
+            0x04 => if shift { b'#' } else { b'3' },
+            0x05 => if shift { b'$' } else { b'4' },
+            0x06 => if shift { b'%' } else { b'5' },
+            0x07 => if shift { b'^' } else { b'6' },
+            0x08 => if shift { b'&' } else { b'7' },
+            0x09 => if shift { b'*' } else { b'8' },
+            0x0A => if shift { b'(' } else { b'9' },
+            0x0B => if shift { b')' } else { b'0' },
+            0x0C => if shift { b'_' } else { b'-' },
+            0x0D => if shift { b'+' } else { b'=' },
+
+            // Special keys
+            0x0E => 0x08,  // Backspace
+            0x0F => b'\t', // Tab
+            0x1C => b'\n', // Enter
+            0x39 => b' ',  // Space
+            0x01 => 0x1B,  // Escape
+
+            // Punctuation
+            0x1A => if shift { b'{' } else { b'[' },
+            0x1B => if shift { b'}' } else { b']' },
+            0x27 => if shift { b':' } else { b';' },
+            0x28 => if shift { b'"' } else { b'\'' },
+            0x29 => if shift { b'~' } else { b'`' },
+            0x2B => if shift { b'|' } else { b'\\' },
+            0x33 => if shift { b'<' } else { b',' },
+            0x34 => if shift { b'>' } else { b'.' },
+            0x35 => if shift { b'?' } else { b'/' },
+
+            // Letters (QWERTY layout)
+            0x10 => self.letter(b'q', shift, caps),
+            0x11 => self.letter(b'w', shift, caps),
+            0x12 => self.letter(b'e', shift, caps),
+            0x13 => self.letter(b'r', shift, caps),
+            0x14 => self.letter(b't', shift, caps),
+            0x15 => self.letter(b'y', shift, caps),
+            0x16 => self.letter(b'u', shift, caps),
+            0x17 => self.letter(b'i', shift, caps),
+            0x18 => self.letter(b'o', shift, caps),
+            0x19 => self.letter(b'p', shift, caps),
+            0x1E => self.letter(b'a', shift, caps),
+            0x1F => self.letter(b's', shift, caps),
+            0x20 => self.letter(b'd', shift, caps),
+            0x21 => self.letter(b'f', shift, caps),
+            0x22 => self.letter(b'g', shift, caps),
+            0x23 => self.letter(b'h', shift, caps),
+            0x24 => self.letter(b'j', shift, caps),
+            0x25 => self.letter(b'k', shift, caps),
+            0x26 => self.letter(b'l', shift, caps),
+            0x2C => self.letter(b'z', shift, caps),
+            0x2D => self.letter(b'x', shift, caps),
+            0x2E => self.letter(b'c', shift, caps),
+            0x2F => self.letter(b'v', shift, caps),
+            0x30 => self.letter(b'b', shift, caps),
+            0x31 => self.letter(b'n', shift, caps),
+            0x32 => self.letter(b'm', shift, caps),
+
+            _ => 0, // Unknown key
+        }
+    }
+
+    /// Handle letter case with shift and caps lock
+    fn letter(&self, base: u8, shift: bool, caps: bool) -> u8 {
+        let upper = shift ^ caps;
+        if upper {
+            base.to_ascii_uppercase()
+        } else {
+            base
+        }
     }
 
     fn draw_all(&mut self) {


### PR DESCRIPTION
## Summary
This PR refactors the keyboard input handling architecture to route keyboard events through the compositor instead of having applications poll directly from the kernel buffer. The keyboard driver now sends key events to the compositor, which routes them to the focused window.

## Key Changes

**Keyboard Driver (`userspace/drivers/keyboard/src/main.rs`)**
- Changed `desktop_port` from `Option<PortId>` to required `compositor_port: PortId`
- Updated `KeyboardDriver::new()` to accept compositor port as a parameter
- Modified event sending to use well-known port 1 (compositor's event port)
- Changed to only send key press events (not releases) to reduce traffic
- Removed TODO about service registry discovery; now uses well-known port constant

**Compositor (`userspace/drivers/ui_shell/src/main.rs`)**
- Added keyboard state tracking (shift, ctrl, alt, caps_lock, extended key prefix)
- Implemented `handle_key()` method to process raw scancodes and track modifier state
- Added `translate_scancode()` method to convert scancodes to ASCII characters with proper shift/caps_lock handling
- Added `letter()` helper method for case conversion
- Implemented keyboard event routing: receives `KeyPress` messages from keyboard driver and forwards them to the focused window
- Added `KeyEvent` and `KeyModifiers` message types to handle keyboard input

**Terminal (`userspace/drivers/terminal/src/main.rs`)**
- Added `convert_ipc_key_event()` method to convert IPC `KeyEvent` to terminal `KeyEvent`
- Updated main event loop to receive `KeyPress` messages from compositor instead of polling input handler
- Changed from polling input handler to processing keyboard events via IPC messages
- Handles special keys (backspace, enter, tab, escape) and control characters

## Implementation Details

- **Well-known port**: Compositor event port is hardcoded as port 1, created first during compositor initialization
- **Event flow**: Keyboard driver → Compositor (port 1) → Focused window's event port
- **Modifier tracking**: Compositor maintains keyboard state and includes modifiers in forwarded events
- **Key filtering**: Only key press events are routed (releases are filtered out to reduce message traffic)
- **Scancode translation**: Full QWERTY layout support with shift and caps_lock handling in the compositor

## Summary by Sourcery

Encaminhar a entrada de teclado através do compositor para que as janelas em foco recebam eventos de teclado via IPC em vez de consultar o kernel diretamente.

Novos recursos:
- Introduz roteamento de eventos de teclado no nível do compositor que encaminha pressionamentos de tecla para a janela em foco.
- Adiciona tradução de scancode para ASCII e rastreamento de modificadores (shift, ctrl, alt, caps lock) no compositor.
- Permite que o terminal consuma a entrada de teclado via mensagens IPC `KeyPress` em vez de um manipulador de entrada local.

Aperfeiçoamentos:
- Rastrear o estado de modificadores do teclado e de teclas estendidas no compositor e empacotá-lo em eventos de tecla encaminhados.
- Limitar os eventos de teclado roteados a pressionamentos de tecla para reduzir o tráfego IPC e manter o tratamento de “escape para sair” do compositor.
- Conectar o driver de teclado a uma porta de eventos do compositor bem conhecida para garantir conectividade previsível na inicialização.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Route keyboard input through the compositor so focused windows receive key events via IPC instead of polling the kernel directly.

New Features:
- Introduce compositor-level keyboard event routing that forwards key presses to the focused window.
- Add scancode-to-ASCII translation and modifier tracking (shift, ctrl, alt, caps lock) in the compositor.
- Allow the terminal to consume keyboard input via IPC KeyPress messages instead of a local input handler.

Enhancements:
- Track keyboard modifier and extended-key state in the compositor and package it into forwarded key events.
- Limit routed keyboard events to key presses to reduce IPC traffic and keep compositor escape-to-exit handling.
- Wire the keyboard driver to a well-known compositor event port for predictable startup connectivity.

</details>