### PR TITLE
Use higher-half virtual addresses for kernel stacks

### DIFF
--- a/kernel/src/arch/gdt.rs
+++ b/kernel/src/arch/gdt.rs
@@ -164,7 +164,17 @@ pub fn set_rsp0(rsp0: u64) {
     }
 }
 
+/// Return the top of the double-fault IST stack as a higher-half virtual address.
+///
+/// The static `DOUBLE_FAULT_STACK` lives in BSS at an identity-mapped (lower-half)
+/// address.  When a double fault fires inside a child process's address space the
+/// CPU loads RSP from TSS.IST[0].  If that address is in the lower half it relies
+/// on the deep-copied identity mapping, which may have been partially overwritten
+/// by user-page remaps.  Converting to the higher-half mirror guarantees the IST
+/// stack is reachable regardless of which PML4 is active, because higher-half
+/// entries (256-511) are shared across all address spaces.
 unsafe fn double_fault_stack_top() -> u64 {
-    let stack_ptr = core::ptr::addr_of!(DOUBLE_FAULT_STACK) as *const u8;
-    stack_ptr.add(DOUBLE_FAULT_STACK_SIZE) as u64
+    let stack_ptr = core::ptr::addr_of!(DOUBLE_FAULT_STACK) as u64;
+    let higher_half_base: u64 = 0xFFFF_8000_0000_0000;
+    stack_ptr + higher_half_base + DOUBLE_FAULT_STACK_SIZE as u64
 }

--- a/kernel/src/init_process.rs
+++ b/kernel/src/init_process.rs
@@ -480,16 +480,26 @@ fn allocate_user_stack(pml4_phys: usize) -> Result<usize, InitError> {
 }
 
 /// Allocate kernel stack for syscall handling
+///
+/// CRITICAL: Returns a higher-half virtual address, NOT an identity-mapped address.
+/// Child processes only share the upper-half PML4 entries (256-511) with the kernel.
+/// The lower-half identity mappings are deep-copied at clone time and may diverge
+/// as user pages are remapped into the child's address space.  Using a higher-half
+/// address guarantees the kernel stack is always reachable regardless of which CR3
+/// is active (e.g., during context-switch trampolines that load a new CR3 before
+/// building the IRET frame on the current stack).
 fn allocate_kernel_stack() -> Result<u64, InitError> {
     let phys = pmm::alloc_pages(KERNEL_STACK_PAGES)
         .ok_or(InitError::MemoryAllocationFailed)?;
     let size = KERNEL_STACK_PAGES * PAGE_SIZE;
-    let top = (phys + size) as u64;
+    let virt = vm::HIGHER_HALF_BASE + phys;
+    let top = (virt + size) as u64;
 
     log_info!(
         LOG_ORIGIN,
-        "Kernel stack allocated: phys=0x{:X}, size={} bytes",
+        "Kernel stack allocated: phys=0x{:X}, virt=0x{:X}, size={} bytes",
         phys,
+        virt,
         size
     );
 

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -229,8 +229,13 @@ fn init_scheduler() {
         }
     }
 
-    let idle_stack = mm::pmm::alloc_pages(4).expect("Failed to allocate idle stack");
-    let idle_stack_top = idle_stack + (4 * mm::pmm::PAGE_SIZE);
+    let idle_stack_phys = mm::pmm::alloc_pages(4).expect("Failed to allocate idle stack");
+    // Use higher-half virtual address for the idle thread's kernel stack.
+    // During context switches from idle to a userspace thread, the switch
+    // trampoline loads the target CR3 while RSP still points here.  Higher-half
+    // PML4 entries (256-511) are shared across all address spaces, so this
+    // address remains valid regardless of which CR3 is active.
+    let idle_stack_top = mm::vm::HIGHER_HALF_BASE + idle_stack_phys + (4 * mm::pmm::PAGE_SIZE);
     let cr3 = read_cr3();
 
     let idle_thread = thread::Thread::new(

--- a/kernel/src/syscall/handler.asm
+++ b/kernel/src/syscall/handler.asm
@@ -35,6 +35,12 @@ syscall_entry:
     mov     [rel temp_arg5], r9
 
     lea     rsp, [rel temp_kernel_stack + 16384]
+    ; Convert the identity-mapped BSS address to its higher-half mirror.
+    ; Higher-half PML4 entries (256-511) are shared across ALL address spaces,
+    ; so this stack remains reachable regardless of which CR3 is active.
+    ; R8 is safe to clobber here: its original value was saved to temp_arg4.
+    mov     r8, 0xFFFF800000000000
+    add     rsp, r8
     and     rsp, -16
 
     push    rbx


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where kernel stacks (double-fault IST stack, syscall handler stack, and idle thread stack) were using identity-mapped lower-half addresses that could become unreachable when a child process's address space diverges from the kernel's.

## Problem
Child processes share only the upper-half PML4 entries (256-511) with the kernel. The lower-half identity mappings are deep-copied at clone time and may be partially overwritten as user pages are remapped into the child's address space. When context-switching or handling exceptions in a child process, kernel stacks at lower-half addresses could become inaccessible if their corresponding page table entries were remapped.

## Solution
Convert all kernel stack allocations to use higher-half virtual addresses (0xFFFF_8000_0000_0000 + physical address). Since higher-half PML4 entries are shared across all address spaces, these stacks remain reachable regardless of which CR3 is active.

## Key Changes
- **gdt.rs**: Updated `double_fault_stack_top()` to convert the identity-mapped BSS address to its higher-half mirror before returning
- **init_process.rs**: Modified `allocate_kernel_stack()` to return a higher-half virtual address and added documentation explaining the critical requirement
- **kernel.rs**: Updated idle thread stack allocation to use higher-half addressing with explanatory comments about context-switch safety
- **syscall/handler.asm**: Added inline conversion of the syscall handler's temporary kernel stack from identity-mapped to higher-half address

## Implementation Details
- Higher-half base constant: `0xFFFF_8000_0000_0000`
- All kernel stacks now use the formula: `HIGHER_HALF_BASE + physical_address`
- Added comprehensive documentation explaining why higher-half addressing is required for correctness during context switches and exception handling

https://claude.ai/code/session_01BxPQtKJgAuojeJn2xdh5YW

## Summary by Sourcery

Alterar todos os usos da pilha do kernel para endereços virtuais na metade superior (higher-half) para garantir que permaneçam acessíveis em todos os espaços de endereçamento.

Correções de bugs:
- Impedir que as pilhas do kernel se tornem inacessíveis quando as tabelas de páginas de processos filhos divergem dos mapeamentos de identidade do kernel.

Melhorias:
- Usar endereços virtuais na metade superior para a pilha IST de double-fault, a pilha do manipulador de syscall e a pilha da thread ociosa, alinhando-as com os mapeamentos compartilhados da metade superior.
- Melhorar a documentação e o logging em torno da alocação de pilha do kernel para esclarecer o requisito de endereçamento na metade superior.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch all kernel stack usages to higher-half virtual addresses to ensure they remain reachable across all address spaces.

Bug Fixes:
- Prevent kernel stacks from becoming inaccessible when child process page tables diverge from the kernel's identity mappings.

Enhancements:
- Use higher-half virtual addresses for the double-fault IST stack, syscall handler stack, and idle thread stack, aligning them with the shared upper-half mappings.
- Improve documentation and logging around kernel stack allocation to clarify the requirement for higher-half addressing.

</details>