### PR TITLE
Fix macOS build failure for elf2atxf tool

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -26,6 +26,9 @@ $NASM_PATH  = "C:\Program Files\NASM\nasm.exe"
 $REPO_PATH  = $PSScriptRoot
 $OVMF_PATH  = "$REPO_PATH\ovmf\OVMF.fd"
 
+# Detect host triple for cross-platform build
+$HOST_TRIPLE = (rustc -vV | Select-String "host: ") -replace "host:\s+", ""
+
 # Apenas as pastas dos drivers (não precisamos mais do nome do binário aqui)
 $USERSPACE_DRIVERS_DIRS = @("keyboard", "mouse", "display", "terminal", "ui_shell", "demo_rects", "demo_text")
 
@@ -121,13 +124,13 @@ New-Item -ItemType Directory -Path "build","build\userspace","efi\EFI\BOOT","efi
 Header "ELF2ATXF TOOL"
 
 $ELF2ATXF_PATH = "tools\elf2atxf"
-$ELF2ATXF_EXE  = "$ELF2ATXF_PATH\target\x86_64-pc-windows-msvc\release\elf2atxf.exe"
+$ELF2ATXF_EXE  = "$ELF2ATXF_PATH\target\$HOST_TRIPLE\release\elf2atxf.exe"
 
 if (-not (Test-Path $ELF2ATXF_EXE) -or $Clean) {
-    Write-Step "Compilando elf2atxf tool..."
+    Write-Step "Compilando elf2atxf tool ($HOST_TRIPLE)..."
 
     Push-Location $ELF2ATXF_PATH
-    cargo build --release --target x86_64-pc-windows-msvc *> "$REPO_PATH\build.log"
+    cargo build --release --target $HOST_TRIPLE *> "$REPO_PATH\build.log"
     if ($LASTEXITCODE -ne 0) { Write-ErrorMsg "Falha ao compilar elf2atxf"; Pop-Location; exit 1 }
     Pop-Location
 
@@ -283,7 +286,7 @@ if (-not $Kernel -and -not $Userspace) {  # Evita rodar assembly se --kernel onl
 
 Write-Step "Linkando Atom.efi..."
 
-$RUST_LLD = "$env:USERPROFILE\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\x86_64-pc-windows-msvc\bin\rust-lld.exe"
+$RUST_LLD = "$env:USERPROFILE\.rustup\toolchains\nightly-$HOST_TRIPLE\lib\rustlib\$HOST_TRIPLE\bin\rust-lld.exe"
 if (-not (Test-Path $RUST_LLD)) {
     Write-Warning "rust-lld não encontrado no caminho padrão. Tentando localizar..."
     $RUST_LLD = Get-ChildItem "$env:USERPROFILE\.rustup\toolchains\nightly*" -Recurse -File -Name "rust-lld.exe" -ErrorAction SilentlyContinue |

--- a/build.sh
+++ b/build.sh
@@ -197,13 +197,16 @@ if [ "$KERNEL_ONLY" != true ]; then
     # -------------------------------------------------------------------------
     step "Building elf2atxf tool..."
 
+    # Detect host triple for cross-platform build
+    HOST_TRIPLE=$(rustc -vV | sed -n 's/host: //p')
+
     if ! rustup +nightly target list --installed | grep -q "x86_64-unknown-none"; then
         step "Installing x86_64-unknown-none target..."
         rustup +nightly target add x86_64-unknown-none
     fi
 
     pushd tools/elf2atxf > /dev/null
-    if cargo build --release 2>build.log; then
+    if cargo build --release --target "$HOST_TRIPLE" 2>build.log; then
         success "elf2atxf built"
     else
         error "Failed to build elf2atxf"
@@ -212,7 +215,7 @@ if [ "$KERNEL_ONLY" != true ]; then
     fi
     popd > /dev/null
 
-    ELF2ATXF="tools/elf2atxf/target/x86_64-unknown-linux-gnu/release/elf2atxf"
+    ELF2ATXF="tools/elf2atxf/target/$HOST_TRIPLE/release/elf2atxf"
 
     # -------------------------------------------------------------------------
     # Build userspace drivers and convert to ATXF

--- a/tools/elf2atxf/.cargo/config.toml
+++ b/tools/elf2atxf/.cargo/config.toml
@@ -1,4 +1,5 @@
 # This is a host tool, not a UEFI application
-# Build for the native host target
+# The target is now dynamically determined by the build scripts (build.sh / build.ps1)
+# to support cross-platform builds (Linux, macOS, Windows).
 [build]
-target = "x86_64-unknown-linux-gnu"
+# target = "x86_64-unknown-linux-gnu"


### PR DESCRIPTION
Fixed a build error on macOS where the elf2atxf host tool was being forced to compile for Linux. Updated build scripts to detect the host platform triple and use it for the tool's compilation and path resolution.

---
*PR created automatically by Jules for task [11438908604202196063](https://jules.google.com/task/11438908604202196063) started by @fpedrolucas95*

## Summary by Sourcery

Corrige a configuração de build específica da plataforma para a ferramenta host elf2atxf, utilizando o triple de host do Rust detectado para compilação e caminhos de ferramentas, a fim de dar suporte a builds multiplataforma.

Correções de bug:
- Resolve a falha de build no macOS causada pelo elf2atxf estar forçado a compilar para um alvo Linux.

Melhorias:
- Usa o triple de alvo do host do Rust ao compilar a ferramenta elf2atxf e ao resolver seu caminho de saída em scripts de build tanto em PowerShell quanto em shell.
- Ajusta a procura pelo `rust-lld` no script de build em PowerShell para derivar o caminho da toolchain a partir do triple de host detectado.
- Para de fixar (hardcode) o alvo Cargo do elf2atxf em sua configuração, permitindo que os scripts de build controlem o alvo dinamicamente.

Build:
- Atualiza os scripts de build de Windows e Unix para detectar o triple de host do Rust e passá-lo como o alvo de build do Cargo para a ferramenta host elf2atxf.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix platform-specific build configuration for the elf2atxf host tool by using the detected Rust host triple for compilation and tooling paths to support cross-platform builds.

Bug Fixes:
- Resolve macOS build failure caused by elf2atxf being forced to compile for a Linux target.

Enhancements:
- Use the Rust host target triple when building the elf2atxf tool and resolving its output path in both PowerShell and shell build scripts.
- Adjust rust-lld lookup in the PowerShell build script to derive the toolchain path from the detected host triple.
- Stop hardcoding the elf2atxf Cargo target in its config so the build scripts can control the target dynamically.

Build:
- Update Windows and Unix build scripts to detect the Rust host triple and pass it as the Cargo build target for the elf2atxf host tool.

</details>