### PR TITLE
Resolve init race condition and improve IPC lookup robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,6 @@ efi/drivers/
 # Tool build logs
 tools/elf2atxf/build.log
 
-# Userspace driver build logs
+# Userspace driver and service build logs
 userspace/drivers/*/build.log
+userspace/services/*/build.log

--- a/userspace/libs/libipc/src/protocol.rs
+++ b/userspace/libs/libipc/src/protocol.rs
@@ -111,7 +111,7 @@ pub fn lookup_service(name: &str) -> SyscallResult<PortId> {
     // Simple retry loop with yield
     let mut result = Err(atom_syscall::SyscallError::TimedOut);
 
-    for _ in 0..100 {
+    for _ in 0..1000 {
         if let Ok(Some((header, len))) = try_recv_message(reply_port, &mut buffer) {
             if header.msg_type == MessageType::NsResponse {
                 let payload = get_payload(&buffer, len);

--- a/userspace/services/init/src/main.rs
+++ b/userspace/services/init/src/main.rs
@@ -149,32 +149,6 @@ fn wait_for_namesvc() -> bool {
     false
 }
 
-/// Wait for a service to register, with a timeout to prevent blocking forever.
-/// Returns true if the service was found, false if timed out.
-fn wait_for_service(name: &str) -> bool {
-    log("init: waiting for service '");
-    log(name);
-    log("'...");
-
-    // Timeout: 500 iterations * 10ms = 5 seconds max wait
-    const MAX_WAIT_ITERATIONS: u32 = 500;
-
-    for _ in 0..MAX_WAIT_ITERATIONS {
-        if libipc::protocol::lookup_service(name).is_ok() {
-            log("init: service '");
-            log(name);
-            log("' is registered and ready");
-            return true;
-        }
-        atom_syscall::thread::sleep_ms(10);
-    }
-
-    log("init: WARNING - timed out waiting for service '");
-    log(name);
-    log("', continuing boot sequence anyway");
-    false
-}
-
 fn boot_sequence() {
     log("===========================================");
     log("Atom Init Process (PID 1)");
@@ -206,14 +180,6 @@ fn boot_sequence() {
     log("[Phase 2] Spawning UI shell (compositor)...");
 
     let _ui_pid = spawn_service("ui_shell");
-
-    // Wait for compositor to be registered before drivers.
-    // Input drivers depend on the compositor's IPC port.
-    // Uses a timeout so boot continues even if compositor is slow.
-    let compositor_ready = wait_for_service("compositor");
-    if !compositor_ready {
-        log("[Phase 2] WARNING: Compositor not ready, drivers will retry lookup themselves");
-    }
 
     log("[Phase 2] UI shell phase complete");
 


### PR DESCRIPTION
This change fixes a race condition during the Atom OS boot sequence where the `init` process could get stuck waiting for the compositor due to a too-short timeout in `lookup_service()`. By removing the explicit wait in `init` and increasing the robustness of `lookup_service()`, the boot sequence now proceeds correctly to Phase 3, where drivers perform their own discovery of the compositor service.

---
*PR created automatically by Jules for task [5767026768765065147](https://jules.google.com/task/5767026768765065147) started by @fpedrolucas95*

## Resumo pelo Sourcery

Ajustar a sincronização da sequência de boot do init com o registro do compositor e tornar mais robusto o timing da busca pelo serviço IPC.

Correções de bugs:
- Eliminar o loop de espera no lado do init que podia fazer a sequência de boot travar enquanto aguardava o serviço do compositor.

Melhorias:
- Aumentar a duração de repetição (`retry`) de `lookup_service` para tornar as buscas pelo serviço de nomes IPC mais robustas em condições de inicialização lenta.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust init boot sequence synchronization with compositor registration and harden IPC service lookup timing.

Bug Fixes:
- Eliminate init-side wait loop that could cause the boot sequence to stall while waiting for the compositor service.

Enhancements:
- Increase lookup_service retry duration to make IPC name service lookups more robust under slow-start conditions.

</details>