### PR TITLE
Fix application launching and right-click menu behavior in ui_shell

### DIFF
--- a/userspace/drivers/ui_shell/src/main.rs
+++ b/userspace/drivers/ui_shell/src/main.rs
@@ -635,6 +635,8 @@ struct Compositor {
     icons: Vec<DesktopIcon>,
     /// Global tick counter
     ticks: u32,
+    /// Counter for mouse clicks
+    click_counter: u32,
     /// Last click info for double-click
     last_click_tick: u32,
     last_click_icon: Option<usize>,
@@ -706,6 +708,7 @@ impl Compositor {
             desktop_bg: theme::DESKTOP_BG_DEFAULT,
             icons,
             ticks: 0,
+            click_counter: 0,
             last_click_tick: 0,
             last_click_icon: None,
             context_menu: ContextMenu {
@@ -757,10 +760,9 @@ impl Compositor {
             // Build list of ports to wait on (avoiding Vec to prevent memory leaks in BumpAllocator)
             let ports = [self.register_port, self.event_port];
 
-            // Poll for application registrations
+            // Poll for application registrations and WM requests
             while let Ok(Some(len)) = try_recv(self.register_port, &mut reg_buffer) {
-                log("Compositor: Received message on register_port");
-                self.handle_app_registration(&reg_buffer[..len]);
+                self.handle_register_message(&reg_buffer[..len]);
             }
 
             // Poll for application events (e.g., SurfacePresent, Mouse, Keyboard)
@@ -801,6 +803,7 @@ impl Compositor {
             // Handle button states
             if event.left_button {
                 if !self.mouse_left_down {
+                    self.click_counter = self.click_counter.wrapping_add(1);
                     self.handle_click(self.cursor.x, self.cursor.y);
                 } else {
                     self.handle_mouse_drag(self.cursor.x, self.cursor.y);
@@ -896,6 +899,26 @@ impl Compositor {
         if let Some(port) = event_port {
             if port != 0 {
                 let _ = send_message_async(port, MessageType::KeyPress, &event.to_bytes());
+            }
+        }
+    }
+
+    /// Handle messages received on the registration port (AppRegister, WmRequest)
+    fn handle_register_message(&mut self, data: &[u8]) {
+        if data.len() < MessageHeader::SIZE {
+            return;
+        }
+
+        let header = match MessageHeader::from_bytes(data) {
+            Some(h) => h,
+            None => return,
+        };
+
+        match header.msg_type {
+            MessageType::AppRegister => self.handle_app_registration(data),
+            MessageType::WmRequest => self.handle_wm_request(&data[MessageHeader::SIZE..]),
+            _ => {
+                log("Compositor: Unexpected message type on register_port");
             }
         }
     }
@@ -1017,6 +1040,7 @@ impl Compositor {
                 if let Some(event) = MouseButtonEvent::from_bytes(&data[payload_start..]) {
                     if event.button == MouseButton::Left {
                         if !self.mouse_left_down {
+                            self.click_counter = self.click_counter.wrapping_add(1);
                             self.handle_click(self.cursor.x, self.cursor.y);
                         }
                         self.mouse_left_down = true;
@@ -1209,15 +1233,15 @@ impl Compositor {
 
         // 5. Check if clicking on a desktop icon
         if let Some(icon_idx) = self.icon_at(x, y) {
-            let current_tick = self.ticks;
-            if self.last_click_icon == Some(icon_idx) && current_tick.wrapping_sub(self.last_click_tick) < 50 {
-                // Double click! (roughly < 500ms if tick is 10ms)
+            let current = self.click_counter;
+            if self.last_click_icon == Some(icon_idx) && current.wrapping_sub(self.last_click_tick) < 2 {
+                // Double click! (2 consecutive clicks)
                 let exe = self.icons[icon_idx].executable.clone();
                 self.spawn_app(&exe);
                 self.last_click_icon = None;
             } else {
                 self.last_click_icon = Some(icon_idx);
-                self.last_click_tick = current_tick;
+                self.last_click_tick = current;
             }
             return;
         }
@@ -1246,17 +1270,45 @@ impl Compositor {
         }
     }
 
+    fn is_on_panel(&self, y: i32) -> bool {
+        y >= 0 && y < 28
+    }
+
+    fn is_on_dock(&self, x: i32, y: i32) -> bool {
+        self.dock_icon_at(x, y).is_some()
+            || {
+                let width = self.fb.width();
+                let height = self.fb.height();
+                let dock_h = 56;
+                y >= (height as i32 - dock_h - 12)
+            }
+    }
+
     fn handle_right_click(&mut self, x: i32, y: i32) {
         // Hide context menu if already visible
         self.context_menu.visible = false;
 
-        // If clicking on desktop (no window, no dock, no icon), show context menu
-        if self.wm.window_at(x, y).is_none() && self.dock_icon_at(x, y).is_none() && self.icon_at(x, y).is_none() {
-            self.context_menu.x = x;
-            self.context_menu.y = y;
-            self.context_menu.visible = true;
-            self.dirty = true;
+        if self.wm.window_at(x, y).is_some() {
+            return;
         }
+
+        if self.is_on_panel(y) {
+            return;
+        }
+
+        if self.is_on_dock(x, y) {
+            return;
+        }
+
+        if self.icon_at(x, y).is_some() {
+            return;
+        }
+
+        // ✅ somente desktop vazio
+        self.context_menu.x = x;
+        self.context_menu.y = y;
+        self.context_menu.visible = true;
+        self.dirty = true;
     }
 
     fn handle_context_menu_click(&mut self, x: i32, y: i32) -> bool {


### PR DESCRIPTION
This submission fixes two main issues in the Atom OS desktop environment:
1. Applications failing to open: This was caused by an unreliable double-click detection mechanism based on loop ticks, which could be delayed by IPC blocking. I replaced it with an event-driven click counter. Additionally, I fixed the registration port handling to correctly process window creation requests (WmRequest) from applications.
2. Right-click menu appearing in wrong places: The context menu now only appears on empty desktop areas, with explicit checks to block it on the top panel, bottom dock area, and existing windows or icons.

The changes were verified by building the userspace components with `./build.sh --userspace`, which succeeded without errors.

---
*PR created automatically by Jules for task [292556587164258509](https://jules.google.com/task/292556587164258509) started by @fpedrolucas95*

## Summary by Sourcery

Corrige problemas de interação na área de trabalho no compositor `ui_shell` relacionados à abertura de aplicativos e ao comportamento do menu de contexto.

Correções de bugs:
- Garante que as requisições do gerenciador de janelas recebidas na porta de registro sejam devidamente encaminhadas junto com as mensagens de registro de aplicativos.
- Faz com que a ativação de ícones da área de trabalho use um detector de duplo clique baseado em cliques, em vez de uma heurística baseada em temporizador, para iniciar aplicativos de forma confiável.
- Restringe o menu de contexto da área de trabalho para que apareça apenas em áreas vazias da área de trabalho, evitando janelas, o painel superior, regiões da dock e ícones.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix desktop interaction issues in the ui_shell compositor related to app launching and context menu behavior.

Bug Fixes:
- Ensure window manager requests received on the registration port are properly dispatched alongside application registration messages.
- Make desktop icon activation use a click-based double-click detector instead of a tick-timer-based heuristic to reliably launch applications.
- Restrict the desktop context menu to appear only on empty desktop areas, avoiding windows, the top panel, dock regions, and icons.

</details>