### PR TITLE
Refactor IPC port allocation and fix userspace thread context switching

### DIFF
--- a/kernel/src/init_process.rs
+++ b/kernel/src/init_process.rs
@@ -9,8 +9,8 @@
 // The init process (init.atxf) is responsible for:
 // - Spawning namesvc (service discovery)
 // - Spawning service_manager (lifecycle management)
-// - Spawning userspace drivers (keyboard, mouse, display)
-// - Spawning ui_shell (compositor / window manager)
+// - Spawning ui_shell (compositor / window manager with unified input)
+// - Spawning display driver
 // - Spawning applications (terminal)
 //
 // Key responsibilities of this module:
@@ -251,6 +251,7 @@ fn create_init_process(
         priority: ThreadPriority::High,
         name: "init",
         capability_table: cap::create_capability_table(pid),
+        is_userspace: true,
     };
 
     thread::add_thread(thread);

--- a/kernel/src/interrupts/switch.asm
+++ b/kernel/src/interrupts/switch.asm
@@ -311,6 +311,34 @@ switch_to_context_internal:
 
     ; ========== IRET to KERNEL (CPL 0) ==========
 .iret_to_kernel:
+    ; In x86_64 long mode, IRETQ ALWAYS pops 5 qwords:
+    ;   RIP, CS, RFLAGS, RSP, SS
+    ; This is true even for CPL0->CPL0 transitions (unlike 32-bit protected mode).
+    ; We must build a full 5-qword IRET frame.
+
+    ; Build full IRET frame (5 qwords = 40 bytes)
+    sub rsp, 40
+
+    ; [rsp+0]  = RIP
+    mov rax, [r15 + OFF_RIP]
+    mov [rsp + 0], rax
+
+    ; [rsp+8]  = CS (kernel code selector)
+    movzx eax, word [r15 + OFF_CS]
+    mov [rsp + 8], rax
+
+    ; [rsp+16] = RFLAGS
+    mov rax, [r15 + OFF_RFLAGS]
+    mov [rsp + 16], rax
+
+    ; [rsp+24] = RSP (restored kernel stack pointer)
+    mov rax, [r15 + OFF_RSP]
+    mov [rsp + 24], rax
+
+    ; [rsp+32] = SS (kernel data selector)
+    movzx eax, word [r15 + OFF_SS]
+    mov [rsp + 32], rax
+
     ; Restore GP registers (except r15)
     mov rax, [r15 + OFF_RAX]
     mov rbx, [r15 + OFF_RBX]
@@ -326,14 +354,8 @@ switch_to_context_internal:
     mov r12, [r15 + OFF_R12]
     mov r13, [r15 + OFF_R13]
     mov r14, [r15 + OFF_R14]
-
-    ; For kernel CPL0->CPL0, IRETQ only pops 3 slots: RIP, CS, RFLAGS
-    ; (no stack switch, so SS:RSP are NOT popped)
-    push qword [r15 + OFF_RFLAGS]
-    push qword [r15 + OFF_CS]
-    push qword [r15 + OFF_RIP]
-
     mov r15, [r15 + OFF_R15]
