### PR TITLE
Add three-layer IDT vector safety validation (build/compile/runtime)

### DIFF
--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -8,8 +8,61 @@
 //
 // Do NOT edit vectors.inc or the generated vectors.rs by hand; edit this
 // file instead and rebuild.
+//
+// Architectural constraint — IDT vector range partitioning on x86_64:
+//
+//   The Intel/AMD x86_64 architecture permanently reserves IDT vectors
+//   0x00–0x1F (0–31) for processor-defined exceptions:
+//
+//     0x00  #DE  Divide Error
+//     0x01  #DB  Debug Exception
+//     0x02  —    Non-Maskable Interrupt
+//     0x03  #BP  Breakpoint
+//     0x04  #OF  Overflow
+//     0x05  #BR  BOUND Range Exceeded
+//     0x06  #UD  Invalid Opcode
+//     0x07  #NM  Device Not Available
+//     0x08  #DF  Double Fault
+//     0x09  —    Coprocessor Segment Overrun (reserved/obsolete)
+//     0x0A  #TS  Invalid TSS
+//     0x0B  #NP  Segment Not Present
+//     0x0C  #SS  Stack-Segment Fault
+//     0x0D  #GP  General Protection Fault
+//     0x0E  #PF  Page Fault
+//     0x0F  —    Reserved
+//     0x10  #MF  x87 Floating-Point Exception
+//     0x11  #AC  Alignment Check
+//     0x12  #MC  Machine Check
+//     0x13  #XM  SIMD Floating-Point Exception
+//     0x14  #VE  Virtualization Exception
+//     0x15  #CP  Control Protection Exception
+//     0x16–0x1F  —  Reserved
+//
+//   Assigning a hardware IRQ (PIC/APIC) to any of these vectors produces
+//   silent, catastrophic aliasing: a timer tick, for example, would be
+//   decoded by the CPU as a General Protection Fault, triggering the wrong
+//   handler with an incorrect error code.  The resulting behaviour is
+//   non-deterministic, extremely difficult to reproduce, and effectively
+//   undebuggable under production conditions.
+//
+//   All entries in the `vectors` table below that represent hardware
+//   interrupts (i.e., routed via PIC or APIC) MUST therefore carry a
+//   value ≥ 0x20.  This invariant is enforced at build time immediately
+//   below the table definition.
+//
+//   Reference: Intel® 64 and IA-32 Architectures Software Developer's
+//              Manual, Volume 3A, Section 6.3 "Sources of Interrupts and
+//              Exceptions", Table 6-1 "Protected-Mode Exceptions and
+//              Interrupts".
 
 use std::{env, fs, path::PathBuf};
