### PR TITLE
Fix premature Ready state for blocked threads

### DIFF
--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -179,12 +179,22 @@ impl Scheduler {
             if let Some(cur) = *current {
                 previous = Some(cur);
 
-                if !ready.is_empty() {
+                // Only requeue if the thread is still runnable (not blocked or exited)
+                let current_state = thread::get_thread_state(cur);
+                let is_runnable = current_state
+                    .map(|s| matches!(s, ThreadState::Running | ThreadState::Ready))
+                    .unwrap_or(false);
+
+                if is_runnable && !ready.is_empty() {
                     let priority = self.get_priority(cur);
                     ready.push(cur, priority);
 
                     log_debug!("sched", "Thread {} requeued (priority={:?})", cur, priority);
 
+                    *current = None;
+                } else if !is_runnable {
+                    // Thread is blocked or exited, don't requeue it
+                    log_debug!("sched", "Thread {} not requeued (state={:?})", cur, current_state);
                     *current = None;
                 }
             }
@@ -216,7 +226,12 @@ impl Scheduler {
 
         if let Some(prev) = previous {
             if Some(prev) != chosen {
-                thread::set_thread_state(prev, ThreadState::Ready);
+                // Only set to Ready if it was previously Running
+                // If it was Blocked, it should stay Blocked
+                let prev_state = thread::get_thread_state(prev);
+                if let Some(ThreadState::Running) = prev_state {
+                    thread::set_thread_state(prev, ThreadState::Ready);
+                }
             }
         }
 

--- a/kernel/src/thread.rs
+++ b/kernel/src/thread.rs
@@ -414,6 +414,11 @@ impl ThreadList {
         }
     }
 
+    fn get_state(&self, id: ThreadId) -> Option<ThreadState> {
+        let threads = self.threads.lock();
+        threads.iter().find(|t| t.id == id).map(|t| t.state)
+    }
+
     pub fn get_stats(&self) -> ThreadStats {
         let threads = self.threads.lock();
         let mut stats = ThreadStats::default();
@@ -663,6 +668,10 @@ pub fn get_runnable_threads() -> Vec<ThreadId> {
 
 pub fn set_thread_state(id: ThreadId, state: ThreadState) -> bool {
     THREAD_LIST.set_state(id, state)
+}
+
+pub fn get_thread_state(id: ThreadId) -> Option<ThreadState> {
+    THREAD_LIST.get_state(id)
 }
 
 pub fn get_thread_stats() -> ThreadStats {


### PR DESCRIPTION
This PR fixes an issue where threads calling wait_any (or other blocking calls) were prematurely marked as Ready and requeued by the scheduler during context switches.

Key changes:
1. Added `get_thread_state` to the thread subsystem.
2. Updated `on_timer_tick` in the scheduler to only requeue threads that are actually in a runnable state (Running or Ready).
3. Modified `apply_switch_with_previous` to ensure that a thread's state is only changed to Ready if it was previously Running, preserving the Blocked state if it was set explicitly before the switch.

## Summary by Sourcery

Garantir que o escalonador respeite os estados de thread bloqueados durante trocas de contexto, evitando recolocar prematuramente na fila threads que não estão prontas para execução.

Correções de bugs:
- Impedir que threads bloqueadas ou finalizadas sejam recolocadas na fila a cada tick do timer, verificando seu estado atual antes de inseri-las novamente na fila de prontas.
- Preservar o estado Blocked de uma thread durante trocas de contexto, apenas mudando seu estado de volta para Ready se ela estava anteriormente em Running.

Melhorias:
- Expor o estado da thread por meio de novos accessors no subsistema de threads, permitindo que o escalonador consulte com segurança o estado atual de uma thread.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure scheduler respects blocked thread states during context switches to prevent prematurely requeuing non-runnable threads.

Bug Fixes:
- Prevent blocked or exited threads from being requeued on timer tick by checking their current thread state before pushing back to the ready queue.
- Preserve a thread’s Blocked state across context switches by only transitioning it back to Ready if it was previously Running.

Enhancements:
- Expose thread state via new accessors in the thread subsystem so the scheduler can query a thread’s current state safely.

</details>