+
     iretq
 
     ; ========== IRET to USER (CPL 3) ==========

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -82,12 +82,26 @@ fn current_time_ms() -> u64 {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PortId(u64);
 
+/// Port IDs 1-255 are reserved for well-known system services.
+/// Dynamic allocation starts at 256.
+const RESERVED_PORT_RANGE: u64 = 256;
+
 impl PortId {
     pub fn new() -> Self {
-        static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+        static NEXT_ID: AtomicU64 = AtomicU64::new(RESERVED_PORT_RANGE);
         PortId(NEXT_ID.fetch_add(1, Ordering::Relaxed))
     }
-    
+
+    /// Create a PortId with a specific reserved ID (1-255).
+    /// Returns None if the ID is outside the reserved range or is 0.
+    pub fn new_reserved(id: u64) -> Option<Self> {
+        if id == 0 || id >= RESERVED_PORT_RANGE {
+            None
+        } else {
+            Some(PortId(id))
+        }
+    }
+
     pub fn from_raw(raw: u64) -> Self {
         PortId(raw)
     }
@@ -449,6 +463,21 @@ impl IpcManager {
 
         self.ports.lock().insert(port_id, port);
         port_id
+    }
+
+    /// Create a port with a specific reserved ID (1-255).
+    /// Returns the PortId on success, or IpcError if the ID is invalid or already in use.
+    fn create_port_with_id(&self, owner: ThreadId, id: u64) -> Result<PortId, IpcError> {
+        let port_id = PortId::new_reserved(id).ok_or(IpcError::InvalidPort)?;
+
+        let mut ports = self.ports.lock();
+        if ports.contains_key(&port_id) {
+            return Err(IpcError::PortBusy);
+        }
+
+        let port = PortState::new(port_id, owner);
+        ports.insert(port_id, port);
+        Ok(port_id)
     }
 
     fn port_owner(&self, port_id: PortId) -> Option<ThreadId> {
@@ -992,6 +1021,12 @@ pub fn init() {
 
 pub fn create_port(owner: ThreadId) -> PortId {
     IPC_MANAGER.create_port(owner)
+}
+
+/// Create a port with a specific reserved ID (1-255).
+/// Used for well-known system service ports (e.g., namesvc on Port 1).
+pub fn create_port_with_id(owner: ThreadId, id: u64) -> Result<PortId, IpcError> {
+    IPC_MANAGER.create_port_with_id(owner, id)
 }
 
 pub fn get_port_owner(port_id: PortId) -> Option<ThreadId> {

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -118,6 +118,7 @@ pub const SYS_LIST_PROCESSES: u64 = 47; // List all processes/threads
 pub const SYS_GET_PROCESS_COUNT: u64 = 48; // Get total number of processes
 pub const SYS_READ_KLOG: u64 = 49; // Read kernel log buffer
 pub const SYS_MOUSE_GET_ID: u64 = 50; // Get detected PS/2 mouseID (0, 3, or 4)
+pub const SYS_IPC_CREATE_PORT_WITH_ID: u64 = 51; // Create IPC port with specific reserved ID
 
 pub const ESUCCESS: u64 = 0;
 pub const ENOTFOUND: u64 = u64::MAX - 10;
@@ -325,6 +326,7 @@ extern "C" fn rust_syscall_dispatcher(
         SYS_GET_PROCESS_COUNT => sys_get_process_count(),
         SYS_READ_KLOG => sys_read_klog(arg0 as *mut u8, arg1 as usize),
         SYS_MOUSE_GET_ID => sys_mouse_get_id(),
+        SYS_IPC_CREATE_PORT_WITH_ID => sys_ipc_create_port_with_id(arg0),
 
         _ => {
             log_warn!(
@@ -654,19 +656,47 @@ fn sys_thread_create(entry_point: u64, stack_ptr: u64, flags: u64) -> u64 {
             return ENOMEM;
         }
     };
-    let kernel_stack = kernel_stack_phys + KERNEL_STACK_SIZE;
-    
-    let thread = crate::thread::Thread::new(
+    let kernel_stack_virt = crate::mm::vm::HIGHER_HALF_BASE + kernel_stack_phys;
+    let kernel_stack_top = (kernel_stack_virt + KERNEL_STACK_SIZE) as u64;
+
+    // Get the caller's address space so the new thread shares it
+    let caller_addr_space = crate::thread::get_thread_address_space(caller).unwrap_or(0);
+
+    // Create a userspace (Ring 3) context for the child thread.
+    // sys_thread_create is only callable from userspace, so child threads
+    // must also run in Ring 3 with the caller's address space.
+    let context = crate::thread::CpuContext::new_user(
         entry_point,
-        kernel_stack as u64,
-        KERNEL_STACK_SIZE,
-        0,
-        crate::thread::ThreadPriority::Normal,
-        "user_thread",
+        stack_ptr,
+        caller_addr_space,
     );
 
-    let tid = thread.id();
-    crate::sched::add_thread(thread);
+    let tid = crate::thread::ThreadId::new();
+    let cap_table = crate::cap::create_capability_table(tid);
+
+    // Write stack canary
+    unsafe {
+        const STACK_CANARY: u64 = 0xDEAD_BEEF_CAFE_BABE;
+        let bottom = kernel_stack_top - KERNEL_STACK_SIZE as u64;
+        let canary_addr = bottom as *mut u64;
+        core::ptr::write_volatile(canary_addr, STACK_CANARY);
+    }
+
+    let thread = crate::thread::Thread {
+        id: tid,
+        state: crate::thread::ThreadState::Ready,
+        context,
+        kernel_stack: kernel_stack_top,
+        kernel_stack_size: KERNEL_STACK_SIZE,
+        address_space: caller_addr_space,
+        priority: crate::thread::ThreadPriority::Normal,
+        name: "user_thread",
+        capability_table: cap_table,
+        is_userspace: true,
+    };
+
+    crate::thread::add_thread(thread);
+    crate::sched::mark_thread_ready(tid);
 
     log_info!(
         LOG_ORIGIN,
@@ -734,6 +764,75 @@ fn sys_ipc_create_port() -> u64 {
             log_error!(
                 LOG_ORIGIN,
                 "ipc_create_port: failed to create root IPC capability"
+            );
+        }
+    }
+
+    port_id.raw()
+}
+
+/// Create an IPC port with a specific reserved ID (1-255).
+/// Used by well-known system services to get deterministic port IDs.
+fn sys_ipc_create_port_with_id(requested_id: u64) -> u64 {
+    const LOG_ORIGIN: &str = "syscall";
+
+    log_debug!(
+        LOG_ORIGIN,
+        "ipc_create_port_with_id(id={})",
+        requested_id
+    );
+
+    let owner = match crate::sched::current_thread() {
+        Some(tid) => tid,
+        None => {
+            log_warn!(
+                LOG_ORIGIN,
+                "ipc_create_port_with_id rejected: no current thread"
+            );
+            return EINVAL;
+        }
+    };
+
+    let port_id = match crate::ipc::create_port_with_id(owner, requested_id) {
+        Ok(id) => id,
+        Err(e) => {
+            log_warn!(
+                LOG_ORIGIN,
+                "ipc_create_port_with_id failed for id={}: {}",
+                requested_id, e
+            );
+            return EINVAL;
+        }
+    };
+
+    log_info!(
+        LOG_ORIGIN,
+        "ipc_create_port_with_id succeeded: port_id={}",
+        port_id
+    );
+
+    // Auto-grant IPC capability for this port
+    let ipc_resource = crate::cap::ResourceType::IpcPort {
+        port_id: port_id.raw(),
+    };
+
+    let permissions =
+        crate::cap::CapPermissions::READ.union(crate::cap::CapPermissions::WRITE);
+
+    match crate::cap::create_root_capability(ipc_resource, owner, permissions) {
+        Ok(cap) => {
+            if let Err(_) = crate::thread::add_thread_capability(owner, cap) {
+                log_warn!(
+                    LOG_ORIGIN,
+                    "ipc_create_port_with_id: failed to attach capability to thread {}",
+                    owner
+                );
+            }
+        }
+        Err(_) => {
+            log_error!(
+                LOG_ORIGIN,
+                "ipc_create_port_with_id: failed to create root IPC capability"
             );
         }
     }
@@ -3353,6 +3452,7 @@ fn spawn_process_internal(
         priority: ThreadPriority::Normal,
         name: static_name,
         capability_table: cap::create_capability_table(pid),
+        is_userspace: true,
     };
 
     // Grant capabilities

--- a/kernel/src/thread.rs
+++ b/kernel/src/thread.rs
@@ -234,6 +234,13 @@ pub struct Thread {
     pub priority: ThreadPriority,
     pub name: &'static str,
     pub capability_table: CapabilityTable,
+    /// Whether this thread executes in Ring 3 (userspace).
+    /// This flag is set at creation time and never changes.
+    /// It determines whether context switches use enter_user* (IRET to Ring 3)
+    /// or switch_context (kernel-to-kernel). This avoids fragile heuristics
+    /// based on address_space comparison or context.cs inspection (which
+    /// reflects kernel CS after a syscall save, not the thread's true CPL).
+    pub is_userspace: bool,
 }
 
 impl Thread {
@@ -280,6 +287,7 @@ impl Thread {
             priority,
             name,
             capability_table,
+            is_userspace: false,
         }
     }
 
@@ -468,6 +476,7 @@ impl ThreadList {
             priority: t.priority,
             name: t.name,
             capability_table: crate::cap::create_capability_table(t.id),
+            is_userspace: t.is_userspace,
         })
     }
 
@@ -885,6 +894,18 @@ pub fn snapshot_context(thread_id: ThreadId) -> Option<CpuContext> {
         .map(|t| t.context)
 }
 
+/// Returns true if the thread executes in Ring 3 (userspace).
+/// This is the authoritative check - it uses the immutable flag set at creation,
+/// not fragile heuristics based on address_space or saved context.cs.
+pub fn is_userspace_thread(thread_id: ThreadId) -> bool {
+    let threads = THREAD_LIST.threads.lock();
+    threads
+        .iter()
+        .find(|t| t.id == thread_id)
+        .map(|t| t.is_userspace)
+        .unwrap_or(false)
+}
+
 /// Force update a thread's userspace context (RIP, RSP, CS, SS, segments)
 /// This is critical before switching to a userspace thread because switch_context
 /// saves the KERNEL RSP into CpuContext.rsp, which would then be used as the
@@ -989,7 +1010,7 @@ pub fn perform_context_switch(from_id: ThreadId, to_id: ThreadId) {
     let userspace_return = crate::syscall::get_userspace_return_addr(from_id);
 
     // Acquire lock, validate, update contexts, get pointers, then RELEASE lock before switch
-    let (from_ctx_ptr, to_ctx_ptr, to_kernel_stack, to_is_usermode, to_is_user_thread, to_entry_rip, to_entry_rsp, to_cr3) = {
+    let switch_info = {
         let mut threads = THREAD_LIST.threads.lock();
 
         let from_idx = threads.iter().position(|t| t.id == from_id)
@@ -1000,192 +1021,132 @@ pub fn perform_context_switch(from_id: ThreadId, to_id: ThreadId) {
         // Validate stack canary for outgoing thread
         let from_thread = &threads[from_idx];
         let bottom = from_thread.kernel_stack.wrapping_sub(from_thread.kernel_stack_size as u64);
-        let ok = unsafe {
+        unsafe {
             let canary_addr = bottom as *const u64;
             let actual = core::ptr::read_volatile(canary_addr);
-            
             if actual != STACK_CANARY {
-                // Get current RSP for diagnosis
-                let current_rsp: u64;
-                core::arch::asm!("mov {}, rsp", out(reg) current_rsp);
-                
                 log_error!(
                     LOG_ORIGIN,
                     "[CANARY_CORRUPT] tid={} name={} canary_addr={:#X} expected={:#X} actual={:#X}",
                     from_id, from_thread.name, canary_addr as u64, STACK_CANARY, actual
                 );
             }
-            
-            actual == STACK_CANARY
         };
 
-        if !ok {
-            // Changed from log_panic to log_error to allow system to continue for diagnosis
-            log_error!(
-                LOG_ORIGIN,
-                "Kernel stack canary corrupted on thread {} '{}' (continuing for diagnosis)",
-                from_id,
-                from_thread.name
-            );
-        }
-
-        // Update FROM thread's context with userspace return address
-        // This must be done BEFORE the context switch so the FROM thread
-        // can resume correctly when it's scheduled again
+        // Update FROM thread's context with userspace return address if it's a userspace thread
         if let Some((user_rip, user_rsp)) = userspace_return {
-            let from_ctx = &mut threads[from_idx].context;
-            if (from_ctx.cs & 0x3) == 0x3 {  // Only for userspace threads
-                from_ctx.rip = user_rip;
-                from_ctx.rsp = user_rsp;
+            if threads[from_idx].is_userspace {
+                threads[from_idx].context.rip = user_rip;
+                threads[from_idx].context.rsp = user_rsp;
             }
         }
 
-        // CRITICAL FIX: Force CR3 to match address_space BEFORE the switch
-        // This prevents triple fault from corrupted CR3 values
-        // The CR3 field in CpuContext may contain garbage from previous saves
+        // Force CR3 to match address_space
         let from_addr_space = threads[from_idx].address_space;
         let to_addr_space = threads[to_idx].address_space;
-        
-        // For kernel threads (address_space=0), use current CR3
         let current_cr3 = unsafe {
             let cr3: u64;
             core::arch::asm!("mov {}, cr3", out(reg) cr3);
             cr3
         };
-        
         let from_cr3 = if from_addr_space == 0 { current_cr3 } else { from_addr_space };
         let to_cr3 = if to_addr_space == 0 { current_cr3 } else { to_addr_space };
-        
         threads[from_idx].context.cr3 = from_cr3;
         threads[to_idx].context.cr3 = to_cr3;
-        
-        // Get raw pointers to contexts and kernel stack
+
+        // Use the authoritative is_userspace flag - NOT address space heuristics
+        let to_is_userspace = threads[to_idx].is_userspace;
+        let has_userspace_return = crate::syscall::get_userspace_return_addr(to_id).is_some();
+
         let from_ptr = &mut threads[from_idx].context as *mut CpuContext;
         let to_ptr = &threads[to_idx].context as *const CpuContext;
         let kstack = threads[to_idx].kernel_stack;
-        
-        // CRITICAL: Detect usermode by checking if we have saved userspace return address
-        // DO NOT trust context.cs - it may contain garbage or kernel CS even for userspace threads
-        let has_userspace_return = crate::syscall::get_userspace_return_addr(to_id).is_some();
-        
-        // Log if switching to usermode
-        if has_userspace_return {
-            log_user_entry_once(to_id, &threads[to_idx].context);
-            log_debug!(
-                LOG_ORIGIN,
-                "Switching to user context: RIP={:#016X} CS={:#04X} SS={:#04X} CPL=3 CR3={:#016X}",
-                threads[to_idx].context.rip,
-                threads[to_idx].context.cs,
-                threads[to_idx].context.ss,
-                threads[to_idx].context.cr3
-            );
-        }
-
-        // Determine if TO thread is a userspace thread by checking address_space
-        let kernel_cr3 = unsafe {
-            let cr3: u64;
-            core::arch::asm!("mov {}, cr3", out(reg) cr3);
-            cr3
-        };
-        let to_is_user_thread = to_addr_space != kernel_cr3;
         let to_entry_rip = threads[to_idx].context.rip;
         let to_entry_rsp = threads[to_idx].context.rsp;
-        
-        (from_ptr, to_ptr, kstack, has_userspace_return, to_is_user_thread, to_entry_rip, to_entry_rsp, to_cr3)
-    }; // 🔓 LOCK RELEASED HERE, BEFORE THE SWITCH
 
-    // CRITICAL: Update TSS.RSP0 for the new thread BEFORE entering userspace
-    // This ensures interrupt frames from usermode go to the correct kernel stack
+        if to_is_userspace {
+            log_user_entry_once(to_id, &threads[to_idx].context);
+        }
+
+        (from_ptr, to_ptr, kstack, to_is_userspace, has_userspace_return, to_entry_rip, to_entry_rsp, to_cr3)
+    }; // Lock released
+
+    let (from_ctx_ptr, to_ctx_ptr, to_kernel_stack, to_is_userspace, has_userspace_return, to_entry_rip, to_entry_rsp, to_cr3) = switch_info;
+
+    // Update TSS.RSP0 for the new thread BEFORE entering userspace
+    // This ensures interrupt/syscall frames from usermode go to the correct kernel stack
     gdt::set_rsp0(to_kernel_stack);
 
     // CRITICAL PATH DECISION:
-    // Use enter_user_first_time() for initial entry (zeroed registers)
-    // Use enter_user() for syscall return (preserves callee-saved registers for ABI)
-    // Only use switch_context() for kernel-to-kernel switches.
-    
-    if to_is_user_thread {
-        // Determine target RIP/RSP: use saved return address if exists, else initial context
-        let (target_rip, target_rsp) = if to_is_usermode {
-            if let Some((urip, ursp)) = crate::syscall::get_userspace_return_addr(to_id) {
-                (urip, ursp)
-            } else {
-                log_error!(
-                    LOG_ORIGIN,
-                    "Thread {} marked as usermode but no return addr - using context",
-                    to_id
-                );
-                (to_entry_rip, to_entry_rsp)
-            }
+    // - Userspace threads (is_userspace=true): Always use enter_user* functions
+    //   which build a proper 5-qword IRET frame for Ring 3 transition.
+    //   * First-time entry: enter_user_first_time (zeros all GPRs)
+    //   * Syscall resume: enter_user_resume (restores callee-saved GPRs) or enter_user
+    // - Kernel threads (is_userspace=false): Use switch_context for
+    //   kernel-to-kernel context switch (saves/restores via assembly).
+    //
+    // The is_userspace flag is set at thread creation and never changes.
+    // This avoids the previous fragile heuristic of comparing address_space to
+    // kernel CR3, which failed for the init process (shares kernel CR3 but runs
+    // in Ring 3), causing IRET with CS=0x0 and SS=0x0.
+
+    if to_is_userspace {
+        // Determine target RIP/RSP: prefer saved userspace return address (from syscall entry),
+        // fall back to initial context values (first-time entry)
+        let (target_rip, target_rsp) = if has_userspace_return {
+            crate::syscall::get_userspace_return_addr(to_id)
+                .unwrap_or((to_entry_rip, to_entry_rsp))
         } else {
             (to_entry_rip, to_entry_rsp)
         };
-        
+
         log_debug!(
             LOG_ORIGIN,
-            "Enter userspace: TID={} RIP={:#016X} RSP={:#016X} CR3={:#016X} first_time={}",
-            to_id, target_rip, target_rsp, to_cr3, !to_is_usermode
+            "Enter userspace: TID={} RIP={:#016X} RSP={:#016X} CR3={:#016X} resume={}",
+            to_id, target_rip, target_rsp, to_cr3, has_userspace_return
         );
-        
+
         // Re-enable interrupts before entering userspace
         crate::interrupts::enable();
-        
-        // Choose the right entry function based on whether this is first-time or syscall return
-        if to_is_usermode {
-            // Syscall return - restore callee-saved registers (RBX, RBP, R12-R15) from saved context
-            if let Some(_gprs) = crate::syscall::get_userspace_gprs(to_id) {
-                // CRITICAL: Pass pointer to GPRs struct (must be stable memory, not stack local)
-                // We need to ensure the USERSPACE_GPRS map entry lives long enough
-                // So we'll get the reference while the lock is held
-                let gprs_map = crate::syscall::USERSPACE_GPRS.lock();
-                if let Some(gprs_ref) = gprs_map.get(&to_id) {
-                    let gprs_ptr = gprs_ref as *const crate::syscall::UserspaceGprs;
-                    drop(gprs_map); // Release lock before entering user
-                    unsafe {
-                        enter_user_resume(target_rip, target_rsp, to_cr3, gprs_ptr);
-                    }
-                } else {
-                    drop(gprs_map);
-                    log_error!(
-                        LOG_ORIGIN,
-                        "Thread {} GPRs disappeared during switch - using enter_user",
-                        to_id
-                    );
-                    unsafe {
-                        enter_user(target_rip, target_rsp, to_cr3);
-                    }
+
+        if has_userspace_return {
+            // Syscall resume - restore callee-saved registers if available
+            let gprs_map = crate::syscall::USERSPACE_GPRS.lock();
+            if let Some(gprs_ref) = gprs_map.get(&to_id) {
+                let gprs_ptr = gprs_ref as *const crate::syscall::UserspaceGprs;
+                drop(gprs_map);
+                unsafe {
+                    enter_user_resume(target_rip, target_rsp, to_cr3, gprs_ptr);
                 }
             } else {
-                log_error!(
-                    LOG_ORIGIN,
-                    "Thread {} has return addr but no saved GPRs - using enter_user",
-                    to_id
-                );
+                drop(gprs_map);
                 unsafe {
                     enter_user(target_rip, target_rsp, to_cr3);
                 }
             }
         } else {
-            // First-time entry - zero all registers for clean state
+            // First-time entry - zero all registers for clean initial state
             unsafe {
                 enter_user_first_time(target_rip, target_rsp, to_cr3);
             }
         }
+        // enter_user* functions are divergent (-> !) so we never reach here
     }
-    
-    // Validate target context before the switch
+
+    // Kernel-to-kernel context switch path
     unsafe {
         guard_context_or_halt(&*to_ctx_ptr, "scheduled");
     }
 
-    // Perform the actual context switch with no locks held
-    // NOTE: This does NOT return in the linear sense - execution continues
-    // in the NEW thread context. When THIS thread is scheduled again in the
-    // future, it will "return" from switch_context at that point.
-    // DO NOT add code after this call expecting it to run in the old context.
+    // Perform the actual context switch with no locks held.
+    // switch_context saves callee-saved registers to FROM, restores from TO,
+    // then enters switch_to_context_internal which builds a proper 5-qword
+    // IRET frame (including SS and RSP) and does iretq.
+    // When THIS thread is scheduled again, it will "return" from switch_context.
     unsafe {
         switch_context(from_ctx_ptr, to_ctx_ptr);
     }
 
-    // Re-enable interrupts when we resume (happens when this thread is scheduled again)
+    // Re-enable interrupts when we resume
     crate::interrupts::enable();
 }

--- a/userspace/libs/libipc/src/services.rs
+++ b/userspace/libs/libipc/src/services.rs
@@ -12,11 +12,13 @@ use alloc::vec::Vec;
 // Well-Known Service Ports
 // ============================================================================
 
-/// Well-known port for the name service
-pub const NAME_SERVICE_PORT: u64 = 100;
+/// Well-known port for the name service.
+/// Must match the reserved port ID used by namesvc (see ports.rs well_known::NAME_SERVICE).
+pub const NAME_SERVICE_PORT: u64 = 1;
 
-/// Well-known port for the service manager
-pub const SERVICE_MANAGER_PORT: u64 = 101;
+/// Well-known port for the service manager.
+/// Must match the reserved port ID used by service_manager (see ports.rs well_known::SERVICE_MANAGER).
+pub const SERVICE_MANAGER_PORT: u64 = 2;
 
 // ============================================================================
 // Name Service Messages (600-699)

--- a/userspace/libs/syscall/src/ipc.rs
+++ b/userspace/libs/syscall/src/ipc.rs
@@ -19,6 +19,21 @@ pub fn create_port() -> SyscallResult<PortId> {
     }
 }
 
+/// Create an IPC port with a specific reserved ID (1-255).
+///
+/// Used by well-known system services (e.g., namesvc on Port 1) to get
+/// deterministic, pre-assigned port IDs instead of sequentially allocated ones.
+pub fn create_port_with_id(id: PortId) -> SyscallResult<PortId> {
+    use crate::raw::{syscall1, numbers::SYS_IPC_CREATE_PORT_WITH_ID};
+    let result = unsafe { syscall1(SYS_IPC_CREATE_PORT_WITH_ID, id) };
+
+    if result == 0 || result >= u64::MAX - 10 {
+        Err(SyscallError::InvalidArgument)
+    } else {
+        Ok(result)
+    }
+}
+
 /// Close an IPC port
 pub fn close_port(port: PortId) -> SyscallResult<()> {
     let result = unsafe { syscall1(SYS_IPC_CLOSE_PORT, port) };

--- a/userspace/libs/syscall/src/raw.rs
+++ b/userspace/libs/syscall/src/raw.rs
@@ -58,6 +58,7 @@ pub mod numbers {
     pub const SYS_GET_PROCESS_COUNT: u64 = 48;
     pub const SYS_READ_KLOG: u64 = 49;
     pub const SYS_MOUSE_GET_ID: u64 = 50;
+    pub const SYS_IPC_CREATE_PORT_WITH_ID: u64 = 51;
 }
 
 /// Raw syscall with no arguments

--- a/userspace/services/init/src/main.rs
+++ b/userspace/services/init/src/main.rs
@@ -9,10 +9,13 @@
 //! 1. Spawn `namesvc` (service discovery)
 //! 2. Spawn `service_manager` (lifecycle management)
 //! 3. Wait for services to be ready
-//! 4. Spawn `ui_shell` (compositor / window manager)
-//! 5. Spawn userspace drivers: keyboard, mouse, display
+//! 4. Spawn `ui_shell` (compositor / window manager with unified input)
+//! 5. Spawn `display` driver
 //! 6. Spawn `terminal`
 //! 7. Enter supervision loop
+//!
+//! Note: Keyboard and mouse input are handled directly by ui_shell via kernel
+//! buffer polling. Separate keyboard/mouse driver processes are not spawned.
 //!
 //! ## Design
 //!

--- a/userspace/services/namesvc/src/main.rs
+++ b/userspace/services/namesvc/src/main.rs
@@ -185,10 +185,19 @@ pub extern "C" fn _start() -> ! {
 }
 
 fn main() -> ! {
-    // Create our service port - this MUST be the first port created in the system to be Port(1)
-    let port = match atom_syscall::ipc::create_port() {
+    // Create our service port with the reserved well-known ID (Port 1).
+    // This uses create_port_with_id() for deterministic assignment instead of
+    // relying on being the first process to call create_port().
+    let port = match atom_syscall::ipc::create_port_with_id(1) {
         Ok(p) => p,
-        Err(_) => loop { atom_syscall::thread::sleep_ms(1000); }
+        Err(_) => {
+            // Fallback: try regular create_port if reserved allocation fails
+            atom_syscall::debug::log("namesvc: WARN - reserved Port(1) failed, using dynamic port");
+            match atom_syscall::ipc::create_port() {
+                Ok(p) => p,
+                Err(_) => loop { atom_syscall::thread::sleep_ms(1000); }
+            }
+        }
     };
 
     atom_syscall::debug::log("namesvc: started on Port(1)");

--- a/userspace/services/service_manager/src/main.rs
+++ b/userspace/services/service_manager/src/main.rs
@@ -14,7 +14,7 @@
 //! - ListServices() - List all managed services and their status
 //! - ServiceStatus(name) - Get status of a specific service
 //!
-//! ## Well-known port: 101 (SERVICE_MANAGER_PORT)
+//! ## Well-known port: 2 (SERVICE_MANAGER_PORT, reserved)
 
 #![no_std]
 #![no_main]
@@ -617,8 +617,8 @@ fn init_default_services() {
 // Main Service Loop
 // ============================================================================
 
-/// Well-known port for the service manager
-pub const SERVICE_MANAGER_PORT: u64 = 101;
+/// Well-known port for the service manager (reserved ID 2)
+pub const SERVICE_MANAGER_PORT: u64 = 2;
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
@@ -628,13 +628,19 @@ pub extern "C" fn _start() -> ! {
 fn main() -> ! {
     atom_syscall::debug::log("svcmgr: Service Manager starting");
 
-    // Create our IPC port
-    let port = match atom_syscall::ipc::create_port() {
+    // Create our IPC port with the reserved well-known ID (Port 2)
+    let port = match atom_syscall::ipc::create_port_with_id(SERVICE_MANAGER_PORT) {
         Ok(p) => p,
         Err(_) => {
-            atom_syscall::debug::log("svcmgr: failed to create port");
-            loop {
-                atom_syscall::thread::sleep_ms(1000);
+            atom_syscall::debug::log("svcmgr: WARN - reserved Port(2) failed, using dynamic port");
+            match atom_syscall::ipc::create_port() {
+                Ok(p) => p,
+                Err(_) => {
+                    atom_syscall::debug::log("svcmgr: failed to create port");
+                    loop {
+                        atom_syscall::thread::sleep_ms(1000);
+                    }
+                }
             }
         }
     };


### PR DESCRIPTION
## Summary

This PR introduces reserved well-known IPC port IDs (1-255) for system services and fixes critical issues with userspace thread context switching. The main changes include:

1. **Reserved IPC Port IDs**: System services (namesvc, service_manager) now use deterministic reserved port IDs instead of relying on allocation order
2. **Userspace Thread Flag**: Added an explicit `is_userspace` flag to threads to reliably distinguish Ring 3 threads from kernel threads
3. **IRET Frame Fix**: Fixed x86_64 context switch to always build a proper 5-qword IRET frame for kernel-to-kernel transitions
4. **Input Handling Consolidation**: Updated documentation to reflect that keyboard/mouse input is now handled by ui_shell rather than separate driver processes

## Key Changes

- **kernel/src/ipc.rs**: 
  - Added `RESERVED_PORT_RANGE` constant (256) to define reserved port IDs (1-255)
  - Added `PortId::new_reserved()` to create ports with specific reserved IDs
  - Added `IpcManager::create_port_with_id()` to allocate reserved ports

- **kernel/src/syscall/mod.rs**:
  - Added `SYS_IPC_CREATE_PORT_WITH_ID` syscall (51) for creating reserved ports
  - Implemented `sys_ipc_create_port_with_id()` with automatic capability granting
  - Fixed `sys_thread_create()` to properly create userspace threads with Ring 3 context

- **kernel/src/thread.rs**:
  - Added `is_userspace: bool` field to `Thread` struct to track Ring 3 execution
  - Added `is_userspace_thread()` function for reliable userspace detection
  - Updated context switch logic to use `is_userspace` flag instead of fragile address_space heuristics

- **kernel/src/interrupts/switch.asm**:
  - Fixed `.iret_to_kernel` to build a full 5-qword IRET frame (RIP, CS, RFLAGS, RSP, SS)
  - Removed incorrect assumption that kernel-to-kernel IRET only pops 3 qwords
  - This fixes potential triple faults when switching between kernel threads

- **kernel/src/init_process.rs**:
  - Updated init process documentation to reflect consolidated input handling
  - Added `is_userspace: true` flag to init thread

- **userspace/libs/libipc/src/services.rs**:
  - Changed `NAME_SERVICE_PORT` from 100 to 1 (reserved)
  - Changed `SERVICE_MANAGER_PORT` from 101 to 2 (reserved)

- **userspace/services/namesvc/src/main.rs** and **service_manager/src/main.rs**:
  - Updated to use `create_port_with_id()` for deterministic port allocation
  - Added fallback to dynamic allocation if reserved port creation fails

## Notable Implementation Details

- The `is_userspace` flag is set at thread creation and never changes, providing a reliable way to distinguish Ring 3 threads from kernel threads without relying on fragile heuristics
- The IRET frame fix ensures that kernel-to-kernel context switches properly restore all CPU state including stack pointer and segment registers
- Reserved port IDs (1-255) are now the authoritative source for well-known service ports, eliminating race conditions in port allocation
- The init process now correctly runs in Ring 3 with the `is_userspace` flag, fixing previous issues where it was incorrectly treated as a kernel thread

https://claude.ai/code/session_01ECZLQCw95s9njDoSXk3Zv4