### PR TITLE
Replace yield_now with sleep_ms in demo_rects animation loop

### DIFF
--- a/userspace/system_apps/demo_rects/src/main.rs
+++ b/userspace/system_apps/demo_rects/src/main.rs
@@ -64,7 +64,7 @@ fn alloc_error(_layout: Layout) -> ! {
 }
 
 use core::panic::PanicInfo;
-use atom_syscall::thread::{yield_now, exit};
+use atom_syscall::thread::{sleep_ms, exit};
 use atom_syscall::debug::log;
 use libgui::application::Application;
 use libgui::color::Color;
@@ -120,7 +120,7 @@ fn main() -> ! {
         if x == 0 || x + 50 >= surface.width() { dx = -dx; }
         if y == 0 || y + 50 >= surface.height() { dy = -dy; }
 
-        yield_now();
+        sleep_ms(16);
     }
 }
 


### PR DESCRIPTION
## Summary
Updated the demo_rects application to use `sleep_ms(16)` instead of `yield_now()` in the animation loop, providing a fixed frame rate of approximately 60 FPS.

## Changes
- Replaced `yield_now()` import with `sleep_ms()` from `atom_syscall::thread`
- Changed the animation loop to call `sleep_ms(16)` instead of `yield_now()`, introducing a 16ms delay between frames

## Details
This change improves the animation behavior by providing a consistent frame rate rather than yielding the CPU immediately. The 16ms sleep duration corresponds to approximately 60 frames per second, creating smoother and more predictable animation of the bouncing rectangles.

https://claude.ai/code/session_01SrmvtLdhWKdBp7NkFu5Hiy

## Summary by Sourcery

Melhorias:
- Utilizar uma pausa de 16 ms no loop de animação `demo_rects` para obter uma taxa de quadros consistente de aproximadamente 60 FPS, em vez de ceder imediatamente a execução.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Use a 16ms sleep in the demo_rects animation loop to target a consistent ~60 FPS frame rate instead of yielding immediately.

</details>