### PR TITLE
Fix kernel panic on thread exit

### DIFF
--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -226,7 +226,19 @@ impl Scheduler {
         previous: Option<ThreadId>,
         next: Option<ThreadId>,
     ) -> Option<ThreadId> {
-        let chosen = next.or(previous).or_else(|| self.idle_id());
+        // Fallback strategy:
+        // 1. Use the explicitly selected 'next' thread if available
+        // 2. Fall back to 'previous' ONLY if it is still runnable (not blocked or exited)
+        // 3. Absolute fallback to the idle thread
+        let chosen = next
+            .or_else(|| {
+                previous.filter(|&id| {
+                    thread::get_thread_state(id)
+                        .map(|s| matches!(s, ThreadState::Running | ThreadState::Ready))
+                        .unwrap_or(false)
+                })
+            })
+            .or_else(|| self.idle_id());
 
         if let Some(prev) = previous {
             if Some(prev) != chosen {

--- a/kernel/src/thread.rs
+++ b/kernel/src/thread.rs
@@ -1431,40 +1431,50 @@ pub fn terminate_entity(thread_id: ThreadId, reason: TerminationReason) {
     log_debug!(LOG_ORIGIN, "Step 6/10: Removing address spaces from manager");
     crate::mm::addrspace::cleanup_thread_address_spaces(thread_id);
 
-    // Step 7: Free kernel stack
-    log_debug!(LOG_ORIGIN, "Step 7/10: Freeing kernel stack");
-    let kernel_stack_bottom = kernel_stack.wrapping_sub(kernel_stack_size as u64);
-    let num_stack_pages = kernel_stack_size / crate::mm::pmm::PAGE_SIZE;
-
-    log_debug!(
-        LOG_ORIGIN,
-        "Freeing {} kernel stack pages starting at 0x{:X}",
-        num_stack_pages,
-        kernel_stack_bottom
-    );
-
-    let current_pml4 = crate::arch::read_cr3() as usize;
+    // Step 7: Free kernel stack (ONLY if not current thread)
     let mut stack_pages_freed = 0;
+    let is_current = crate::sched::current_thread() == Some(thread_id);
 
-    for i in 0..num_stack_pages {
-        let page_addr = kernel_stack_bottom + (i * crate::mm::pmm::PAGE_SIZE) as u64;
+    if !is_current {
+        log_debug!(LOG_ORIGIN, "Step 7/10: Freeing kernel stack");
+        let kernel_stack_bottom = kernel_stack.wrapping_sub(kernel_stack_size as u64);
+        let num_stack_pages = kernel_stack_size / crate::mm::pmm::PAGE_SIZE;
 
-        if let Ok((phys_addr, _)) = crate::mm::vm::query_mapping_in_pml4(current_pml4, page_addr as usize) {
-            crate::mm::pmm::free_page(phys_addr);
-            stack_pages_freed += 1;
+        log_debug!(
+            LOG_ORIGIN,
+            "Freeing {} kernel stack pages starting at 0x{:X}",
+            num_stack_pages,
+            kernel_stack_bottom
+        );
+
+        let current_pml4 = crate::arch::read_cr3() as usize;
+
+        for i in 0..num_stack_pages {
+            let page_addr = kernel_stack_bottom + (i * crate::mm::pmm::PAGE_SIZE) as u64;
+
+            if let Ok((phys_addr, _)) = crate::mm::vm::query_mapping_in_pml4(current_pml4, page_addr as usize) {
+                crate::mm::pmm::free_page(phys_addr);
+                stack_pages_freed += 1;
+            }
         }
-    }
 
-    log_debug!(LOG_ORIGIN, "Freed {} kernel stack pages", stack_pages_freed);
-    RESOURCE_COUNTERS.kernel_stacks_freed.fetch_add(1, Ordering::Relaxed);
+        log_debug!(LOG_ORIGIN, "Freed {} kernel stack pages", stack_pages_freed);
+        RESOURCE_COUNTERS.kernel_stacks_freed.fetch_add(1, Ordering::Relaxed);
+    } else {
+        log_warn!(LOG_ORIGIN, "Step 7/10: Deferring kernel stack cleanup for current thread");
+    }
 
     // Step 8: Remove from scheduler (handled automatically when thread is removed)
     log_debug!(LOG_ORIGIN, "Step 8/10: Scheduler will remove thread on next tick");
 
-    // Step 9: Remove from global thread list
-    log_debug!(LOG_ORIGIN, "Step 9/10: Removing from thread list");
-    if let Some(_removed) = THREAD_LIST.remove(thread_id) {
-        log_debug!(LOG_ORIGIN, "Thread removed from global list");
+    // Step 9: Remove from global thread list (ONLY if not current thread)
+    if !is_current {
+        log_debug!(LOG_ORIGIN, "Step 9/10: Removing from thread list");
+        if let Some(_removed) = THREAD_LIST.remove(thread_id) {
+            log_debug!(LOG_ORIGIN, "Thread removed from global list");
+        }
+    } else {
+        log_warn!(LOG_ORIGIN, "Step 9/10: Deferring global list removal for current thread");
     }
 
     // Step 10: Update counters and log final report


### PR DESCRIPTION
This change fixes a critical bug where closing an application (like Terminal) could lead to a kernel panic ("no threads to switch to") and a complete system freeze. 

The fix involves:
1. Updating `kernel/src/sched.rs` to validate that the fallback thread is actually runnable.
2. Updating `kernel/src/thread.rs` to avoid "self-destruction" of the current thread during termination, allowing for a safe context switch.

---
*PR created automatically by Jules for task [8501919636747788234](https://jules.google.com/task/8501919636747788234) started by @fpedrolucas95*

## Summary by Sourcery

Evita pânicos do kernel durante a finalização de threads, garantindo uma seleção segura de fallback do escalonador e evitando a limpeza prematura da thread atualmente em execução.

Correções de bugs:
- Evitar liberar a pilha de kernel e remover a thread atual da lista global enquanto ela ainda está em execução, prevenindo autodestruição durante a finalização.
- Garantir que o escalonador só faça fallback para uma thread previamente em execução se ela ainda estiver em estado executável, eliminando alvos inválidos de troca de contexto que poderiam levar a pânicos.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent kernel panics during thread termination by ensuring safe scheduler fallback selection and avoiding premature cleanup of the currently running thread.

Bug Fixes:
- Avoid freeing the kernel stack and removing the current thread from the global list while it is still running, preventing self-destruction during termination.
- Ensure the scheduler only falls back to a previously running thread if it is still in a runnable state, eliminating invalid context switch targets that could lead to panics.

</details>