### PR TITLE
Reduce Kernel Log Verbosity

### DIFF
--- a/kernel/src/input.rs
+++ b/kernel/src/input.rs
@@ -143,13 +143,8 @@ pub fn on_keyboard_irq() {
         }
 
         let scancode = read_data();
-        crate::serial_println!("[IRQ1] scancode: 0x{:02X}", scancode);
         buf.push(scancode);
         count += 1;
-    }
-
-    if count == 0 {
-        crate::serial_println!("[IRQ1] no data available (status check failed)");
     }
 }
 
@@ -171,15 +166,6 @@ pub fn on_mouse_irq() {
         count += 1;
     }
     
-    if count > 0 {
-        // Log raw bytes for debugging
-        if count >= 3 {
-            crate::serial_println!("[IRQ12] {} bytes: [{:02X} {:02X} {:02X}]",
-                count, bytes_debug[0], bytes_debug[1], bytes_debug[2]);
-        } else {
-            crate::serial_println!("[IRQ12] {} bytes", count);
-        }
-    }
 }
 
 /// Poll for next keyboard byte (called from syscall)

--- a/kernel/src/interrupts/handlers.rs
+++ b/kernel/src/interrupts/handlers.rs
@@ -396,8 +396,6 @@ pub extern "x86-interrupt" fn timer_interrupt_handler(_frame: &mut InterruptStac
 }
 
 pub extern "x86-interrupt" fn keyboard_interrupt_handler(_frame: &mut InterruptStackFrame) {
-    // Debug: Log every IRQ1
-    crate::serial_println!("[IRQ1] keyboard handler called");
 
     // Buffer raw keyboard data for userspace driver
     input::on_keyboard_irq();
@@ -411,8 +409,6 @@ pub extern "x86-interrupt" fn keyboard_interrupt_handler(_frame: &mut InterruptS
 }
 
 pub extern "x86-interrupt" fn mouse_interrupt_handler(_frame: &mut InterruptStackFrame) {
-    // Debug: Log every IRQ12
-    crate::serial_println!("[IRQ12] handler called");
     
     // Buffer raw mouse data for userspace driver
     input::on_mouse_irq();

--- a/kernel/src/log.rs
+++ b/kernel/src/log.rs
@@ -135,7 +135,7 @@ static mut CURRENT_LOG_LEVEL: LogLevel = LogLevel::Debug;
 static mut VGA_OUTPUT_ENABLED: bool = false;
 
 pub fn init() {
-    set_level(LogLevel::Debug);
+    set_level(LogLevel::Info);
 }
 
 /// Mark that the heap is now available for allocations

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -86,7 +86,6 @@ impl ReadyQueues {
                             // Thread is not Ready (e.g. WaitingIpc, Blocked, Exited)
                             // Do not put it back in the queue.
                             // It will be re-added when it becomes Ready.
-                            crate::serial_println!("[SCHED_DEBUG] pop_next: thread {} is in state {:?}, removing from queue", id, state);
                         }
                     }
                 }
@@ -290,7 +289,6 @@ impl Scheduler {
         let priority = self.get_priority(id);
         thread::set_thread_state(id, ThreadState::Ready);
         self.ready.lock().push(id, priority);
-        crate::serial_println!("[SCHED_DEBUG] mark_thread_ready: thread {} added to queue (priority={:?})", id, priority);
     }
 
     fn current_thread(&self) -> Option<ThreadId> {

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -334,15 +334,12 @@ extern "C" fn rust_syscall_dispatcher(
         }
     };
 
