### PR TITLE
Implement full PS/2 controller initialization with mouse extension detection

### DIFF
--- a/kernel/src/input.rs
+++ b/kernel/src/input.rs
@@ -1,42 +1,97 @@
-// Input Subsystem - Minimal IRQ Buffer for Userspace Drivers
+// Input Subsystem - PS/2 Controller and Mouse/Keyboard IRQ Buffering
 //
-// This module provides a minimal kernel-side input buffer that captures raw
-// hardware events from keyboard and mouse IRQs. The actual driver logic runs
-// entirely in userspace - this module only provides IRQ-safe buffering.
+// This module implements the full PS/2 controller initialization and provides
+// IRQ-safe ring buffers for raw hardware events. The actual driver logic
+// (packet parsing, event generation) runs in userspace.
 //
-// Design philosophy:
-// - Kernel does NOT interpret scancodes or mouse packets
-// - Kernel only buffers raw bytes from hardware I/O ports
-// - Userspace drivers poll these buffers via syscalls
-// - This maintains microkernel architecture with minimal kernel code
+// PS/2 Mouse initialization follows the OSDev specification:
+// 1. Disable devices during configuration
+// 2. Configure controller (Compaq status byte: enable IRQ1 + IRQ12)
+// 3. Re-enable ports
+// 4. Reset keyboard, set scancode set 2
+// 5. Reset mouse to defaults
+// 6. Detect scroll wheel via magic sample rate sequence (200, 100, 80)
+// 7. Detect 4th/5th buttons via second magic sequence (200, 200, 80)
+// 8. Configure sample rate, resolution, scaling
+// 9. Enable data reporting (streaming mode)
+// 10. Re-verify controller config (guards against config corruption)
 //
-// Key responsibilities:
-// - Buffer raw PS/2 scancodes from keyboard IRQ (IRQ1)
-// - Buffer raw PS/2 bytes from mouse IRQ (IRQ12)
-// - Provide syscall-accessible polling interface
-// - Handle IRQ-safe ring buffer operations
+// The detected mouseID (0, 3, or 4) determines packet size:
+//   - ID 0: 3-byte packets (basic mouse)
+//   - ID 3: 4-byte packets (scroll wheel, Z-axis)
+//   - ID 4: 4-byte packets (scroll wheel + 4th/5th buttons)
 //
 // Public interface:
 // - `init()` - Initialize the input subsystem
+// - `init_ps2_mouse_full()` - Full PS/2 controller init
 // - `on_keyboard_irq()` - Called from keyboard interrupt handler
 // - `on_mouse_irq()` - Called from mouse interrupt handler
 // - `poll_keyboard_byte()` - Syscall: get next keyboard byte
 // - `poll_mouse_byte()` - Syscall: get next mouse byte
+// - `get_mouse_id()` - Return detected mouseID (0, 3, or 4)
 
 use spin::Mutex;
+use core::sync::atomic::{AtomicU8, Ordering};
 use crate::log_info;
 
-// PS/2 ports
+// ============================================================================
+// PS/2 Hardware Constants
+// ============================================================================
+
+/// PS/2 data port - reads/writes data bytes
 const PS2_DATA_PORT: u16 = 0x60;
+/// PS/2 status/command port - reads status, writes commands
 const PS2_STATUS_PORT: u16 = 0x64;
+
+/// Status register bit: output buffer full (data available to read)
 const STATUS_OUTPUT_FULL: u8 = 0x01;
+/// Status register bit: input buffer full (controller busy, wait before writing)
+const STATUS_INPUT_FULL: u8 = 0x02;
+/// Status register bit: data came from auxiliary (mouse) port
 const STATUS_AUX_DATA: u8 = 0x20;
 
-// Ring buffer capacity (must be power of 2 for efficiency)
+/// PS/2 controller commands (written to STATUS_PORT)
+const CMD_READ_CONFIG: u8 = 0x20;
+const CMD_WRITE_CONFIG: u8 = 0x60;
+const CMD_DISABLE_KEYBOARD: u8 = 0xAD;
+const CMD_ENABLE_KEYBOARD: u8 = 0xAE;
+const CMD_DISABLE_MOUSE: u8 = 0xA7;
+const CMD_ENABLE_MOUSE: u8 = 0xA8;
+const CMD_SEND_TO_MOUSE: u8 = 0xD4;
+
+/// PS/2 mouse commands (sent via CMD_SEND_TO_MOUSE)
+const MOUSE_CMD_RESET: u8 = 0xFF;
+const MOUSE_CMD_SET_DEFAULTS: u8 = 0xF6;
+const MOUSE_CMD_DISABLE_STREAMING: u8 = 0xF5;
+const MOUSE_CMD_ENABLE_STREAMING: u8 = 0xF4;
+const MOUSE_CMD_SET_SAMPLE_RATE: u8 = 0xF3;
+const MOUSE_CMD_GET_ID: u8 = 0xF2;
+const MOUSE_CMD_SET_RESOLUTION: u8 = 0xE8;
+const MOUSE_CMD_SET_SCALING_1_1: u8 = 0xE6;
+
+/// PS/2 response codes
+const PS2_ACK: u8 = 0xFA;
+const PS2_SELF_TEST_PASS: u8 = 0xAA;
+const PS2_SELF_TEST_FAIL: u8 = 0xFC;
+
+/// Controller config bits
+const CONFIG_IRQ1_ENABLE: u8 = 0x01;     // bit 0: keyboard interrupt
+const CONFIG_IRQ12_ENABLE: u8 = 0x02;    // bit 1: mouse interrupt
+const CONFIG_KEYBOARD_CLOCK: u8 = 0x10;  // bit 4: disable keyboard clock
+const CONFIG_MOUSE_CLOCK: u8 = 0x20;     // bit 5: disable mouse clock
+const CONFIG_TRANSLATION: u8 = 0x40;     // bit 6: scancode translation
+
+/// Timeout for waiting on PS/2 controller (iterations)
+const PS2_TIMEOUT: u32 = 100_000;
+
+// ============================================================================
+// Ring Buffers
+// ============================================================================
+
 const KEYBOARD_BUFFER_SIZE: usize = 128;
 const MOUSE_BUFFER_SIZE: usize = 256;
 
