### PR TITLE
Refactor thread scheduling after exit to prevent use-after-free

### DIFF
--- a/kernel/src/interrupts/handlers.rs
+++ b/kernel/src/interrupts/handlers.rs
@@ -291,11 +291,10 @@ pub extern "C" fn rust_exception_handler(frame: *const InterruptFrame) {
                         }
                     );
 
-                    // Switch to next thread
-                    let (_, next) = sched::on_timer_tick();
-                    if let Some(next_id) = next {
-                        log_info!(LOG_ORIGIN, "Switching to thread {}", next_id);
-                        crate::sched::perform_context_switch(tid, next_id);
+                    // Schedule next thread (falls back to idle if no other thread is ready)
+                    if let Some(next_id) = sched::schedule_after_exit(tid) {
+                        log_info!(LOG_ORIGIN, "Switching to thread {} after page fault kill", next_id);
+                        crate::thread::jump_to_thread(next_id);
                     }
 
                     log_panic!(LOG_ORIGIN, "No threads available after killing faulting thread");
@@ -335,11 +334,10 @@ pub extern "C" fn rust_exception_handler(frame: *const InterruptFrame) {
                         }
                     );
 
-                    // Switch to next thread
-                    let (_, next) = sched::on_timer_tick();
-                    if let Some(next_id) = next {
-                        log_info!(LOG_ORIGIN, "Switching to thread {}", next_id);
-                        crate::sched::perform_context_switch(tid, next_id);
+                    // Schedule next thread (falls back to idle if no other thread is ready)
+                    if let Some(next_id) = sched::schedule_after_exit(tid) {
+                        log_info!(LOG_ORIGIN, "Switching to thread {} after GPF kill", next_id);
+                        crate::thread::jump_to_thread(next_id);
                     }
 
                     log_panic!(LOG_ORIGIN, "No threads available after killing faulting thread");
@@ -392,11 +390,10 @@ pub extern "C" fn rust_exception_handler(frame: *const InterruptFrame) {
                         }
                     );
 
