### PR TITLE
Refine physical RAM identification and statistics reporting

### DIFF
--- a/kernel/src/boot.rs
+++ b/kernel/src/boot.rs
@@ -5,9 +5,21 @@
 //! proper.
 
 // EFI Memory Types - these become available after ExitBootServices()
+pub const EFI_RESERVED_MEMORY: u32 = 0;
+pub const EFI_LOADER_CODE: u32 = 1;
+pub const EFI_LOADER_DATA: u32 = 2;
 pub const EFI_BOOT_SERVICES_CODE: u32 = 3;
 pub const EFI_BOOT_SERVICES_DATA: u32 = 4;
+pub const EFI_RUNTIME_SERVICES_CODE: u32 = 5;
+pub const EFI_RUNTIME_SERVICES_DATA: u32 = 6;
 pub const EFI_CONVENTIONAL_MEMORY: u32 = 7;
+pub const EFI_UNUSABLE_MEMORY: u32 = 8;
+pub const EFI_ACPI_RECLAIM_MEMORY: u32 = 9;
+pub const EFI_ACPI_MEMORY_NVS: u32 = 10;
+pub const EFI_MEMORY_MAPPED_IO: u32 = 11;
+pub const EFI_MEMORY_MAPPED_IO_PORT_SPACE: u32 = 12;
+pub const EFI_PAL_CODE: u32 = 13;
+pub const EFI_PERSISTENT_MEMORY: u32 = 14;
 
 #[repr(C)]
 pub struct MemoryMap {

--- a/kernel/src/mm/pmm.rs
+++ b/kernel/src/mm/pmm.rs
@@ -33,7 +33,7 @@
 // - Zeroed variants for page tables and heap init
 // - get_stats / get_detailed_stats / get_memory_stats — diagnostics
 
-use crate::boot::{MemoryMap, EFI_CONVENTIONAL_MEMORY, EFI_BOOT_SERVICES_CODE, EFI_BOOT_SERVICES_DATA};
+use crate::boot::*;
 #[allow(unused_imports)]
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use spin::Mutex;
@@ -111,6 +111,25 @@ fn is_usable_memory(typ: u32) -> bool {
     typ == EFI_CONVENTIONAL_MEMORY
         || typ == EFI_BOOT_SERVICES_CODE
         || typ == EFI_BOOT_SERVICES_DATA
+}
+
+/// Check if an EFI memory type represents physical RAM (even if reserved or used by kernel/EFI)
+#[inline]
+fn is_any_ram(typ: u32) -> bool {
+    matches!(
+        typ,
+        EFI_LOADER_CODE
+            | EFI_LOADER_DATA
+            | EFI_BOOT_SERVICES_CODE
+            | EFI_BOOT_SERVICES_DATA
+            | EFI_RUNTIME_SERVICES_CODE
+            | EFI_RUNTIME_SERVICES_DATA
+            | EFI_CONVENTIONAL_MEMORY
+            | EFI_ACPI_RECLAIM_MEMORY
+            | EFI_ACPI_MEMORY_NVS
+            | EFI_PAL_CODE
+            | EFI_PERSISTENT_MEMORY
+    )
 }
 
 /// Get human-readable name for EFI memory type
@@ -252,14 +271,17 @@ pub unsafe fn init(memory_map: &MemoryMap) {
         let num_pages = d.number_of_pages as usize;
         let end = start.saturating_add(num_pages * PAGE_SIZE);
 
-        if is_usable_memory(d.typ) {
+        if is_any_ram(d.typ) {
             physical_ram_pages += num_pages;
+        } else {
+            reserved_pages += num_pages;
+        }
+
+        if is_usable_memory(d.typ) {
             usable_region_count += 1;
             if end > highest_usable_addr {
                 highest_usable_addr = end;
             }
-        } else {
-            reserved_pages += num_pages;
         }
     }
 

--- a/kernel/src/mm/vm.rs
+++ b/kernel/src/mm/vm.rs
@@ -60,20 +60,10 @@ use core::arch::asm;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use crate::mm::pmm;
-use crate::boot::{EfiMemoryDescriptor, MemoryMap};
+use crate::boot::*;
 
 use crate::{log_debug, log_info, log_error};
 
-const EFI_LOADER_CODE: u32 = 1;
-const EFI_LOADER_DATA: u32 = 2;
-const EFI_BOOT_SERVICES_CODE: u32 = 3;
-const EFI_BOOT_SERVICES_DATA: u32 = 4;
-const EFI_RUNTIME_SERVICES_CODE: u32 = 5;
-const EFI_RUNTIME_SERVICES_DATA: u32 = 6;
-const EFI_CONVENTIONAL_MEMORY: u32 = 7;
-const EFI_ACPI_RECLAIM_MEMORY: u32 = 9;
-const EFI_ACPI_MEMORY_NVS: u32 = 10;
-const EFI_PERSISTENT_MEMORY: u32 = 14;
 const EFI_MEMORY_UC: u64 = 0x0000_0000_0000_0001;
 const EFI_MEMORY_WC: u64 = 0x0000_0000_0000_0002;
 const EFI_MEMORY_WT: u64 = 0x0000_0000_0000_0004;
@@ -86,11 +76,11 @@ const ENTRIES_PER_TABLE: usize = 512;
 const ADDR_MASK: u64 = 0x000F_FFFF_FFFF_F000;
 /// Higher-half kernel virtual memory base address
 pub const HIGHER_HALF_BASE: usize = 0xFFFF_8000_0000_0000;
-/// Higher-half mirror covers up to 16 GiB of physical RAM.
-/// This must be >= the PMM's static bitmap coverage (16 GiB)
+/// Higher-half mirror covers up to 64 GiB of physical RAM.
+/// This must be >= the PMM's maximum supported memory (64 GiB)
 /// to ensure all tracked physical memory is accessible via the
 /// kernel's higher-half virtual addresses.
-const HIGHER_HALF_MIRROR_SIZE: usize = 16usize * 1024 * 1024 * 1024;
+const HIGHER_HALF_MIRROR_SIZE: usize = 64usize * 1024 * 1024 * 1024;
 static ACTIVE_PML4: AtomicUsize = AtomicUsize::new(0);
 static MAPPED_PAGES: AtomicUsize = AtomicUsize::new(0);
 static PAGE_TABLE_PAGES: AtomicUsize = AtomicUsize::new(0);


### PR DESCRIPTION
Improved memory reporting by correctly identifying all physical RAM regions and increasing the kernel mirror size to 64GB. This ensures system commands like `sysinfo` and `mem` report realistic values that match VM configurations.

---
*PR created automatically by Jules for task [9257932659766908447](https://jules.google.com/task/9257932659766908447) started by @fpedrolucas95*

## Summary by Sourcery

Refinar a detecção de memória física e a cobertura do espelho virtual para melhorar as estatísticas de RAM e o alinhamento com os tipos de memória EFI.

Novos recursos:
- Rastrear todas as regiões de RAM relacionadas ao EFI, incluindo tipos reservados e não utilizáveis, como parte da contabilização de RAM física.

Aperfeiçoamentos:
- Expandir o espelho do kernel na metade superior para cobrir até 64 GiB de RAM física, em linha com a memória máxima suportada pelo PMM.
- Centralizar as constantes de tipos de memória EFI no módulo de boot e reutilizá-las no código de gerenciamento de memória para garantir consistência.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine physical memory detection and virtual mirror coverage to improve RAM statistics and alignment with EFI memory types.

New Features:
- Track all EFI RAM-related regions, including reserved and non-usable types, as part of physical RAM accounting.

Enhancements:
- Expand the higher-half kernel mirror to cover up to 64 GiB of physical RAM in line with the PMM's maximum supported memory.
- Centralize EFI memory type constants in the boot module and reuse them in memory management code for consistency.

</details>