-/// Ring buffer for raw input bytes
+/// Lock-free ring buffer for raw input bytes (power-of-2 size)
 struct RingBuffer<const N: usize> {
     buffer: [u8; N],
     head: usize,
@@ -55,7 +110,7 @@ impl<const N: usize> RingBuffer<N> {
     fn push(&mut self, byte: u8) -> bool {
         let next_head = (self.head + 1) % N;
         if next_head == self.tail {
-            return false; // Buffer full, drop byte
+            return false; // Buffer full
         }
         self.buffer[self.head] = byte;
         self.head = next_head;
@@ -71,35 +126,29 @@ impl<const N: usize> RingBuffer<N> {
         Some(byte)
     }
 
-    #[allow(dead_code)]
-    fn len(&self) -> usize {
-        if self.head >= self.tail {
-            self.head - self.tail
-        } else {
-            N - self.tail + self.head
-        }
-    }
-
-    #[allow(dead_code)]
-    fn is_empty(&self) -> bool {
-        self.head == self.tail
+    fn clear(&mut self) {
+        self.head = 0;
+        self.tail = 0;
     }
 }
 
-// Global input buffers protected by spinlocks
-static KEYBOARD_BUFFER: Mutex<RingBuffer<KEYBOARD_BUFFER_SIZE>> = 
+// ============================================================================
+// Global State
+// ============================================================================
+
+static KEYBOARD_BUFFER: Mutex<RingBuffer<KEYBOARD_BUFFER_SIZE>> =
     Mutex::new(RingBuffer::new());
-static MOUSE_BUFFER: Mutex<RingBuffer<MOUSE_BUFFER_SIZE>> = 
+static MOUSE_BUFFER: Mutex<RingBuffer<MOUSE_BUFFER_SIZE>> =
     Mutex::new(RingBuffer::new());
 
-/// Initialize the input subsystem
-pub fn init() {
-    log_info!("input", "Input subsystem initialized (userspace driver model)");
-    log_info!("input", "Keyboard buffer: {} bytes, Mouse buffer: {} bytes",
-        KEYBOARD_BUFFER_SIZE, MOUSE_BUFFER_SIZE);
-}
+/// Detected mouse ID: 0 = basic, 3 = scroll wheel, 4 = scroll + 5 buttons
+static MOUSE_ID: AtomicU8 = AtomicU8::new(0);
 
-/// Read PS/2 status register
+// ============================================================================
+// Low-Level PS/2 I/O
+// ============================================================================
+
+/// Read the PS/2 status register (port 0x64)
 #[inline]
 fn read_status() -> u8 {
     unsafe {
@@ -114,7 +163,7 @@ fn read_status() -> u8 {
     }
 }
 
-/// Read PS/2 data register
+/// Read a byte from the PS/2 data port (port 0x60)
 #[inline]
 fn read_data() -> u8 {
     unsafe {
@@ -129,89 +178,7 @@ fn read_data() -> u8 {
     }
 }
 
-/// Called from keyboard interrupt handler (IRQ1)
-/// Reads all available bytes and buffers them for userspace
-pub fn on_keyboard_irq() {
-    let mut buf = KEYBOARD_BUFFER.lock();
-    let mut count = 0u8;
-
-    // Read all available keyboard data
-    while read_status() & STATUS_OUTPUT_FULL != 0 {
-        // Check it's not mouse data
-        if read_status() & STATUS_AUX_DATA != 0 {
-            break; // This is mouse data, not keyboard
-        }
-
-        let scancode = read_data();
-        buf.push(scancode);
-        count += 1;
-    }
-}
-
-/// Called from mouse interrupt handler (IRQ12)
-/// Reads all available bytes and buffers them for userspace
-pub fn on_mouse_irq() {
-    let mut buf = MOUSE_BUFFER.lock();
-    let mut count = 0u32;
-    let mut bytes_debug = [0u8; 16];
-    
-    // Read all available mouse data (marked with AUX bit)
-    while read_status() & (STATUS_OUTPUT_FULL | STATUS_AUX_DATA) == 
-          (STATUS_OUTPUT_FULL | STATUS_AUX_DATA) {
-        let byte = read_data();
-        if (count as usize) < bytes_debug.len() {
-            bytes_debug[count as usize] = byte;
-        }
-        buf.push(byte);
-        count += 1;
-    }
-    
-}
-
-/// Poll for next keyboard byte (called from syscall)
-/// Returns None if buffer is empty
-pub fn poll_keyboard_byte() -> Option<u8> {
-    KEYBOARD_BUFFER.lock().pop()
-}
-
-/// Poll for next mouse byte (called from syscall)
-/// Returns None if buffer is empty
-pub fn poll_mouse_byte() -> Option<u8> {
-    MOUSE_BUFFER.lock().pop()
-}
-
-// ============================================================================
-// MICROKERNEL ARCHITECTURE NOTE
-// ============================================================================
-//
-// Event parsing (KeyEvent, MouseEvent) is handled in USERSPACE, not the kernel.
-// The kernel only provides:
-// - Raw byte buffers populated by IRQ handlers
-// - Syscalls to poll raw bytes from these buffers
-// - PS/2 hardware initialization
-//
-// The userspace UI shell (ui_shell.atxf) is responsible for:
-// - Parsing raw scancodes into key events
-// - Assembling PS/2 packets into mouse events
-// - Routing events to windows
-// ============================================================================
-
-fn wait_for_input_buffer() {
-    for _ in 0..10000 {
-        if read_status() & 0x02 == 0 {
-            return;
-        }
-    }
-}
-
-fn wait_for_output_buffer() {
-    for _ in 0..10000 {
-        if read_status() & 0x01 != 0 {
-            return;
-        }
-    }
-}
-
+/// Write a command byte to the PS/2 command port (port 0x64)
 fn write_command(cmd: u8) {
     unsafe {
         core::arch::asm!(
@@ -223,6 +190,7 @@ fn write_command(cmd: u8) {
     }
 }
 
+/// Write a data byte to the PS/2 data port (port 0x60)
 fn write_data(data: u8) {
     unsafe {
         core::arch::asm!(
@@ -234,103 +202,224 @@ fn write_data(data: u8) {
     }
 }
 
-fn send_mouse_command(cmd: u8) {
-    wait_for_input_buffer();
-    write_command(0xD4); // Send to mouse
-    wait_for_input_buffer();
-    write_data(cmd);
-    // Wait for ACK
-    wait_for_output_buffer();
-    let _ = read_data(); // Consume ACK (0xFA)
+/// Wait until the PS/2 input buffer is empty (ready to accept writes).
+/// Must be called before every write to port 0x60 or 0x64.
+fn wait_for_input_buffer() -> bool {
+    for _ in 0..PS2_TIMEOUT {
+        if read_status() & STATUS_INPUT_FULL == 0 {
+            return true;
+        }
+    }
+    false
 }
 
-/// Initialize PS/2 controller for keyboard and mouse support
-/// Based on SANiK's PS/2 Mouse code and OSDev documentation
-pub fn init_ps2_mouse_full() {
-    log_info!("input", "Initializing PS/2 controller (keyboard + mouse)...");
+/// Wait until the PS/2 output buffer has data (ready to read from port 0x60).
+fn wait_for_output_buffer() -> bool {
+    for _ in 0..PS2_TIMEOUT {
+        if read_status() & STATUS_OUTPUT_FULL != 0 {
+            return true;
+        }
+    }
+    false
+}
 
-    // Drain any pending data first (before IRQs are enabled)
+/// Drain any pending data from the PS/2 output buffer
+fn flush_output_buffer() {
     for _ in 0..100 {
         if read_status() & STATUS_OUTPUT_FULL == 0 {
             break;
         }
         let _ = read_data();
     }
+}
 
-    // 1. Disable devices during configuration
-    wait_for_input_buffer();
-    write_command(0xAD); // Disable keyboard port
-    wait_for_input_buffer();
-    write_command(0xA7); // Disable mouse port
+// ============================================================================
+// Mouse Command Helpers
+// ============================================================================
 
-    // Flush output buffer again
-    for _ in 0..10 {
-        if read_status() & STATUS_OUTPUT_FULL == 0 {
-            break;
-        }
-        let _ = read_data();
+/// Send a command byte to the mouse via the PS/2 controller.
+/// Sequence: write 0xD4 to port 0x64 (prefix), then write command to port 0x60.
+/// Waits for and returns the ACK byte (should be 0xFA).
+fn mouse_write(cmd: u8) -> u8 {
+    wait_for_input_buffer();
+    write_command(CMD_SEND_TO_MOUSE);
+    wait_for_input_buffer();
+    write_data(cmd);
+    // Wait for ACK
+    if wait_for_output_buffer() {
+        read_data()
+    } else {
+        0 // Timeout
     }
+}
 
-    // 2. Configure controller (compaq status byte)
+/// Set mouse sample rate (two-byte command: 0xF3 + rate value).
+/// Valid rates: 10, 20, 40, 60, 80, 100, 200 samples/sec.
+fn set_mouse_sample_rate(rate: u8) {
+    mouse_write(MOUSE_CMD_SET_SAMPLE_RATE);
+    mouse_write(rate);
+}
+
+/// Read the current mouseID via command 0xF2.
+/// After the ACK, the mouse sends one byte: the current ID.
+fn read_mouse_id() -> u8 {
+    mouse_write(MOUSE_CMD_GET_ID);
+    if wait_for_output_buffer() {
+        read_data()
+    } else {
+        0 // Timeout, assume basic mouse
+    }
+}
+
+// ============================================================================
+// Public Interface
+// ============================================================================
+
+/// Initialize the input subsystem
+pub fn init() {
+    log_info!("input", "Input subsystem initialized (userspace driver model)");
+    log_info!("input", "Keyboard buffer: {} bytes, Mouse buffer: {} bytes",
+        KEYBOARD_BUFFER_SIZE, MOUSE_BUFFER_SIZE);
+}
+
+/// Return the detected mouseID (0, 3, or 4).
+/// Called from syscall handler.
+pub fn get_mouse_id() -> u8 {
+    MOUSE_ID.load(Ordering::Relaxed)
+}
+
+/// Called from keyboard interrupt handler (IRQ1).
+/// Reads available keyboard data and buffers it for userspace.
+pub fn on_keyboard_irq() {
+    let mut buf = KEYBOARD_BUFFER.lock();
+
+    // Read all available keyboard data (not mouse data)
+    while read_status() & STATUS_OUTPUT_FULL != 0 {
+        if read_status() & STATUS_AUX_DATA != 0 {
+            break; // Mouse data, not keyboard
+        }
+        let scancode = read_data();
+        buf.push(scancode);
+    }
+}
+
+/// Called from mouse interrupt handler (IRQ12).
+/// Reads available mouse data (marked with AUX bit) and buffers it.
+pub fn on_mouse_irq() {
+    let mut buf = MOUSE_BUFFER.lock();
+
+    // Read all available mouse data
+    while read_status() & (STATUS_OUTPUT_FULL | STATUS_AUX_DATA)
+        == (STATUS_OUTPUT_FULL | STATUS_AUX_DATA)
+    {
+        let byte = read_data();
+        buf.push(byte);
+    }
+}
+
+/// Poll for next keyboard byte (called from syscall).
+/// Returns None if buffer is empty.
+pub fn poll_keyboard_byte() -> Option<u8> {
+    KEYBOARD_BUFFER.lock().pop()
+}
+
+/// Poll for next mouse byte (called from syscall).
+/// Returns None if buffer is empty.
+pub fn poll_mouse_byte() -> Option<u8> {
+    MOUSE_BUFFER.lock().pop()
+}
+
+// ============================================================================
+// Full PS/2 Controller Initialization
+// ============================================================================
+
+/// Initialize PS/2 controller for keyboard and mouse support.
+///
+/// Follows the OSDev wiki PS/2 mouse initialization procedure:
+/// - Configures controller interrupts (IRQ1 for keyboard, IRQ12 for mouse)
+/// - Resets keyboard and enables scancode set 2 with translation
+/// - Resets mouse and detects extensions (scroll wheel, extra buttons)
+/// - Configures sample rate (60/sec), resolution (8 count/mm), linear scaling
+/// - Enables streaming mode for automatic packet generation
+pub fn init_ps2_mouse_full() {
+    log_info!("input", "Initializing PS/2 controller (keyboard + mouse)...");
+
+    // ========================================================================
+    // Phase 1: Controller Configuration
+    // ========================================================================
+
+    // Drain any pending data before touching the controller
+    flush_output_buffer();
+
+    // Disable both devices during configuration
     wait_for_input_buffer();
-    write_command(0x20); // Get compaq status byte
+    write_command(CMD_DISABLE_KEYBOARD);
+    wait_for_input_buffer();
+    write_command(CMD_DISABLE_MOUSE);
+
+    // Flush output buffer again after disabling
+    flush_output_buffer();
+
+    // Read the current controller configuration byte (Compaq status byte)
+    wait_for_input_buffer();
+    write_command(CMD_READ_CONFIG);
     wait_for_output_buffer();
-    let status = read_data();
+    let config = read_data();
 
-    // Set bit 0 (enable IRQ1/keyboard), bit 1 (enable IRQ12/mouse)
-    // Set bit 6 (enable translation to Scancode Set 1) - CRITICAL for QEMU!
-    // Clear bit 4 (enable keyboard clock), bit 5 (enable mouse clock)
-    let new_status = (status | 0x43) & !0x30;  // 0x43 = IRQ1 + IRQ12 + Translation
-    log_info!("input", "PS/2 controller status: 0x{:02X} -> 0x{:02X} (IRQ1+IRQ12+Translation enabled)", status, new_status);
+    // Configure: Enable IRQ1 (keyboard) + IRQ12 (mouse) + Translation
+    // Clear: Keyboard clock disable + Mouse clock disable
+    let new_config = (config | CONFIG_IRQ1_ENABLE | CONFIG_IRQ12_ENABLE | CONFIG_TRANSLATION)
+        & !(CONFIG_KEYBOARD_CLOCK | CONFIG_MOUSE_CLOCK);
+
+    log_info!("input", "PS/2 config: 0x{:02X} -> 0x{:02X} (IRQ1+IRQ12+Translation)",
+        config, new_config);
 
     wait_for_input_buffer();
-    write_command(0x60); // Set compaq status byte
+    write_command(CMD_WRITE_CONFIG);
     wait_for_input_buffer();
-    write_data(new_status);
+    write_data(new_config);
 
-    // 3. Re-enable ports
+    // Re-enable both ports
     wait_for_input_buffer();
-    write_command(0xAE); // Enable keyboard port (first PS/2 port)
+    write_command(CMD_ENABLE_KEYBOARD);
     wait_for_input_buffer();
-    write_command(0xA8); // Enable aux/mouse port (second PS/2 port)
+    write_command(CMD_ENABLE_MOUSE);
     log_info!("input", "PS/2 ports enabled (keyboard + mouse)");
 
-    // 4. Reset keyboard (0xFF) and wait for self-test
-    log_info!("input", "PS/2 keyboard: Sending reset command...");
+    // ========================================================================
+    // Phase 2: Keyboard Initialization
+    // ========================================================================
+
+    log_info!("input", "PS/2 keyboard: Sending reset...");
     wait_for_input_buffer();
-    write_data(0xFF); // Reset keyboard
+    write_data(MOUSE_CMD_RESET); // 0xFF to keyboard (directly via port 0x60)
 
     // Wait for ACK (0xFA)
-    wait_for_output_buffer();
-    let reset_ack = read_data();
-    if reset_ack == 0xFA {
-        log_info!("input", "PS/2 keyboard: Reset ACK received");
-    } else {
-        log_info!("input", "PS/2 keyboard: Reset response: 0x{:02X} (expected 0xFA)", reset_ack);
+    if wait_for_output_buffer() {
+        let ack = read_data();
+        if ack == PS2_ACK {
+            log_info!("input", "PS/2 keyboard: Reset ACK received");
+        } else {
+            log_info!("input", "PS/2 keyboard: Reset response: 0x{:02X}", ack);
+        }
     }
 
-    // Wait for self-test pass (0xAA) - can take a while
-    // Some keyboards also send 0xFC (self-test failed) or just timeout
+    // Wait for self-test (0xAA = pass, 0xFC = fail)
     for _ in 0..1000 {
         if read_status() & STATUS_OUTPUT_FULL != 0 {
-            let selftest = read_data();
-            if selftest == 0xAA {
+            let result = read_data();
+            if result == PS2_SELF_TEST_PASS {
                 log_info!("input", "PS/2 keyboard: Self-test passed (0xAA)");
                 break;
-            } else if selftest == 0xFC {
+            } else if result == PS2_SELF_TEST_FAIL {
                 log_info!("input", "PS/2 keyboard: Self-test FAILED (0xFC)");
                 break;
-            } else {
-                log_info!("input", "PS/2 keyboard: Self-test response: 0x{:02X}", selftest);
             }
         }
-        // Small delay
-        for _ in 0..10000 {
-            core::hint::spin_loop();
-        }
+        for _ in 0..10_000 { core::hint::spin_loop(); }
     }
 
-    // 5. Set scancode set 2 (with translation enabled, we get Set 1 codes)
+    // Set scancode set 2 (with translation enabled, CPU sees Set 1 codes)
     wait_for_input_buffer();
     write_data(0xF0); // Set scancode set command
     wait_for_output_buffer();
@@ -342,73 +431,120 @@ pub fn init_ps2_mouse_full() {
     let scanset_ack = read_data();
     log_info!("input", "PS/2 keyboard: Scancode set 2 response: 0x{:02X}", scanset_ack);
 
-    // 6. Enable keyboard scanning (send 0xF4 to keyboard)
+    // Enable keyboard scanning
     wait_for_input_buffer();
-    write_data(0xF4); // Enable scanning
+    write_data(MOUSE_CMD_ENABLE_STREAMING); // 0xF4 enables keyboard scanning too
     wait_for_output_buffer();
     let kbd_ack = read_data();
-    if kbd_ack == 0xFA {
-        log_info!("input", "PS/2 keyboard: Scanning enabled (ACK received)");
+    log_info!("input", "PS/2 keyboard: Scanning enabled (0x{:02X})", kbd_ack);
+
+    // ========================================================================
+    // Phase 3: Mouse Initialization
+    // ========================================================================
+
+    log_info!("input", "PS/2 mouse: Initializing...");
+
+    // Set defaults (resets to: packets disabled, 3-byte mode, 100/sec, 4px/mm)
+    mouse_write(MOUSE_CMD_SET_DEFAULTS);
+
+    // Disable streaming during configuration
+    mouse_write(MOUSE_CMD_DISABLE_STREAMING);
+
+    // ========================================================================
+    // Phase 4: Detect Mouse Extensions (Scroll Wheel + Extra Buttons)
+    // ========================================================================
+
+    // Magic sequence #1: Enable scroll wheel (mouseID 0 -> 3)
+    // Set sample rate to 200, 100, 80, then read ID
+    set_mouse_sample_rate(200);
+    set_mouse_sample_rate(100);
+    set_mouse_sample_rate(80);
+
+    let mouse_id = read_mouse_id();
+    log_info!("input", "PS/2 mouse: After wheel detection sequence, mouseID = {}", mouse_id);
+
+    let mut final_id = mouse_id;
+
+    if mouse_id == 3 {
+        log_info!("input", "PS/2 mouse: Scroll wheel detected (mouseID 3)");
+
+        // Magic sequence #2: Enable 4th and 5th buttons (mouseID 3 -> 4)
+        // Set sample rate to 200, 200, 80, then read ID
+        set_mouse_sample_rate(200);
+        set_mouse_sample_rate(200);
+        set_mouse_sample_rate(80);
+
+        let mouse_id2 = read_mouse_id();
+        log_info!("input", "PS/2 mouse: After 5-button detection sequence, mouseID = {}", mouse_id2);
+
+        if mouse_id2 == 4 {
+            log_info!("input", "PS/2 mouse: 5-button mouse detected (mouseID 4)");
+            final_id = 4;
+        } else {
+            final_id = 3;
+        }
     } else {
-        log_info!("input", "PS/2 keyboard: Enable response: 0x{:02X} (expected 0xFA)", kbd_ack);
+        log_info!("input", "PS/2 mouse: Basic 3-button mouse (mouseID 0)");
     }
 
-    // 5. Tell mouse to use default settings
-    send_mouse_command(0xF6); // ACK consumed by send_mouse_command
+    MOUSE_ID.store(final_id, Ordering::Relaxed);
 
-    // 6. Set scaling 1:1 (0xE6) - LINEAR movement, no acceleration
-    send_mouse_command(0xE6); // ACK consumed by send_mouse_command
+    // ========================================================================
+    // Phase 5: Configure Mouse Parameters
+    // ========================================================================
+
+    // Set scaling 1:1 (linear, no acceleration)
+    mouse_write(MOUSE_CMD_SET_SCALING_1_1);
     log_info!("input", "PS/2 mouse: Scaling set to 1:1 (linear)");
 
-    // 7. Set resolution to 8 count/mm (0x03) for higher precision
-    // E8 is a two-byte command: first E8 (ACK), then data byte (ACK)
-    send_mouse_command(0xE8); // Set Resolution command, ACK consumed
-    send_mouse_command(0x03); // Resolution value: 8 count/mm, ACK consumed
+    // Set resolution to 8 count/mm (value 0x03) for highest precision
+    mouse_write(MOUSE_CMD_SET_RESOLUTION);
+    mouse_write(0x03);
     log_info!("input", "PS/2 mouse: Resolution set to 8 count/mm");
 
-    // 8. Set sample rate to 100 samples/sec
-    // F3 is a two-byte command: first F3 (ACK), then data byte (ACK)
-    send_mouse_command(0xF3); // Set Sample Rate command, ACK consumed
-    send_mouse_command(100);  // Sample rate value: 100, ACK consumed
-    log_info!("input", "PS/2 mouse: Sample rate set to 100/sec");
+    // Set sample rate to 60 samples/sec
+    // OSDev docs: human eyes don't see faster than 30 fps, rates < 30 are jerky,
+    // rates > 100 waste I/O bus bandwidth. 60 is a good balance.
+    set_mouse_sample_rate(60);
+    log_info!("input", "PS/2 mouse: Sample rate set to 60/sec");
 
-    // 9. Enable the mouse (start streaming packets)
-    send_mouse_command(0xF4); // Enable Data Reporting, ACK consumed
+    // ========================================================================
+    // Phase 6: Enable Streaming and Finalize
+    // ========================================================================
 
-    // 10. CRITICAL: Re-write controller configuration byte.
-    // The mouse initialization sequence can corrupt the PS/2 controller
-    // config byte (observed: 0x47 → 0x00), disabling both IRQ1 and IRQ12.
-    // We must restore the config to ensure interrupts are delivered.
-    wait_for_input_buffer();
-    write_command(0x60); // Write controller configuration byte
-    wait_for_input_buffer();
-    write_data(new_status); // Restore: IRQ1 + IRQ12 + Translation enabled
+    // Enable data reporting (mouse starts sending packets on movement/clicks)
+    mouse_write(MOUSE_CMD_ENABLE_STREAMING);
+    log_info!("input", "PS/2 mouse: Streaming enabled");
 
-    // 11. Verify final controller configuration
+    // CRITICAL: Re-write controller configuration byte.
+    // Mouse initialization can corrupt the PS/2 controller config byte
+    // (observed: 0x47 -> 0x00), disabling both IRQ1 and IRQ12.
     wait_for_input_buffer();
-    write_command(0x20); // Read controller status byte
+    write_command(CMD_WRITE_CONFIG);
+    wait_for_input_buffer();
+    write_data(new_config);
+
+    // Verify final controller configuration
+    wait_for_input_buffer();
+    write_command(CMD_READ_CONFIG);
     wait_for_output_buffer();
-    let final_status = read_data();
-    log_info!("input", "PS/2 controller final status: 0x{:02X} (IRQ1={}, IRQ12={})",
-        final_status,
-        if final_status & 0x01 != 0 { "enabled" } else { "DISABLED" },
-        if final_status & 0x02 != 0 { "enabled" } else { "DISABLED" }
+    let final_config = read_data();
+    log_info!("input", "PS/2 controller final config: 0x{:02X} (IRQ1={}, IRQ12={})",
+        final_config,
+        if final_config & CONFIG_IRQ1_ENABLE != 0 { "on" } else { "OFF" },
+        if final_config & CONFIG_IRQ12_ENABLE != 0 { "on" } else { "OFF" }
     );
 
-    // 12. Clear any leftover ACK bytes from the buffer
-    // (some ACKs may have been captured by IRQ12 during init)
+    // Clear any leftover ACK bytes from the mouse buffer
+    // (IRQ12 may have captured ACKs during initialization)
     {
         let mut buf = MOUSE_BUFFER.lock();
-        while buf.pop().is_some() {}
+        buf.clear();
     }
-    
-    // Also drain hardware buffer
-    for _ in 0..10 {
-        if read_status() & STATUS_OUTPUT_FULL == 0 {
-            break;
-        }
-        let _ = read_data();
-    }
-    
-    log_info!("input", "PS/2 mouse initialized: 1:1 scaling, 8 count/mm, 100 samples/sec");
+
+    // Drain hardware buffer
+    flush_output_buffer();
+
+    log_info!("input", "PS/2 mouse initialized: mouseID={}, 1:1 scaling, 8 count/mm, 60 samples/sec",
+        final_id);
 }

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -117,6 +117,7 @@ pub const SYS_GET_MEMORY_INFO: u64 = 46; // Get system memory information
 pub const SYS_LIST_PROCESSES: u64 = 47; // List all processes/threads
 pub const SYS_GET_PROCESS_COUNT: u64 = 48; // Get total number of processes
 pub const SYS_READ_KLOG: u64 = 49; // Read kernel log buffer
+pub const SYS_MOUSE_GET_ID: u64 = 50; // Get detected PS/2 mouseID (0, 3, or 4)
 
 pub const ESUCCESS: u64 = 0;
 pub const ENOTFOUND: u64 = u64::MAX - 10;
@@ -323,6 +324,7 @@ extern "C" fn rust_syscall_dispatcher(
         SYS_LIST_PROCESSES => sys_list_processes(arg0 as *mut crate::thread::ProcessInfo, arg1 as usize),
         SYS_GET_PROCESS_COUNT => sys_get_process_count(),
         SYS_READ_KLOG => sys_read_klog(arg0 as *mut u8, arg1 as usize),
+        SYS_MOUSE_GET_ID => sys_mouse_get_id(),
 
         _ => {
             log_warn!(
@@ -345,13 +347,17 @@ fn sys_mouse_poll(out_ptr: *mut u8) -> u64 {
     // Return next raw mouse byte for userspace driver to process
     if let Some(byte) = crate::input::poll_mouse_byte() {
         unsafe {
-            // Write directly to userspace memory
-            // Note: In a production microkernel, we would use safer accessors
             *out_ptr = byte;
         }
         return ESUCCESS;
     }
     EWOULDBLOCK
+}
+
+/// Return the detected PS/2 mouseID (0, 3, or 4).
+/// Userspace uses this to determine packet size and feature support.
+fn sys_mouse_get_id() -> u64 {
+    crate::input::get_mouse_id() as u64
 }
 
 /// Read a byte from an IO port (privileged operation for drivers)

--- a/userspace/drivers/mouse/src/main.rs
+++ b/userspace/drivers/mouse/src/main.rs
@@ -1,13 +1,30 @@
 // Userspace PS/2 Mouse Driver for Atom OS
 //
-// This driver polls raw mouse bytes from the kernel via syscalls and
-// dispatches mouse events via IPC to the compositor.
+// This driver polls raw mouse bytes from the kernel via syscalls,
+// assembles them into PS/2 packets, and dispatches mouse events
+// via IPC to the compositor.
+//
+// Supports all PS/2 mouse modes as detected by the kernel:
+//   mouseID 0: 3-byte packets (basic 3-button mouse)
+//   mouseID 3: 4-byte packets (scroll wheel, Z-axis movement)
+//   mouseID 4: 4-byte packets (scroll wheel + 4th/5th buttons)
+//
+// Packet format (first 3 bytes, always present):
+//   byte 0: [Y_ovf | X_ovf | Y_sign | X_sign | 1 | Mid | Right | Left]
+//   byte 1: X movement value (unsigned, sign in byte 0 bit 4)
+//   byte 2: Y movement value (unsigned, sign in byte 0 bit 5)
+//
+// 4th byte (mouseID 3): signed 8-bit Z movement
+// 4th byte (mouseID 4): [0|0|btn5|btn4|Z3|Z2|Z1|Z0] (4-bit signed Z)
+//
+// Delta sign extension uses the OSDev recommended formula:
+//   rel_x = raw_x - ((flags << 4) & 0x100)
+//   rel_y = raw_y - ((flags << 3) & 0x100)
 //
 // Architecture:
-// 1. Polls raw bytes from kernel ring buffer via mouse_poll_byte() syscall.
-// 2. Assembles 3-byte PS/2 packets.
-// 3. Looks up "compositor" service and sends events to its port.
-// 4. Also registers itself as "mouse" service.
+//   Hardware IRQ12 -> Kernel ring buffer -> mouse_poll_byte() syscall
+//   -> This driver (packet assembly + decoding)
+//   -> IPC events to compositor (MouseMove, MouseButtonDown/Up, MouseScroll)
 
 #![no_std]
 #![no_main]
@@ -23,9 +40,11 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 use atom_syscall::ipc::{create_port, PortId};
 use atom_syscall::thread::{yield_now, exit};
 use atom_syscall::debug::log;
-use atom_syscall::input::mouse_poll_byte;
+use atom_syscall::input::{mouse_poll_byte, mouse_get_id};
 
-use libipc::messages::{MessageType, MouseMoveEvent, MouseButtonEvent, MouseButton};
+use libipc::messages::{
+    MessageType, MouseMoveEvent, MouseButtonEvent, MouseScrollEvent, MouseButton,
+};
 use libipc::protocol::{send_message_async, register_service, lookup_service};
 
 // ============================================================================
@@ -72,83 +91,47 @@ fn alloc_error(_: Layout) -> ! { loop {} }
 // Mouse State
 // ============================================================================
 
+/// Full mouse state from a decoded PS/2 packet
 #[derive(Clone, Copy, Default)]
-pub struct MouseState {
-    pub delta_x: i16,
-    pub delta_y: i16,
-    pub left_button: bool,
-    pub right_button: bool,
-    pub middle_button: bool,
+struct MouseState {
+    dx: i32,
+    dy: i32,
+    dz: i32,
+    left: bool,
+    right: bool,
+    middle: bool,
+    button4: bool,
+    button5: bool,
 }
 
-struct MouseDriver {
-    packet: [u8; 3],
+/// PS/2 mouse packet assembler and decoder
+struct PacketDecoder {
+    packet: [u8; 4],
     cycle: u8,
-    state: MouseState,
-    compositor_port: PortId,
+    packet_size: u8, // 3 or 4 bytes
+    mouse_id: u8,    // 0, 3, or 4
 }
 
-impl MouseDriver {
-    fn new(compositor_port: PortId) -> Self {
+impl PacketDecoder {
+    fn new(mouse_id: u8) -> Self {
         Self {
-            packet: [0; 3],
+            packet: [0; 4],
             cycle: 0,
-            state: MouseState::default(),
-            compositor_port,
+            packet_size: if mouse_id >= 3 { 4 } else { 3 },
+            mouse_id,
         }
     }
 
-    fn run(&mut self) -> ! {
-        let mut prev_state = MouseState::default();
-
-        log("Mouse Driver: Entering poll loop");
-
-        loop {
-            // Poll for raw bytes from kernel buffer
-            while let Some(byte) = mouse_poll_byte() {
-                if let Some(new_state) = self.process_byte(byte) {
-                    // Send move event if deltas are non-zero
-                    if new_state.delta_x != 0 || new_state.delta_y != 0 {
-                        let move_msg = MouseMoveEvent {
-                            x: 0, y: 0,
-                            dx: new_state.delta_x,
-                            dy: new_state.delta_y,
-                        };
-                        let _ = send_message_async(self.compositor_port, MessageType::MouseMove, &move_msg.to_bytes());
-                    }
-
-                    // Send button events if state changed
-                    if new_state.left_button != prev_state.left_button {
-                        let msg_type = if new_state.left_button { MessageType::MouseButtonDown } else { MessageType::MouseButtonUp };
-                        let btn_msg = MouseButtonEvent { button: MouseButton::Left, x: 0, y: 0 };
-                        let _ = send_message_async(self.compositor_port, msg_type, &btn_msg.to_bytes());
-                    }
-                    if new_state.right_button != prev_state.right_button {
-                        let msg_type = if new_state.right_button { MessageType::MouseButtonDown } else { MessageType::MouseButtonUp };
-                        let btn_msg = MouseButtonEvent { button: MouseButton::Right, x: 0, y: 0 };
-                        let _ = send_message_async(self.compositor_port, msg_type, &btn_msg.to_bytes());
-                    }
-                    if new_state.middle_button != prev_state.middle_button {
-                        let msg_type = if new_state.middle_button { MessageType::MouseButtonDown } else { MessageType::MouseButtonUp };
-                        let btn_msg = MouseButtonEvent { button: MouseButton::Middle, x: 0, y: 0 };
-                        let _ = send_message_async(self.compositor_port, msg_type, &btn_msg.to_bytes());
-                    }
-
-                    prev_state = new_state;
-                }
-            }
-            yield_now();
-        }
-    }
-
-    fn process_byte(&mut self, byte: u8) -> Option<MouseState> {
+    /// Feed a raw byte and return a decoded state when a full packet is ready.
+    fn feed(&mut self, byte: u8) -> Option<MouseState> {
         match self.cycle {
             0 => {
-                // Bit 3 must be 1 in the first byte of a PS/2 packet
+                // First byte: bit 3 must be set (PS/2 "always 1" alignment bit)
                 if byte & 0x08 != 0 {
                     self.packet[0] = byte;
                     self.cycle = 1;
                 }
+                // Otherwise, discard and resync
                 None
             }
             1 => {
@@ -158,32 +141,150 @@ impl MouseDriver {
             }
             2 => {
                 self.packet[2] = byte;
+                if self.packet_size == 3 {
+                    self.cycle = 0;
+                    return self.decode();
+                }
+                self.cycle = 3;
+                None
+            }
+            3 => {
+                self.packet[3] = byte;
                 self.cycle = 0;
-
-                let flags = self.packet[0];
-
-                // Check for overflow bits
-                if (flags & 0xC0) != 0 { return None; }
-
-                // Extract deltas with sign extension
-                let mut dx = self.packet[1] as i16;
-                if flags & 0x10 != 0 { dx -= 256; }
-
-                let mut dy = self.packet[2] as i16;
-                if flags & 0x20 != 0 { dy -= 256; }
-
-                self.state.delta_x = dx;
-                self.state.delta_y = dy;
-                self.state.left_button = (flags & 0x01) != 0;
-                self.state.right_button = (flags & 0x02) != 0;
-                self.state.middle_button = (flags & 0x04) != 0;
-
-                Some(self.state)
+                self.decode()
             }
             _ => { self.cycle = 0; None }
         }
     }
+
+    /// Decode the assembled packet into a MouseState.
+    fn decode(&self) -> Option<MouseState> {
+        let flags = self.packet[0];
+
+        // Discard overflow packets (X or Y overflow bits set)
+        if flags & 0xC0 != 0 {
+            return None;
+        }
+
+        // OSDev recommended sign extension:
+        //   rel_x = raw_x - ((flags << 4) & 0x100)
+        //   rel_y = raw_y - ((flags << 3) & 0x100)
+        let dx = (self.packet[1] as i32) - (((flags as i32) << 4) & 0x100);
+        let dy = (self.packet[2] as i32) - (((flags as i32) << 3) & 0x100);
+
+        let left = flags & 0x01 != 0;
+        let right = flags & 0x02 != 0;
+        let middle = flags & 0x04 != 0;
+
+        let mut dz: i32 = 0;
+        let mut button4 = false;
+        let mut button5 = false;
+
+        if self.packet_size == 4 {
+            let b4 = self.packet[3];
+            match self.mouse_id {
+                3 => {
+                    // mouseID 3: signed 8-bit Z movement
+                    dz = b4 as i8 as i32;
+                }
+                4 => {
+                    // mouseID 4: bits 4-5 are extra buttons, low nibble is signed 4-bit Z
+                    button4 = b4 & 0x10 != 0;
+                    button5 = b4 & 0x20 != 0;
+                    let z_raw = b4 & 0x0F;
+                    dz = if z_raw & 0x08 != 0 {
+                        (z_raw | 0xF0) as i8 as i32
+                    } else {
+                        z_raw as i32
+                    };
+                }
+                _ => {}
+            }
+        }
+
+        Some(MouseState { dx, dy, dz, left, right, middle, button4, button5 })
+    }
 }
+
+// ============================================================================
+// Mouse Driver
+// ============================================================================
+
+struct MouseDriver {
+    decoder: PacketDecoder,
+    prev: MouseState,
+    compositor_port: PortId,
+}
+
+impl MouseDriver {
+    fn new(mouse_id: u8, compositor_port: PortId) -> Self {
+        Self {
+            decoder: PacketDecoder::new(mouse_id),
+            prev: MouseState::default(),
+            compositor_port,
+        }
+    }
+
+    fn run(&mut self) -> ! {
+        log("Mouse Driver: Entering poll loop");
+
+        loop {
+            while let Some(byte) = mouse_poll_byte() {
+                if let Some(state) = self.decoder.feed(byte) {
+                    self.dispatch(state);
+                    self.prev = state;
+                }
+            }
+            yield_now();
+        }
+    }
+
+    /// Dispatch IPC events to compositor based on decoded mouse state.
+    fn dispatch(&self, state: MouseState) {
+        // Movement event
+        if state.dx != 0 || state.dy != 0 {
+            let msg = MouseMoveEvent {
+                x: 0, y: 0,
+                dx: state.dx as i16,
+                dy: state.dy as i16,
+            };
+            let _ = send_message_async(self.compositor_port, MessageType::MouseMove, &msg.to_bytes());
+        }
+
+        // Scroll event (Z-axis)
+        if state.dz != 0 {
+            let msg = MouseScrollEvent {
+                dz: state.dz,
+                x: 0, y: 0,
+            };
+            let _ = send_message_async(self.compositor_port, MessageType::MouseScroll, &msg.to_bytes());
+        }
+
+        // Button events (send on state change)
+        self.check_button(state.left, self.prev.left, MouseButton::Left);
+        self.check_button(state.right, self.prev.right, MouseButton::Right);
+        self.check_button(state.middle, self.prev.middle, MouseButton::Middle);
+        self.check_button(state.button4, self.prev.button4, MouseButton::Button4);
+        self.check_button(state.button5, self.prev.button5, MouseButton::Button5);
+    }
+
+    /// Send button down/up event if the state changed.
+    fn check_button(&self, current: bool, previous: bool, button: MouseButton) {
+        if current != previous {
+            let msg_type = if current {
+                MessageType::MouseButtonDown
+            } else {
+                MessageType::MouseButtonUp
+            };
+            let msg = MouseButtonEvent { button, x: 0, y: 0 };
+            let _ = send_message_async(self.compositor_port, msg_type, &msg.to_bytes());
+        }
+    }
+}
+
+// ============================================================================
+// Entry Point
+// ============================================================================
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
@@ -193,13 +294,22 @@ pub extern "C" fn _start() -> ! {
 fn main() -> ! {
     log("Mouse Driver: Starting...");
 
-    // 1. Create our own IPC port and register as "mouse" service (as requested)
+    // 1. Query the kernel for the detected mouseID
+    let mouse_id = mouse_get_id();
+    match mouse_id {
+        0 => log("Mouse Driver: Basic 3-button mouse (mouseID 0, 3-byte packets)"),
+        3 => log("Mouse Driver: Scroll wheel mouse (mouseID 3, 4-byte packets)"),
+        4 => log("Mouse Driver: 5-button mouse (mouseID 4, 4-byte packets)"),
+        _ => log("Mouse Driver: Unknown mouseID, assuming basic"),
+    }
+
+    // 2. Register as "mouse" service
     if let Ok(our_port) = create_port() {
         let _ = register_service("mouse", our_port);
         log("Mouse Driver: Service 'mouse' registered");
     }
 
-    // 2. Look up "compositor" port to send events (the proven model)
+    // 3. Look up compositor port for sending events
     log("Mouse Driver: Looking up compositor...");
     let compositor_port = loop {
         match lookup_service("compositor") {
@@ -211,7 +321,8 @@ fn main() -> ! {
         }
     };
 
-    let mut driver = MouseDriver::new(compositor_port);
+    // 4. Run the driver
+    let mut driver = MouseDriver::new(mouse_id, compositor_port);
     driver.run()
 }
 

--- a/userspace/libs/libipc/src/messages.rs
+++ b/userspace/libs/libipc/src/messages.rs
@@ -416,6 +416,8 @@ pub enum MouseButton {
     Left = 0,
     Right = 1,
     Middle = 2,
+    Button4 = 3,
+    Button5 = 4,
 }
 
 impl MouseButton {
@@ -424,6 +426,8 @@ impl MouseButton {
             0 => Some(Self::Left),
             1 => Some(Self::Right),
             2 => Some(Self::Middle),
+            3 => Some(Self::Button4),
+            4 => Some(Self::Button5),
             _ => None,
         }
     }
@@ -490,6 +494,43 @@ impl MouseButtonEvent {
             button: MouseButton::from_u8(bytes[0])?,
             x: i32::from_le_bytes([bytes[1], bytes[2], bytes[3], bytes[4]]),
             y: i32::from_le_bytes([bytes[5], bytes[6], bytes[7], bytes[8]]),
+        })
+    }
+}
+
+/// Mouse scroll event (wheel movement)
+///
+/// dz values from the PS/2 spec:
+///   +1 = scroll up (vertical) or right (horizontal)
+///   -1 = scroll down (vertical) or left (horizontal)
+///   Larger magnitudes indicate faster scrolling.
+#[derive(Debug, Clone, Copy)]
+pub struct MouseScrollEvent {
+    /// Vertical scroll delta (positive = up, negative = down)
+    pub dz: i32,
+    /// Current cursor X position
+    pub x: i32,
+    /// Current cursor Y position
+    pub y: i32,
+}
+
+impl MouseScrollEvent {
+    pub fn to_bytes(&self) -> [u8; 12] {
+        let mut bytes = [0u8; 12];
+        bytes[0..4].copy_from_slice(&self.dz.to_le_bytes());
+        bytes[4..8].copy_from_slice(&self.x.to_le_bytes());
+        bytes[8..12].copy_from_slice(&self.y.to_le_bytes());
+        bytes
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < 12 {
+            return None;
+        }
+        Some(Self {
+            dz: i32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
+            x: i32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
+            y: i32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]),
         })
     }
 }

--- a/userspace/libs/syscall/src/input.rs
+++ b/userspace/libs/syscall/src/input.rs
@@ -1,22 +1,19 @@
 // Input device syscalls (keyboard, mouse)
 
-use crate::error::EWOULDBLOCK;
-use crate::raw::{syscall0, numbers::*};
+use crate::raw::{syscall0, syscall1, numbers::*};
 
 // ============================================================================
 // Mouse Input
 // ============================================================================
 
-/// Poll for next raw mouse byte from PS/2 controller
+/// Poll for next raw mouse byte from PS/2 controller.
 ///
 /// Returns Some(byte) if a mouse byte is available, None otherwise.
-/// The userspace driver must assemble these bytes into 3-byte packets.
-///
-/// This is a non-blocking call.
+/// Non-blocking.
 #[inline]
 pub fn mouse_poll_byte() -> Option<u8> {
     let mut byte = 0u8;
-    let result = unsafe { crate::raw::syscall1(SYS_MOUSE_POLL, &mut byte as *mut u8 as u64) };
+    let result = unsafe { syscall1(SYS_MOUSE_POLL, &mut byte as *mut u8 as u64) };
 
     if result == crate::error::ESUCCESS {
         Some(byte)
@@ -25,43 +22,76 @@ pub fn mouse_poll_byte() -> Option<u8> {
     }
 }
 
-/// Mouse event with position delta and button states
+/// Get the PS/2 mouseID detected at boot.
+///
+/// Returns:
+///   0 = basic 3-button mouse (3-byte packets)
+///   3 = scroll wheel mouse (4-byte packets, Z-axis)
+///   4 = 5-button mouse (4-byte packets, Z-axis + buttons 4 & 5)
+#[inline]
+pub fn mouse_get_id() -> u8 {
+    unsafe { syscall0(SYS_MOUSE_GET_ID) as u8 }
+}
+
+/// Mouse event with position delta, button states, and scroll.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct MouseEvent {
     pub dx: i32,
     pub dy: i32,
+    pub dz: i32,
     pub left_button: bool,
     pub right_button: bool,
     pub middle_button: bool,
+    pub button4: bool,
+    pub button5: bool,
 }
 
-/// PS/2 Mouse driver that processes raw bytes into movement deltas and button states
+/// PS/2 Mouse driver that processes raw bytes into events.
+///
+/// Supports all three mouse modes:
+///   - mouseID 0: 3-byte packets (basic 3-button)
+///   - mouseID 3: 4-byte packets (scroll wheel, signed Z)
+///   - mouseID 4: 4-byte packets (scroll wheel + 4th/5th buttons)
+///
+/// Uses the OSDev-recommended sign extension formula for delta values:
+///   rel_x = raw_x - ((flags << 4) & 0x100)
+///   rel_y = raw_y - ((flags << 3) & 0x100)
 pub struct MouseDriver {
-    packet: [u8; 3],
+    packet: [u8; 4],
     cycle: u8,
-    prev_left: bool,
+    packet_size: u8, // 3 or 4 bytes
+    mouse_id: u8,    // 0, 3, or 4
 }
 
 impl MouseDriver {
     pub const fn new() -> Self {
         Self {
-            packet: [0; 3],
+            packet: [0; 4],
             cycle: 0,
-            prev_left: false,
+            packet_size: 3,
+            mouse_id: 0,
         }
     }
 
-    /// Process available mouse data and return movement delta if a complete packet is ready
-    pub fn poll(&mut self) -> Option<(i32, i32)> {
-        while let Some(byte) = mouse_poll_byte() {
-            if let Some(event) = self.process_byte(byte) {
-                return Some((event.dx, event.dy));
-            }
-        }
-        None
+    /// Initialize the driver by querying the kernel for the detected mouseID.
+    /// Must be called before polling.
+    pub fn init(&mut self) {
+        self.mouse_id = mouse_get_id();
+        self.packet_size = if self.mouse_id >= 3 { 4 } else { 3 };
     }
 
-    /// Process available mouse data and return full event with buttons if a complete packet is ready
+    /// Return the detected mouseID.
+    pub fn mouse_id(&self) -> u8 {
+        self.mouse_id
+    }
+
+    /// Return the packet size (3 or 4).
+    pub fn packet_size(&self) -> u8 {
+        self.packet_size
+    }
+
+    /// Poll for a complete mouse event.
+    /// Returns Some(event) when a full packet has been assembled.
     pub fn poll_event(&mut self) -> Option<MouseEvent> {
         while let Some(byte) = mouse_poll_byte() {
             if let Some(event) = self.process_byte(byte) {
@@ -71,21 +101,21 @@ impl MouseDriver {
         None
     }
 
-    /// Check if left button was just pressed (rising edge)
-    pub fn left_clicked(&mut self) -> bool {
-        // This should be called after poll_event to detect clicks
-        false // Actual implementation is in poll_event
-    }
-
-    /// Process a single mouse byte
+    /// Process a single raw byte from the PS/2 mouse stream.
+    ///
+    /// Returns Some(MouseEvent) when a complete packet is assembled.
+    /// Uses bit 3 of the first byte (always-1 flag) for packet sync.
+    /// Discards packets with X or Y overflow (bits 6-7 of byte 0).
     fn process_byte(&mut self, byte: u8) -> Option<MouseEvent> {
         match self.cycle {
             0 => {
-                // First byte must have bit 3 set (always 1 in PS/2)
+                // First byte: verify bit 3 is set (PS/2 "always 1" bit)
+                // This helps maintain packet alignment.
                 if byte & 0x08 != 0 {
                     self.packet[0] = byte;
                     self.cycle = 1;
                 }
+                // If bit 3 is not set, skip this byte (resync)
                 None
             }
             1 => {
@@ -95,35 +125,21 @@ impl MouseDriver {
             }
             2 => {
                 self.packet[2] = byte;
-                self.cycle = 0;
-                
-                // Decode packet
-                let flags = self.packet[0];
-                
-                // Check for overflow
-                if flags & 0xC0 != 0 {
-                    return None;
-                }
-                
-                // Extract deltas with sign extension
-                let mut dx = self.packet[1] as i32;
-                let mut dy = self.packet[2] as i32;
-                
-                if flags & 0x10 != 0 { dx -= 256; }
-                if flags & 0x20 != 0 { dy -= 256; }
-                
-                // Extract button states
-                let left_button = (flags & 0x01) != 0;
-                let right_button = (flags & 0x02) != 0;
-                let middle_button = (flags & 0x04) != 0;
 
-                Some(MouseEvent {
-                    dx,
-                    dy,
-                    left_button,
-                    right_button,
-                    middle_button,
-                })
+                if self.packet_size == 3 {
+                    // Complete 3-byte packet
+                    self.cycle = 0;
+                    return self.decode_packet();
+                }
+
+                // Wait for 4th byte
+                self.cycle = 3;
+                None
+            }
+            3 => {
+                self.packet[3] = byte;
+                self.cycle = 0;
+                self.decode_packet()
             }
             _ => {
                 self.cycle = 0;
@@ -131,33 +147,110 @@ impl MouseDriver {
             }
         }
     }
+
+    /// Decode a complete PS/2 mouse packet into a MouseEvent.
+    ///
+    /// Packet format (first 3 bytes, always present):
+    ///   byte 0: [Y_overflow | X_overflow | Y_sign | X_sign | 1 | Mid | Right | Left]
+    ///   byte 1: X movement (unsigned, sign in byte 0 bit 4)
+    ///   byte 2: Y movement (unsigned, sign in byte 0 bit 5)
+    ///
+    /// 4th byte (mouseID 3): Z movement (signed 8-bit, -8 to +7 for scroll)
+    /// 4th byte (mouseID 4): [0 | 0 | btn5 | btn4 | Z3 | Z2 | Z1 | Z0] (Z is signed 4-bit)
+    fn decode_packet(&self) -> Option<MouseEvent> {
+        let flags = self.packet[0];
+
+        // Discard packets with X or Y overflow (bits 6-7)
+        if flags & 0xC0 != 0 {
+            return None;
+        }
+
+        // Extract deltas using OSDev recommended formula:
+        //   rel_x = raw_x - ((flags << 4) & 0x100)
+        //   rel_y = raw_y - ((flags << 3) & 0x100)
+        // This correctly produces a signed value from the 9-bit two's complement.
+        let dx = (self.packet[1] as i32) - (((flags as i32) << 4) & 0x100);
+        let dy = (self.packet[2] as i32) - (((flags as i32) << 3) & 0x100);
+
+        // Button states from first byte
+        let left_button = flags & 0x01 != 0;
+        let right_button = flags & 0x02 != 0;
+        let middle_button = flags & 0x04 != 0;
+
+        // 4th byte: scroll and extra buttons
+        let mut dz: i32 = 0;
+        let mut button4 = false;
+        let mut button5 = false;
+
+        if self.packet_size == 4 {
+            let byte4 = self.packet[3];
+
+            match self.mouse_id {
+                3 => {
+                    // mouseID 3: byte 4 is signed 8-bit Z movement
+                    // Values: 0 = no scroll, 1 = up, 0xFF = down,
+                    //         2 = right, 0xFE = left
+                    dz = byte4 as i8 as i32;
+                }
+                4 => {
+                    // mouseID 4: low nibble is signed 4-bit Z, bits 4-5 are buttons
+                    button4 = byte4 & 0x10 != 0;
+                    button5 = byte4 & 0x20 != 0;
+
+                    // Sign-extend 4-bit Z value
+                    let z_raw = byte4 & 0x0F;
+                    dz = if z_raw & 0x08 != 0 {
+                        // Negative: sign-extend from 4 bits
+                        (z_raw | 0xF0) as i8 as i32
+                    } else {
+                        z_raw as i32
+                    };
+                }
+                _ => {}
+            }
+        }
+
+        Some(MouseEvent {
+            dx,
+            dy,
+            dz,
+            left_button,
+            right_button,
+            middle_button,
+            button4,
+            button5,
+        })
+    }
 }
 
-/// Legacy function for simple polling (returns delta if complete packet ready)
-/// Note: This creates a new driver each call, so state is not preserved.
-/// For proper usage, create a MouseDriver instance and call poll() on it.
+/// Simple polling function for backward compatibility.
+/// Creates a persistent driver instance internally.
 #[inline]
 pub fn mouse_poll() -> Option<(i32, i32)> {
-    // For backward compatibility, just poll a byte and return None
-    // The proper way is to use MouseDriver
     static mut DRIVER: MouseDriver = MouseDriver::new();
-    unsafe { DRIVER.poll() }
+    static mut INITIALIZED: bool = false;
+    unsafe {
+        if !INITIALIZED {
+            DRIVER.init();
+            INITIALIZED = true;
+        }
+        DRIVER.poll_event().map(|e| (e.dx, e.dy))
+    }
 }
 
 // ============================================================================
 // Keyboard Input
 // ============================================================================
 
-/// Poll keyboard for next scancode
+/// Poll keyboard for next scancode.
 ///
 /// Returns Some(scancode) if a key event is available, None otherwise.
 /// Scancodes are raw PS/2 set 1 scancodes.
-///
-/// This is a non-blocking call.
+/// Non-blocking.
 #[inline]
 pub fn keyboard_poll() -> Option<u8> {
     let mut scancode = 0u8;
-    let result = unsafe { crate::raw::syscall1(SYS_KEYBOARD_POLL, &mut scancode as *mut u8 as u64) };
+    let result = unsafe { syscall1(SYS_KEYBOARD_POLL, &mut scancode as *mut u8 as u64) };
 
     if result == crate::error::ESUCCESS {
         Some(scancode)
@@ -181,11 +274,10 @@ pub struct KeyEvent {
 // Scancode Translation (US Layout)
 // ============================================================================
 
-/// Translate PS/2 set 1 scancode to ASCII character
+/// Translate PS/2 set 1 scancode to ASCII character.
 ///
 /// Returns Some(char) for printable characters, None for special keys.
 pub fn scancode_to_ascii(scancode: u8, shift: bool) -> Option<char> {
-    // Key release (high bit set)
     if scancode >= 128 {
         return None;
     }
@@ -227,26 +319,22 @@ pub fn scancode_to_ascii(scancode: u8, shift: bool) -> Option<char> {
 
 /// Scancode constants for special keys
 pub mod scancodes {
-    // Modifier keys
     pub const LEFT_SHIFT: u8 = 0x2A;
     pub const RIGHT_SHIFT: u8 = 0x36;
     pub const LEFT_CTRL: u8 = 0x1D;
     pub const LEFT_ALT: u8 = 0x38;
     pub const CAPS_LOCK: u8 = 0x3A;
 
-    // Release codes (scancode | 0x80)
     pub const LEFT_SHIFT_RELEASE: u8 = 0xAA;
     pub const RIGHT_SHIFT_RELEASE: u8 = 0xB6;
     pub const LEFT_CTRL_RELEASE: u8 = 0x9D;
     pub const LEFT_ALT_RELEASE: u8 = 0xB8;
 
-    // Special keys
     pub const ESCAPE: u8 = 0x01;
     pub const BACKSPACE: u8 = 0x0E;
     pub const TAB: u8 = 0x0F;
     pub const ENTER: u8 = 0x1C;
     pub const SPACE: u8 = 0x39;
 
-    // Extended prefix
     pub const EXTENDED_PREFIX: u8 = 0xE0;
 }

--- a/userspace/libs/syscall/src/raw.rs
+++ b/userspace/libs/syscall/src/raw.rs
@@ -57,6 +57,7 @@ pub mod numbers {
     pub const SYS_LIST_PROCESSES: u64 = 47;
     pub const SYS_GET_PROCESS_COUNT: u64 = 48;
     pub const SYS_READ_KLOG: u64 = 49;
+    pub const SYS_MOUSE_GET_ID: u64 = 50;
 }
 
 /// Raw syscall with no arguments


### PR DESCRIPTION
## Summary

This PR implements a complete PS/2 controller initialization sequence that detects and configures mouse extensions (scroll wheel and extra buttons), replacing the minimal IRQ-only buffering approach. The kernel now performs full hardware initialization following the OSDev specification, while userspace drivers remain responsible for packet parsing and event generation.

## Key Changes

### Kernel Input Subsystem (`kernel/src/input.rs`)
- **Full PS/2 initialization**: Implemented 6-phase initialization sequence:
  1. Controller configuration with IRQ1/IRQ12 and scancode translation
  2. Keyboard reset and scancode set 2 configuration
  3. Mouse reset to defaults
  4. Mouse extension detection via magic sample rate sequences
  5. Mouse parameter configuration (scaling, resolution, sample rate)
  6. Streaming mode enablement with config verification

- **Mouse extension detection**: Detects three mouse types via magic sequences:
  - mouseID 0: Basic 3-button mouse (3-byte packets)
  - mouseID 3: Scroll wheel mouse (4-byte packets with Z-axis)
  - mouseID 4: 5-button mouse (4-byte packets with Z-axis + buttons 4/5)

- **Hardware constants**: Added comprehensive PS/2 port constants, command codes, and status bits with documentation

- **Improved I/O helpers**: Enhanced `wait_for_input_buffer()` and `wait_for_output_buffer()` with timeout returns; added `flush_output_buffer()` and mouse-specific helpers (`mouse_write()`, `set_mouse_sample_rate()`, `read_mouse_id()`)

- **Global mouse ID tracking**: Added `MOUSE_ID` atomic to store detected mouse type for userspace queries

### Syscall Interface (`kernel/src/syscall/mod.rs`)
- Added `SYS_MOUSE_GET_ID` (syscall 50) to allow userspace drivers to query the detected mouse type
- Implemented `sys_mouse_get_id()` handler

### Userspace Mouse Driver (`userspace/drivers/mouse/src/main.rs`)
- **Packet decoder**: Refactored into `PacketDecoder` struct that handles 3-byte and 4-byte packet assembly with proper synchronization on the "always 1" bit (bit 3 of first byte)

- **Full packet decoding**: Implements OSDev-recommended sign extension for X/Y deltas and proper handling of:
  - Overflow detection (discards packets with overflow bits set)
  - Z-axis (scroll wheel) for mouseID 3 and 4
  - Extra buttons (button4/button5) for mouseID 4
  - 4-bit signed Z-axis for mouseID 4

- **Event dispatch**: Sends separate IPC messages for movement, scrolling, and button state changes to compositor

- **Mouse type detection**: Queries kernel at startup to determine packet size and feature support

### IPC Messages (`userspace/libs/libipc/src/messages.rs`)
- Added `MouseButton::Button4` and `MouseButton::Button5` enum variants
- Added `MouseScrollEvent` struct for wheel movement with Z-axis delta
- Implemented serialization/deserialization for scroll events

## Notable Implementation Details

- **Critical config restoration**: The initialization sequence re-writes the PS/2 controller configuration byte after mouse setup, as mouse initialization can corrupt it (observed: 0x47 → 0x00), disabling both IRQ1 and IRQ12

- **Timeout handling**: All PS/2 I/O operations use configurable timeouts (100,000 iterations) to prevent infinite hangs

- **Microkernel architecture preserved**: Kernel only handles hardware initialization and raw byte buffering; all packet parsing and event generation remains in userspace

- **Sample rate tuning**: Set to 60 samples/sec (balance between responsiveness and I/O bandwidth efficiency)

- **Resolution**: Configured to 8 count/mm for highest precision

- **Scaling**: Set to 1:1 (linear, no acceleration)

https://claude.ai/code/session_01HfqVdJJyqwu41EhhjQ2kVK