-    crate::serial_println!("[SYSCALL_RET] Syscall {} returning: {:#X}", syscall_num, result);
     result
 }
 
 fn sys_mouse_poll() -> u64 {
     // Return next raw mouse byte for userspace driver to process
     if let Some(byte) = crate::input::poll_mouse_byte() {
-        // Debug: Log bytes being returned to userspace
-        crate::serial_println!("[MOUSE_POLL] returning byte: 0x{:02X}", byte);
         return byte as u64;
     }
     EWOULDBLOCK
@@ -429,28 +426,18 @@ fn sys_get_ticks() -> u64 {
 
 /// Debug log from userspace
 fn sys_debug_log(msg_ptr: *const u8, len: usize) -> u64 {
-    crate::serial_println!("[DEBUG_LOG] Entry: msg_ptr={:p}, len={}", msg_ptr, len);
-
     if msg_ptr.is_null() || len > 256 {
-        crate::serial_println!("[DEBUG_LOG] Invalid args, returning EINVAL");
         return EINVAL;
     }
 
-    crate::serial_println!("[DEBUG_LOG] Creating slice...");
     let msg = unsafe {
         core::slice::from_raw_parts(msg_ptr, len)
     };
 
-    crate::serial_println!("[DEBUG_LOG] Converting to UTF-8...");
     if let Ok(s) = core::str::from_utf8(msg) {
-        crate::serial_println!("[DEBUG_LOG] Logging message...");
         log_info!("userspace", "{}", s);
-        crate::serial_println!("[DEBUG_LOG] Message logged successfully");
-    } else {
-        crate::serial_println!("[DEBUG_LOG] UTF-8 conversion failed");
     }
 
-    crate::serial_println!("[DEBUG_LOG] Returning ESUCCESS");
     ESUCCESS
 }
 
@@ -647,11 +634,6 @@ fn sys_thread_create(entry_point: u64, stack_ptr: u64, flags: u64) -> u64 {
     };
     let kernel_stack = kernel_stack_phys + KERNEL_STACK_SIZE;
     
-    crate::serial_println!(
-        "[THREAD_CREATE] Allocating kernel stack: phys={:#X} top={:#X} size={} pages={}",
-        kernel_stack_phys, kernel_stack, KERNEL_STACK_SIZE, KERNEL_STACK_SIZE / 4096
-    );
-
     let thread = crate::thread::Thread::new(
         entry_point,
         kernel_stack as u64,
@@ -3294,11 +3276,6 @@ fn spawn_process_internal(
     let kernel_stack_virt = vm::HIGHER_HALF_BASE + kernel_stack_phys;
     let kernel_stack_top = (kernel_stack_virt + KERNEL_STACK_PAGES * PAGE_SIZE) as u64;
     
-    crate::serial_println!(
-        "[SPAWN_PROCESS] Allocating kernel stack: phys={:#X} virt={:#X} top={:#X} size={} pages={}",
-        kernel_stack_phys, kernel_stack_virt, kernel_stack_top,
-        KERNEL_STACK_PAGES * PAGE_SIZE, KERNEL_STACK_PAGES
-    );
 
     // Calculate entry point
     let entry_point = text_base + sections.entry_offset;
@@ -3329,16 +3306,12 @@ fn spawn_process_internal(
         
         // Verify write
         let readback = core::ptr::read_volatile(canary_addr);
-        crate::serial_println!(
-            "[CANARY_SET] tid={} name={} addr={:#X} val={:#X} (expected={:#X}) top={:#X} bottom={:#X} size={}",
-            pid, static_name, canary_addr as u64, readback, STACK_CANARY,
-            kernel_stack_top, bottom, KERNEL_STACK_PAGES * PAGE_SIZE
-        );
         
         if readback != STACK_CANARY {
-            crate::serial_println!(
-                "[CANARY_SET] WARNING: Canary read-back mismatch! Got {:#X} expected {:#X}",
-                readback, STACK_CANARY
+            log_error!(
+                "spawn",
+                "tid={} name={} Canary read-back mismatch! Got {:#X} expected {:#X}",
+                pid, static_name, readback, STACK_CANARY
             );
         }
     }

--- a/kernel/src/thread.rs
+++ b/kernel/src/thread.rs
@@ -65,7 +65,7 @@ use alloc::vec::Vec;
 use core::sync::atomic::{AtomicU64, Ordering};
 use spin::Mutex;
 use crate::arch::gdt;
-use crate::{log_error, log_info, log_panic};
+use crate::{log_debug, log_error, log_info, log_panic};
 
 use crate::cap::CapabilityTable;
 
@@ -258,15 +258,12 @@ impl Thread {
             
             // Read back to verify write succeeded
             let readback = core::ptr::read_volatile(canary_addr);
-            crate::serial_println!(
-                "[CANARY_SET] tid={} name={} addr={:#X} val={:#X} (expected={:#X}) top={:#X} bottom={:#X} size={}",
-                id, name, canary_addr as u64, readback, STACK_CANARY, kernel_stack, bottom, kernel_stack_size
-            );
             
             if readback != STACK_CANARY {
-                crate::serial_println!(
-                    "[CANARY_SET] WARNING: Canary read-back mismatch! Got {:#X} expected {:#X}",
-                    readback, STACK_CANARY
+                log_error!(
+                    LOG_ORIGIN,
+                    "tid={} name={} Canary read-back mismatch! Got {:#X} expected {:#X}",
+                    id, name, readback, STACK_CANARY
                 );
             }
             
@@ -495,9 +492,7 @@ impl ThreadList {
         thread_id: ThreadId,
         capability: crate::cap::Capability,
     ) -> Result<crate::cap::CapHandle, crate::cap::CapError> {
-        crate::serial_println!("[ADD_CAPABILITY] Thread {} attempting to lock THREAD_LIST", thread_id);
         let mut threads = self.threads.lock();
-        crate::serial_println!("[ADD_CAPABILITY] Lock acquired for thread {}", thread_id);
         let thread = threads
             .iter_mut()
             .find(|t| t.id == thread_id)
@@ -591,7 +586,7 @@ pub fn thread_count() -> usize {
 pub fn log_user_entry_once(thread_id: ThreadId, ctx: &CpuContext) {
     let mut entries = USERMODE_ENTRIES.lock();
     if entries.insert(thread_id) {
-        log_info!(
+        log_debug!(
             LOG_ORIGIN,
             "Thread {} entering user mode: RIP={:#016X} RSP={:#016X} CS={:#04X} SS={:#04X}",
             thread_id,
@@ -612,34 +607,34 @@ pub fn log_user_entry_once(thread_id: ThreadId, ctx: &CpuContext) {
         }
         
         unsafe {
-            log_info!(
+            log_debug!(
                 "DEBUG_IRET",
                 "IRET frame @ kernel RSP={:#016X}:",
                 DEBUG_IRET_KERNEL_RSP
             );
-            log_info!(
+            log_debug!(
                 "DEBUG_IRET",
                 "  [rsp+0]  RIP    = {:#016X} (expected: {:#016X})",
                 DEBUG_IRET_RIP,
                 ctx.rip
             );
-            log_info!(
+            log_debug!(
                 "DEBUG_IRET",
                 "  [rsp+8]  CS     = {:#016X} (expected: 0x000000000000001B)",
                 DEBUG_IRET_CS
             );
-            log_info!(
+            log_debug!(
                 "DEBUG_IRET",
                 "  [rsp+16] RFLAGS = {:#016X}",
                 DEBUG_IRET_RFLAGS
             );
-            log_info!(
+            log_debug!(
                 "DEBUG_IRET",
                 "  [rsp+24] RSP    = {:#016X} (expected: {:#016X})",
                 DEBUG_IRET_RSP,
                 ctx.rsp
             );
-            log_info!(
+            log_debug!(
                 "DEBUG_IRET",
                 "  [rsp+32] SS     = {:#016X} (expected: 0x0000000000000023)",
                 DEBUG_IRET_SS
@@ -791,7 +786,7 @@ pub unsafe fn jump_to_context(context: &CpuContext) -> ! {
     // For first-time user entry, use dedicated enter_user to avoid complex switch logic
     let is_user_mode = (context.cs & 0x3) == 0x3;
     if is_user_mode {
-        log_info!(
+        log_debug!(
             LOG_ORIGIN,
             "Using enter_user for first user jump: RIP={:#016X} RSP={:#016X} CR3={:#016X}",
             context.rip,
@@ -897,7 +892,6 @@ pub fn snapshot_context(thread_id: ThreadId) -> Option<CpuContext> {
 pub fn force_set_userspace_ctx(thread_id: ThreadId, user_rip: u64, user_rsp: u64) {
     let mut threads = THREAD_LIST.threads.lock();
     if let Some(t) = threads.iter_mut().find(|t| t.id == thread_id) {
-        crate::serial_println!("[FORCE_USER_CTX] Thread {} RIP={:#X} RSP={:#X}", thread_id, user_rip, user_rsp);
         t.context.rip = user_rip;
         t.context.rsp = user_rsp;
         t.context.cs = gdt::USER_CODE_SELECTOR;
@@ -921,28 +915,15 @@ where
 /// userspace RIP (return address) and RSP, not the kernel's RIP/RSP.
 /// This is critical for syscalls that may cause context switches (e.g., yield).
 pub fn update_thread_userspace_context(thread_id: ThreadId, user_rip: u64, user_rsp: u64) {
-    crate::serial_println!("[UPDATE_CTX] Entry: thread_id={}, user_rip={:#X}, user_rsp={:#X}", thread_id, user_rip, user_rsp);
-
-    crate::serial_println!("[UPDATE_CTX] Acquiring THREAD_LIST lock...");
     let mut threads = THREAD_LIST.threads.lock();
-    crate::serial_println!("[UPDATE_CTX] Lock acquired, searching for thread {}...", thread_id);
 
     if let Some(thread) = threads.iter_mut().find(|t| t.id == thread_id) {
-        crate::serial_println!("[UPDATE_CTX] Thread found, CS={:#X}", thread.context.cs);
         // Only update if this is a userspace thread (CPL=3)
         if (thread.context.cs & 0x3) == 0x3 {
-            crate::serial_println!("[UPDATE_CTX] Updating RIP and RSP...");
             thread.context.rip = user_rip;
             thread.context.rsp = user_rsp;
-            crate::serial_println!("[UPDATE_CTX] Update complete");
-        } else {
-            crate::serial_println!("[UPDATE_CTX] Not a userspace thread, skipping update");
         }
-    } else {
-        crate::serial_println!("[UPDATE_CTX] Thread {} not found!", thread_id);
     }
-
-    crate::serial_println!("[UPDATE_CTX] Releasing lock and returning");
 }
 
 pub fn capture_current_context() -> CpuContext {
@@ -1009,9 +990,7 @@ pub fn perform_context_switch(from_id: ThreadId, to_id: ThreadId) {
 
     // Acquire lock, validate, update contexts, get pointers, then RELEASE lock before switch
     let (from_ctx_ptr, to_ctx_ptr, to_kernel_stack, to_is_usermode, to_is_user_thread, to_entry_rip, to_entry_rsp, to_cr3) = {
-        crate::serial_println!("[CONTEXT_SWITCH] Acquiring THREAD_LIST lock for switch from {} to {}", from_id, to_id);
         let mut threads = THREAD_LIST.threads.lock();
-        crate::serial_println!("[CONTEXT_SWITCH] Lock acquired");
 
         let from_idx = threads.iter().position(|t| t.id == from_id)
             .expect("from thread not found in context switch");
@@ -1030,30 +1009,11 @@ pub fn perform_context_switch(from_id: ThreadId, to_id: ThreadId) {
                 let current_rsp: u64;
                 core::arch::asm!("mov {}, rsp", out(reg) current_rsp);
                 
-                crate::serial_println!(
+                log_error!(
+                    LOG_ORIGIN,
                     "[CANARY_CORRUPT] tid={} name={} canary_addr={:#X} expected={:#X} actual={:#X}",
                     from_id, from_thread.name, canary_addr as u64, STACK_CANARY, actual
                 );
-                crate::serial_println!(
-                    "[CANARY_CORRUPT] stack_top={:#X} bottom={:#X} size={} current_rsp={:#X}",
-                    from_thread.kernel_stack, bottom, from_thread.kernel_stack_size, current_rsp
-                );
-                crate::serial_println!(
-                    "[CANARY_CORRUPT] rsp_out_of_range={} (rsp < bottom OR rsp >= top)",
-                    current_rsp < bottom || current_rsp >= from_thread.kernel_stack
-                );
-                
-                // Dump 64 bytes around canary for forensics
-                crate::serial_println!("[CANARY_CORRUPT] Memory dump around canary:");
-                for offset in -4i64..=4i64 {
-                    let addr = (canary_addr as i64 + offset * 8) as *const u64;
-                    let val = core::ptr::read_volatile(addr);
-                    crate::serial_println!(
-                        "  [{:#X}] = {:#016X} {}",
-                        addr as u64, val,
-                        if offset == 0 { "<-- CANARY" } else { "" }
-                    );
-                }
             }
             
             actual == STACK_CANARY
@@ -1075,7 +1035,6 @@ pub fn perform_context_switch(from_id: ThreadId, to_id: ThreadId) {
         if let Some((user_rip, user_rsp)) = userspace_return {
             let from_ctx = &mut threads[from_idx].context;
             if (from_ctx.cs & 0x3) == 0x3 {  // Only for userspace threads
-                crate::serial_println!("[CONTEXT_SWITCH] Updating FROM thread {} userspace return: RIP={:#X} RSP={:#X}", from_id, user_rip, user_rsp);
                 from_ctx.rip = user_rip;
                 from_ctx.rsp = user_rsp;
             }
@@ -1100,11 +1059,6 @@ pub fn perform_context_switch(from_id: ThreadId, to_id: ThreadId) {
         threads[from_idx].context.cr3 = from_cr3;
         threads[to_idx].context.cr3 = to_cr3;
         
-        crate::serial_println!(
-            "[CONTEXT_SWITCH] CR3 fix: from_id={} addr_space={:#X} forced_cr3={:#X} | to_id={} addr_space={:#X} forced_cr3={:#X}",
-            from_id, from_addr_space, from_cr3, to_id, to_addr_space, to_cr3
-        );
-        
         // Get raw pointers to contexts and kernel stack
         let from_ptr = &mut threads[from_idx].context as *mut CpuContext;
         let to_ptr = &threads[to_idx].context as *const CpuContext;
@@ -1114,15 +1068,10 @@ pub fn perform_context_switch(from_id: ThreadId, to_id: ThreadId) {
         // DO NOT trust context.cs - it may contain garbage or kernel CS even for userspace threads
         let has_userspace_return = crate::syscall::get_userspace_return_addr(to_id).is_some();
         
-        crate::serial_println!(
-            "[CONTEXT_SWITCH] TO thread {} has_userspace_return={} context.cs={:#X}",
-            to_id, has_userspace_return, threads[to_idx].context.cs
-        );
-
         // Log if switching to usermode
         if has_userspace_return {
             log_user_entry_once(to_id, &threads[to_idx].context);
-            log_info!(
+            log_debug!(
                 LOG_ORIGIN,
                 "Switching to user context: RIP={:#016X} CS={:#04X} SS={:#04X} CPL=3 CR3={:#016X}",
                 threads[to_idx].context.rip,
@@ -1142,15 +1091,8 @@ pub fn perform_context_switch(from_id: ThreadId, to_id: ThreadId) {
         let to_entry_rip = threads[to_idx].context.rip;
         let to_entry_rsp = threads[to_idx].context.rsp;
         
-        crate::serial_println!(
-            "[CONTEXT_SWITCH] Pointers acquired, to_is_user={} has_ret={} entry_rip={:#X} entry_rsp={:#X}",
-            to_is_user_thread, has_userspace_return, to_entry_rip, to_entry_rsp
-        );
-        crate::serial_println!("[CONTEXT_SWITCH] Releasing lock BEFORE switch");
         (from_ptr, to_ptr, kstack, has_userspace_return, to_is_user_thread, to_entry_rip, to_entry_rsp, to_cr3)
     }; // 🔓 LOCK RELEASED HERE, BEFORE THE SWITCH
-
-    crate::serial_println!("[CONTEXT_SWITCH] Lock released");
 
     // CRITICAL: Update TSS.RSP0 for the new thread BEFORE entering userspace
     // This ensures interrupt frames from usermode go to the correct kernel stack
@@ -1165,7 +1107,6 @@ pub fn perform_context_switch(from_id: ThreadId, to_id: ThreadId) {
         // Determine target RIP/RSP: use saved return address if exists, else initial context
         let (target_rip, target_rsp) = if to_is_usermode {
             if let Some((urip, ursp)) = crate::syscall::get_userspace_return_addr(to_id) {
-                crate::serial_println!("[CONTEXT_SWITCH] User return from syscall: tid={} rip={:#X} rsp={:#X}", to_id, urip, ursp);
                 (urip, ursp)
             } else {
                 log_error!(
@@ -1176,11 +1117,10 @@ pub fn perform_context_switch(from_id: ThreadId, to_id: ThreadId) {
                 (to_entry_rip, to_entry_rsp)
             }
         } else {
-            crate::serial_println!("[CONTEXT_SWITCH] First user entry: tid={} rip={:#X} rsp={:#X}", to_id, to_entry_rip, to_entry_rsp);
             (to_entry_rip, to_entry_rsp)
         };
         
-        log_info!(
+        log_debug!(
             LOG_ORIGIN,
             "Enter userspace: TID={} RIP={:#016X} RSP={:#016X} CR3={:#016X} first_time={}",
             to_id, target_rip, target_rsp, to_cr3, !to_is_usermode
@@ -1192,22 +1132,13 @@ pub fn perform_context_switch(from_id: ThreadId, to_id: ThreadId) {
         // Choose the right entry function based on whether this is first-time or syscall return
         if to_is_usermode {
             // Syscall return - restore callee-saved registers (RBX, RBP, R12-R15) from saved context
-            if let Some(gprs) = crate::syscall::get_userspace_gprs(to_id) {
-                crate::serial_println!(
-                    "[CONTEXT_SWITCH] -> enter_user_resume (restore GPRs, rip={:#X}, rsp={:#X}, cr3={:#X})",
-                    target_rip, target_rsp, to_cr3
-                );
-                crate::serial_println!(
-                    "[CONTEXT_SWITCH]    GPRs: rbx={:#X} rbp={:#X} r12={:#X} r13={:#X} r14={:#X} r15={:#X}",
-                    gprs.rbx, gprs.rbp, gprs.r12, gprs.r13, gprs.r14, gprs.r15
-                );
+            if let Some(_gprs) = crate::syscall::get_userspace_gprs(to_id) {
                 // CRITICAL: Pass pointer to GPRs struct (must be stable memory, not stack local)
                 // We need to ensure the USERSPACE_GPRS map entry lives long enough
                 // So we'll get the reference while the lock is held
                 let gprs_map = crate::syscall::USERSPACE_GPRS.lock();
                 if let Some(gprs_ref) = gprs_map.get(&to_id) {
                     let gprs_ptr = gprs_ref as *const crate::syscall::UserspaceGprs;
-                    crate::serial_println!("[CONTEXT_SWITCH]    GPRs ptr: {:p}", gprs_ptr);
                     drop(gprs_map); // Release lock before entering user
                     unsafe {
                         enter_user_resume(target_rip, target_rsp, to_cr3, gprs_ptr);
@@ -1235,25 +1166,16 @@ pub fn perform_context_switch(from_id: ThreadId, to_id: ThreadId) {
             }
         } else {
             // First-time entry - zero all registers for clean state
-            crate::serial_println!(
-                "[CONTEXT_SWITCH] -> enter_user_first_time (clean state, rip={:#X}, rsp={:#X}, cr3={:#X})",
-                target_rip, target_rsp, to_cr3
-            );
             unsafe {
                 enter_user_first_time(target_rip, target_rsp, to_cr3);
             }
         }
     }
     
-    // Kernel thread switch - use normal context switch
-    crate::serial_println!("[CONTEXT_SWITCH] Kernel-to-kernel switch");
-
     // Validate target context before the switch
     unsafe {
         guard_context_or_halt(&*to_ctx_ptr, "scheduled");
     }
-
-    crate::serial_println!("[CONTEXT_SWITCH] switch_context (no return to this context)");
 
     // Perform the actual context switch with no locks held
     // NOTE: This does NOT return in the linear sense - execution continues

--- a/userspace/services/namesvc/build.log
+++ b/userspace/services/namesvc/build.log
@@ -1,0 +1,6 @@
+error: current package believes it's in a workspace when it's not:
+current:   /app/userspace/services/namesvc/Cargo.toml
+workspace: /app/Cargo.toml
+
+this may be fixable by adding `userspace/services/namesvc` to the `workspace.members` array of the manifest located at: /app/Cargo.toml
+Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.

--- a/userspace/services/service_manager/build.log
+++ b/userspace/services/service_manager/build.log
@@ -1,0 +1,6 @@
+error: current package believes it's in a workspace when it's not:
+current:   /app/userspace/services/service_manager/Cargo.toml
+workspace: /app/Cargo.toml
+
+this may be fixable by adding `userspace/services/service_manager` to the `workspace.members` array of the manifest located at: /app/Cargo.toml
+Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.


### PR DESCRIPTION
Addresses the issue of excessive kernel logging (30k+ lines/min) by removing high-frequency serial output and adjusting default log levels. Pertinent diagnostic information is preserved through proper log levels.

---
*PR created automatically by Jules for task [14860343245800409616](https://jules.google.com/task/14860343245800409616) started by @fpedrolucas95*

## Summary by Sourcery

Reduz a verbosidade dos logs do kernel removendo a saída de depuração serial de alta frequência e diminuindo o nível de log padrão, preservando o registro de erros para condições críticas.

Correções de bugs:
- Preserva e eleva os logs de incompatibilidade de *stack canary* para o nível de erro para melhorar a visibilidade de problemas de corrupção.

Melhorias:
- Rebaixa vários logs informativos de transição para modo usuário e de troca de contexto de nível info para nível debug, a fim de limitar o ruído rotineiro nos logs.
- Simplifica os caminhos de syscall, entrada, escalonamento e criação de processos/threads removendo logs de depuração excessivos que produziam grandes volumes de saída serial.

Tarefas de manutenção:
- Adiciona artefatos `build.log` gerados para os serviços em espaço de usuário `namesvc` e `service_manager`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reduce kernel log verbosity by removing high-frequency serial debug output and lowering default log level while preserving error logging for critical conditions.

Bug Fixes:
- Preserve and elevate stack canary mismatch logs to error level for better visibility of corruption issues.

Enhancements:
- Downgrade various informational user-mode transition and context switch logs from info to debug level to limit routine noise in logs.
- Simplify syscall, input, scheduling, and process/thread creation paths by removing excessive debug logging that produced large volumes of serial output.

Chores:
- Add generated build.log artifacts for namesvc and service_manager userspace services.

</details>