-                    // Switch to next thread
-                    let (_, next) = sched::on_timer_tick();
-                    if let Some(next_id) = next {
-                        log_info!(LOG_ORIGIN, "Switching to thread {}", next_id);
-                        crate::sched::perform_context_switch(tid, next_id);
+                    // Schedule next thread (falls back to idle if no other thread is ready)
+                    if let Some(next_id) = sched::schedule_after_exit(tid) {
+                        log_info!(LOG_ORIGIN, "Switching to thread {} after exception kill", next_id);
+                        crate::thread::jump_to_thread(next_id);
                     }
 
                     log_panic!(LOG_ORIGIN, "No threads available after killing faulting thread");

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -226,7 +226,15 @@ impl Scheduler {
         previous: Option<ThreadId>,
         next: Option<ThreadId>,
     ) -> Option<ThreadId> {
-        let chosen = next.or(previous).or_else(|| self.idle_id());
+        // Only use previous as fallback if it is still a runnable thread.
+        // A terminated/exited thread must never be selected as the fallback;
+        // fall through to the idle thread instead.
+        let valid_previous = previous.filter(|&id| {
+            thread::get_thread_state(id)
+                .map(|s| matches!(s, ThreadState::Running | ThreadState::Ready))
+                .unwrap_or(false)
+        });
+        let chosen = next.or(valid_previous).or_else(|| self.idle_id());
 
         if let Some(prev) = previous {
             if Some(prev) != chosen {
@@ -294,6 +302,48 @@ impl Scheduler {
     fn current_thread(&self) -> Option<ThreadId> {
         *self.current.lock()
     }
+
+    /// Remove all scheduler state for a terminated thread.
+    /// Clears it from the ready queues, priority maps, and current thread slot.
+    fn remove_thread_state(&self, id: ThreadId) {
+        // Remove from priority maps
+        self.base_priorities.lock().remove(&id);
+        self.effective_priorities.lock().remove(&id);
+
+        // Remove from ready queues
+        let mut ready = self.ready.lock();
+        for queue in ready.queues.iter_mut() {
+            queue.retain(|tid| *tid != id);
+        }
+
+        // If it was the current thread, clear the current slot
+        let mut current = self.current.lock();
+        if *current == Some(id) {
+            *current = None;
+        }
+    }
+
+    /// Schedule the next thread after the current thread has exited.
+    /// Clears the terminated thread from the scheduler, picks the next
+    /// runnable thread from the ready queues, and falls back to the idle
+    /// thread if no other thread is available.
+    fn schedule_after_exit_impl(&self, terminated_id: ThreadId) -> Option<ThreadId> {
+        self.remove_thread_state(terminated_id);
+
+        let next = {
+            let mut ready = self.ready.lock();
+            ready.pop_next()
+        };
+
+        let chosen = next.or_else(|| self.idle_id());
+
+        if let Some(id) = chosen {
+            thread::set_thread_state(id, ThreadState::Running);
+            *self.current.lock() = Some(id);
+        }
+
+        chosen
+    }
 }
 
 static SCHEDULER: Scheduler = Scheduler::new();
@@ -322,6 +372,21 @@ pub fn drive_cooperative_tick() {
             perform_context_switch(prev_id, next_id);
         }
     }
+}
+
+/// Remove all scheduler state for a terminated thread.
+/// Must be called during thread termination to prevent the scheduler
+/// from referencing a destroyed thread.
+pub fn remove_thread(id: ThreadId) {
+    SCHEDULER.remove_thread_state(id);
+}
+
+/// Schedule the next thread after a thread has exited/been terminated.
+/// Cleans up the terminated thread from the scheduler and returns the
+/// next runnable thread, falling back to the idle thread.
+/// The caller is responsible for actually switching to the returned thread.
+pub fn schedule_after_exit(terminated_id: ThreadId) -> Option<ThreadId> {
+    SCHEDULER.schedule_after_exit_impl(terminated_id)
 }
 
 pub fn mark_thread_ready(id: ThreadId) {

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -521,20 +521,22 @@ fn sys_thread_exit(exit_code: u64) -> u64 {
             crate::thread::TerminationReason::NormalExit { exit_code }
         );
 
-        // Schedule next thread - this should never return since our thread is gone
-        let (prev, next) = crate::sched::on_timer_tick();
-
-        if let (Some(prev_id), Some(next_id)) = (prev, next) {
-            if prev_id != next_id {
-                crate::sched::perform_context_switch(prev_id, next_id);
-            }
+        // Schedule the next thread after the current one has been destroyed.
+        // schedule_after_exit cleans up the scheduler state for the terminated
+        // thread and returns the next runnable thread (falls back to idle).
+        if let Some(next_id) = crate::sched::schedule_after_exit(tid) {
+            log_info!(LOG_ORIGIN, "thread_exit: switching to thread {}", next_id);
+            // jump_to_thread never returns - it directly enters the target thread
+            crate::thread::jump_to_thread(next_id);
         }
 
+        // No thread available at all (not even idle) - should never happen
         log_panic!(
             LOG_ORIGIN,
-            "thread_exit returned unexpectedly (tid={}) - no threads to switch to!",
+            "thread_exit: no runnable thread after exit (tid={}) - system halted",
             tid
         );
+        loop { crate::arch::halt(); }
     }
 
     ESUCCESS

--- a/kernel/src/thread.rs
+++ b/kernel/src/thread.rs
@@ -1458,8 +1458,9 @@ pub fn terminate_entity(thread_id: ThreadId, reason: TerminationReason) {
     log_debug!(LOG_ORIGIN, "Freed {} kernel stack pages", stack_pages_freed);
     RESOURCE_COUNTERS.kernel_stacks_freed.fetch_add(1, Ordering::Relaxed);
 
-    // Step 8: Remove from scheduler (handled automatically when thread is removed)
-    log_debug!(LOG_ORIGIN, "Step 8/10: Scheduler will remove thread on next tick");
+    // Step 8: Remove from scheduler queues, priority maps, and current-thread slot
+    log_debug!(LOG_ORIGIN, "Step 8/10: Removing from scheduler");
+    crate::sched::remove_thread(thread_id);
 
     // Step 9: Remove from global thread list
     log_debug!(LOG_ORIGIN, "Step 9/10: Removing from thread list");


### PR DESCRIPTION
## Summary
This PR refactors the thread scheduling logic to properly handle thread termination and prevent the scheduler from referencing destroyed threads. The main issue was that after a thread exits or is killed, the scheduler could still attempt to use it as a fallback, leading to potential use-after-free bugs.

## Key Changes

- **New scheduler API**: Introduced `schedule_after_exit()` function that properly cleans up a terminated thread from all scheduler state (ready queues, priority maps, current thread slot) before selecting the next runnable thread.

- **Improved fallback logic**: Modified `select_next_thread()` to validate that the previous thread is still in a runnable state before using it as a fallback. Terminated threads now properly fall through to the idle thread instead.

- **Consistent thread switching**: Replaced all instances of `perform_context_switch()` with `jump_to_thread()` in exception handlers and syscalls when switching after thread termination. This is more appropriate since we're not performing a context save for the terminated thread.

- **Explicit cleanup in terminate_entity()**: Added explicit call to `sched::remove_thread()` during thread termination (Step 8) instead of relying on implicit cleanup, making the lifecycle clearer.

- **Updated exception handlers**: All three exception handlers (page fault, GPF, general exception) now use the new `schedule_after_exit()` API when killing a faulting thread.

- **Improved sys_thread_exit()**: Simplified the exit syscall to use the new scheduling API and added a safety loop at the end in case the system somehow has no runnable threads.

## Implementation Details

The `schedule_after_exit()` function:
1. Removes the terminated thread from all scheduler data structures
2. Pops the next thread from the ready queues
3. Falls back to the idle thread if no other thread is available
4. Sets the chosen thread to Running state and updates the current thread slot
5. Returns the next thread ID for the caller to jump to

This ensures that a terminated thread can never be selected as the next thread to run, eliminating the use-after-free window that existed in the previous implementation.

https://claude.ai/code/session_01Ekjrsph2eb2KCkAyVSuycH