+
+/// Minimum legal IDT vector for hardware interrupts on x86_64.
+///
+/// The architecture permanently reserves vectors 0x00–0x1F for CPU-defined
+/// exceptions.  Any PIC/APIC-routed interrupt must use a vector ≥ this value.
+/// See the module-level comment above and Intel SDM Vol. 3A §6.3, Table 6-1.
+const FIRST_SAFE_IRQ_VECTOR: u8 = 0x20;
 
 fn main() {
     // -----------------------------------------------------------------------
@@ -22,6 +75,40 @@ fn main() {
         ("MOUSE_INTERRUPT_VECTOR",    44),
         ("USER_TRAP_INTERRUPT_VECTOR", 0x68),
     ];
+
+    // -----------------------------------------------------------------------
+    // Build-time architectural guard.
+    //
+    // Reject any vector assignment that falls inside the CPU-reserved
+    // exception range.  This check runs unconditionally on every `cargo
+    // build`, so an invalid edit is caught immediately with an actionable
+    // error message rather than surviving to produce a silently broken
+    // kernel image.
+    //
+    // Implementation note: `panic!` in a build script causes `cargo` to
+    // print the message and abort the build with a non-zero exit code,
+    // which is exactly the desired behaviour.
+    // -----------------------------------------------------------------------
+    for &(name, val) in vectors {
+        if val < FIRST_SAFE_IRQ_VECTOR {
+            panic!(
+                "\n\n\
+                 *** INVALID INTERRUPT VECTOR ASSIGNMENT ***\n\
+                 \n\
+                 Constant : {name}\n\
+                 Value    : {val:#04X} ({val})\n\
+                 Required : >= {FIRST_SAFE_IRQ_VECTOR:#04X} ({FIRST_SAFE_IRQ_VECTOR})\n\
+                 \n\
+                 x86_64 permanently reserves IDT vectors 0x00–0x1F for CPU-defined\n\
+                 exceptions (#DE, #DB, #NMI, #BP, … #CP).  Routing a hardware IRQ\n\
+                 (PIC/APIC) into this range aliases it with a CPU exception handler,\n\
+                 producing non-deterministic faults that are effectively undebuggable.\n\
+                 \n\
+                 Fix : assign a value >= 0x20 (32) to `{name}` in kernel/build.rs.\n\
+                 Ref : Intel SDM Vol. 3A §6.3, Table 6-1.\n"
+            );
+        }
+    }
 
     // -----------------------------------------------------------------------
     // Rust side — write OUT_DIR/vectors.rs, included by interrupts/mod.rs.

--- a/kernel/src/interrupts/idt.rs
+++ b/kernel/src/interrupts/idt.rs
@@ -31,10 +31,87 @@
 // - `verify_mapping` proactively checks VM mappings to catch early boot bugs
 // - Any mismatch between IDT entries and actual handler symbols will lead
 //   to fatal triple faults, making early diagnostics critical
+//
+// ── Architectural constraint: IDT vector partitioning on x86_64 ─────────────
+//
+// The Intel/AMD x86_64 architecture permanently reserves IDT vectors
+// 0x00–0x1F (decimal 0–31) for processor-defined exceptions.  This partition
+// is enforced by the silicon: the CPU decodes the IDT index unconditionally
+// as a bare integer offset into the descriptor table; it does not distinguish
+// between a software-installed "hardware IRQ" gate and a CPU-generated fault.
+//
+// If a hardware interrupt routed by the PIC or local APIC is assigned to a
+// vector in [0x00, 0x1F], the CPU will invoke the corresponding IDT entry for
+// *both* the CPU exception and the hardware IRQ.  Concretely:
+//
+//   • The timer IRQ on vector 0x0D would fire the #GP handler on every tick,
+//     with a fabricated error code pushed by the hardware stub.  The handler
+//     would attempt to decode a protection fault that never occurred, likely
+//     killing an innocent thread or halting the kernel.
+//   • On SMP systems, cross-processor IPI delivery to a conflicted vector
+//     can corrupt the APIC priority model, blocking all future interrupts.
+//
+// The canonical solution is APIC/PIC remapping: during controller
+// initialisation (apic.rs) the legacy 8259A PIC master is initialised with
+// an ICW2 value of 0x20, and the local APIC LVT timer register is programmed
+// with TIMER_INTERRUPT_VECTOR.  Both operations require TIMER_INTERRUPT_VECTOR
+// ≥ 0x20 to be safe.
+//
+// This invariant is enforced at three independent layers:
+//   1. Build time  — kernel/build.rs panics if any vector < 0x20 (runs on
+//                    every `cargo build` before code generation).
+//   2. Compile time — const assertions below reject an invalid generated
+//                    constant without executing a single instruction.
+//   3. Runtime     — asserts at the top of `init()` catch any path that
+//                    bypasses the build script (e.g., out-of-tree builds,
+//                    injected constants, feature-gated overrides).
+//
+// Reference: Intel® 64 and IA-32 Architectures Software Developer's Manual,
+//            Volume 3A, Section 6.3 "Sources of Interrupts and Exceptions",
+//            Table 6-1 "Protected-Mode Exceptions and Interrupts".
 
 use core::mem::size_of;
 use crate::{log_debug, log_info};
 use super::{KEYBOARD_INTERRUPT_VECTOR, MOUSE_INTERRUPT_VECTOR, TIMER_INTERRUPT_VECTOR, USER_TRAP_INTERRUPT_VECTOR};
+
+// ── Compile-time vector safety assertions ────────────────────────────────────
+//
+// These `const` evaluations are checked by the Rust compiler when the kernel
+// crate is compiled, independently of the build script.  They provide a second
+// enforcement layer: even if build.rs is not re-run (e.g., incremental build
+// with a stale vectors.rs, or an out-of-tree build that supplies its own
+// constants), the compiler will reject any binary where a hardware IRQ vector
+// falls inside the CPU-reserved exception range [0x00, 0x1F].
+//
+// A compile-time failure here is intentional and desirable: it is always
+// preferable to a kernel that silently aliases timer interrupts with CPU
+// exception handlers.
+const _: () = assert!(
+    TIMER_INTERRUPT_VECTOR >= 0x20,
+    "TIMER_INTERRUPT_VECTOR must be >= 0x20: x86_64 reserves vectors 0x00-0x1F \
+     for CPU-defined exceptions (#DE, #DB, #NMI, #BP, ... #CP). \
+     A hardware IRQ at this vector aliases a CPU exception handler. \
+     Fix the assignment in kernel/build.rs. \
+     Ref: Intel SDM Vol. 3A §6.3, Table 6-1.",
+);
+const _: () = assert!(
+    KEYBOARD_INTERRUPT_VECTOR >= 0x20,
+    "KEYBOARD_INTERRUPT_VECTOR must be >= 0x20: x86_64 reserves vectors 0x00-0x1F \
+     for CPU-defined exceptions. Fix the assignment in kernel/build.rs. \
+     Ref: Intel SDM Vol. 3A §6.3, Table 6-1.",
+);
+const _: () = assert!(
+    MOUSE_INTERRUPT_VECTOR >= 0x20,
+    "MOUSE_INTERRUPT_VECTOR must be >= 0x20: x86_64 reserves vectors 0x00-0x1F \
+     for CPU-defined exceptions. Fix the assignment in kernel/build.rs. \
+     Ref: Intel SDM Vol. 3A §6.3, Table 6-1.",
+);
+const _: () = assert!(
+    USER_TRAP_INTERRUPT_VECTOR >= 0x20,
+    "USER_TRAP_INTERRUPT_VECTOR must be >= 0x20: x86_64 reserves vectors 0x00-0x1F \
+     for CPU-defined exceptions. Fix the assignment in kernel/build.rs. \
+     Ref: Intel SDM Vol. 3A §6.3, Table 6-1.",
+);
 
 const IDT_SIZE: usize = 256;
 const DOUBLE_FAULT_IST: u8 = 1;
@@ -134,6 +211,60 @@ const LOG_ORIGIN: &str = "idt";
 const DPL_RING3: u8 = 0x60;
 
 pub fn init() {
+    // ── Runtime vector safety assertions ─────────────────────────────────────
+    //
+    // Belt-and-suspenders defence executed unconditionally at the entry point
+    // of IDT initialisation, before any descriptor is written or `lidt` is
+    // issued.
+    //
+    // Rationale for a runtime assert in addition to build-time and compile-time
+    // checks:
+    //   • Protects against out-of-tree or CI builds that supply pre-generated
+    //     vectors.rs files without re-running build.rs.
+    //   • Catches conditional-compilation paths (feature flags, cfg attributes)
+    //     that might substitute a different constant value at link time.
+    //   • Provides a clear, actionable kernel panic message at boot rather than
+    //     the non-deterministic triple-fault that would occur if an aliased
+    //     vector were actually loaded into the CPU.
+    //
+    // If any assert fires, the kernel halts immediately with an unambiguous
+    // message identifying the offending constant, its actual value, and the
+    // architectural reference.  This is the correct behaviour: a kernel with
+    // an aliased IRQ vector is unsound and must not proceed to load the IDT.
+    assert!(
+        TIMER_INTERRUPT_VECTOR >= 0x20,
+        "IDT init aborted: TIMER_INTERRUPT_VECTOR ({:#04X}) falls inside the \
+         CPU-reserved exception range 0x00-0x1F. A hardware IRQ at this vector \
+         aliases a CPU exception handler, causing non-deterministic faults. \
+         Fix the assignment in kernel/build.rs. \
+         Ref: Intel SDM Vol. 3A §6.3, Table 6-1.",
+        TIMER_INTERRUPT_VECTOR,
+    );
+    assert!(
+        KEYBOARD_INTERRUPT_VECTOR >= 0x20,
+        "IDT init aborted: KEYBOARD_INTERRUPT_VECTOR ({:#04X}) falls inside the \
+         CPU-reserved exception range 0x00-0x1F. \
+         Fix the assignment in kernel/build.rs. \
+         Ref: Intel SDM Vol. 3A §6.3, Table 6-1.",
+        KEYBOARD_INTERRUPT_VECTOR,
+    );
+    assert!(
+        MOUSE_INTERRUPT_VECTOR >= 0x20,
+        "IDT init aborted: MOUSE_INTERRUPT_VECTOR ({:#04X}) falls inside the \
+         CPU-reserved exception range 0x00-0x1F. \
+         Fix the assignment in kernel/build.rs. \
+         Ref: Intel SDM Vol. 3A §6.3, Table 6-1.",
+        MOUSE_INTERRUPT_VECTOR,
+    );
+    assert!(
+        USER_TRAP_INTERRUPT_VECTOR >= 0x20,
+        "IDT init aborted: USER_TRAP_INTERRUPT_VECTOR ({:#04X}) falls inside the \
+         CPU-reserved exception range 0x00-0x1F. \
+         Fix the assignment in kernel/build.rs. \
+         Ref: Intel SDM Vol. 3A §6.3, Table 6-1.",
+        USER_TRAP_INTERRUPT_VECTOR,
+    );
+
     unsafe {
         let idt_addr = core::ptr::addr_of!(IDT) as usize;
         log_debug!(LOG_ORIGIN, "IDT address: 0x{:X}", idt_addr);


### PR DESCRIPTION
## Summary

This PR implements a comprehensive, defense-in-depth validation strategy to prevent hardware interrupt vectors from being assigned to x86_64 CPU-reserved exception ranges (0x00–0x1F). Invalid assignments would cause silent, catastrophic aliasing where hardware IRQs are decoded as CPU exceptions, producing non-deterministic faults.

## Key Changes

- **Build-time validation** (`kernel/build.rs`):
  - Added `FIRST_SAFE_IRQ_VECTOR` constant (0x20) documenting the architectural constraint
  - Implemented validation loop that panics during `cargo build` if any vector < 0x20
  - Added comprehensive module-level documentation explaining the x86_64 vector partitioning requirement with full exception table reference

- **Compile-time validation** (`kernel/src/interrupts/idt.rs`):
  - Added four `const` assertions that reject invalid vectors at compile time
  - Assertions check `TIMER_INTERRUPT_VECTOR`, `KEYBOARD_INTERRUPT_VECTOR`, `MOUSE_INTERRUPT_VECTOR`, and `USER_TRAP_INTERRUPT_VECTOR`
  - Provides a second enforcement layer independent of build script execution

- **Runtime validation** (`kernel/src/interrupts/idt.rs`):
  - Added four runtime `assert!` statements at the entry of `init()` function
  - Executes before any IDT descriptor is written or `lidt` is issued
  - Catches out-of-tree builds, feature-gated overrides, and conditional compilation paths
  - Provides clear, actionable panic messages with actual values and architectural references

- **Documentation**:
  - Added detailed architectural constraint explanation in both files
  - Included Intel SDM Vol. 3A §6.3, Table 6-1 references throughout
  - Documented rationale for three-layer enforcement strategy
  - Explained consequences of vector aliasing (timer IRQ firing #GP handler, SMP APIC corruption)

## Implementation Details

The three validation layers are intentionally redundant:
1. **Build time** catches errors on every `cargo build` before code generation
2. **Compile time** rejects invalid binaries even if build.rs is not re-run (incremental builds, out-of-tree builds)
3. **Runtime** provides final safety net with clear diagnostics before IDT is loaded into CPU

This belt-and-suspenders approach ensures that a kernel with an aliased IRQ vector cannot proceed to load the IDT, preventing the non-deterministic triple-fault that would otherwise occur.

https://claude.ai/code/session_01TiTAXv1KkrVu9WKN9UTtVH

## Summary by Sourcery

Aplicar intervalos seguros de vetores de IDT para interrupções de hardware em x86_64 por meio de validação em camadas, a fim de evitar aliasing com vetores de exceção reservados pela CPU.

Novos recursos:
- Introduzir validação em tempo de build no script de build do kernel para rejeitar vetores de IRQ de hardware atribuídos abaixo de 0x20.
- Adicionar *const assertions* em tempo de compilação garantindo que vetores de interrupção importantes estejam fora da faixa de exceções reservadas pela CPU.
- Adicionar *assertions* em tempo de execução na inicialização da IDT para abortar o boot se vetores de interrupção inseguros forem detectados.

Melhorias:
- Documentar a restrição arquitetural e a justificativa para o particionamento de vetores da IDT e a aplicação em múltiplas camadas, tanto no script de build quanto no módulo de IDT.

Documentação:
- Adicionar documentação detalhada sobre reserva de vetores de IDT em x86_64, incluindo tabela de exceções e referências ao Intel SDM, para orientar a atribuição segura de vetores de interrupção.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce safe IDT vector ranges for hardware interrupts on x86_64 through layered validation to prevent aliasing with CPU-reserved exception vectors.

New Features:
- Introduce build-time validation in the kernel build script to reject hardware IRQ vectors assigned below 0x20.
- Add compile-time const assertions ensuring key interrupt vectors are outside the CPU-reserved exception range.
- Add runtime assertions in IDT initialization to abort boot if unsafe interrupt vectors are detected.

Enhancements:
- Document the architectural constraint and rationale for IDT vector partitioning and multi-layer enforcement in both the build script and IDT module.

Documentation:
- Add detailed x86_64 IDT vector reservation documentation, including exception table and Intel SDM references, to guide safe interrupt vector assignment.

</details>