### PR TITLE
Decouple tgl_blit_to_argb32 from TinyGL internal structures

### DIFF
--- a/userspace/apps/tinygl_demo/main.c
+++ b/userspace/apps/tinygl_demo/main.c
@@ -623,7 +623,7 @@ int main(void)
         gears_draw();
 
         /* Blit RGB565 → ARGB32 into the compositor shared surface */
-        tgl_blit_to_argb32(ctx, 0, surface, win.stride);
+        tgl_blit_to_argb32(scratch, tw, th, tw, surface, win.stride);
 
         /* Tell compositor to composite and display the frame */
         wm_commit(wm_port, win.window_id);

--- a/userspace/libs/tinygl/atomos_tgl.h
+++ b/userspace/libs/tinygl/atomos_tgl.h
@@ -20,7 +20,7 @@
  *   // ... draw ...
  *
  *   // 4. Blit to the compositor's 32-bit ARGB surface and commit
- *   tgl_blit_to_argb32(ctx, 0, compositor_surface, stride_in_pixels);
+ *   tgl_blit_to_argb32(scratch, width, height, width, compositor_surface, stride_in_pixels);
  *   wm_commit(...);
  */
 
@@ -28,7 +28,6 @@
 #define ATOMOS_TGL_H
 
 #include <stdint.h>
-#include <GL/oscontext.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,15 +36,18 @@ extern "C" {
 /*
  * tgl_blit_to_argb32 — blit TinyGL framebuffer to AtomOS compositor surface.
  *
- *   ctx           — context created with ostgl_create_context(w, h, 16, ...)
- *   buf_idx       — framebuffer index (0 for single-buffered use)
+ *   src           — pointer to the RGB565 pixel buffer passed to ostgl_create_context
+ *   w             — width in pixels
+ *   h             — height in pixels
+ *   src_stride_px — source stride in *pixels* (usually equal to w)
  *   dst           — pointer to the compositor's shared-surface memory
  *   dst_stride_px — surface stride in *pixels* (WmWindowInfo.stride)
  *
  * The function converts every pixel from RGB565 (TinyGL internal 16-bit) to
- * ARGB32 (0x00RRGGBB).  The destination width and height are taken from ctx.
+ * ARGB32 (0x00RRGGBB).
  */
-void tgl_blit_to_argb32(ostgl_context *ctx, int buf_idx,
+void tgl_blit_to_argb32(const uint16_t *src, uint32_t w, uint32_t h,
+                         uint32_t src_stride_px,
                          uint32_t *dst, uint32_t dst_stride_px);
 
 #ifdef __cplusplus

--- a/userspace/libs/tinygl/atomos_zb_blit.c
+++ b/userspace/libs/tinygl/atomos_zb_blit.c
@@ -17,23 +17,14 @@
  */
 
 #include "atomos_tgl.h"
-#include "zbuffer.h"      /* internal TinyGL header — compiled as part of libtinygl */
 #include <stdint.h>
 
-void tgl_blit_to_argb32(ostgl_context *ctx, int buf_idx,
-                          uint32_t *dst, uint32_t dst_stride_px)
+void tgl_blit_to_argb32(const uint16_t *src, uint32_t w, uint32_t h,
+                         uint32_t src_stride_px,
+                         uint32_t *dst, uint32_t dst_stride_px)
 {
-    ZBuffer *zb = (ZBuffer *)ctx->zbs[buf_idx];
-
-    /* TinyGL stores pixels as uint16_t RGB565; linesize is in *bytes*. */
-    const uint16_t *src    = (const uint16_t *)zb->pbuf;
-    uint32_t        w      = (uint32_t)zb->xsize;
-    uint32_t        h      = (uint32_t)zb->ysize;
-    /* src_stride in pixels = linesize / sizeof(uint16_t) */
-    uint32_t        sspx   = (uint32_t)((unsigned)zb->linesize >> 1u);
-
     for (uint32_t y = 0; y < h; y++) {
-        const uint16_t *srow = src + y * sspx;
+        const uint16_t *srow = src + y * src_stride_px;
         uint32_t       *drow = dst + y * dst_stride_px;
 
         for (uint32_t x = 0; x < w; x++) {


### PR DESCRIPTION
## Summary
Refactored `tgl_blit_to_argb32` to accept explicit buffer parameters instead of depending on TinyGL's internal context and ZBuffer structures. This improves API clarity, reduces coupling, and makes the function more reusable.

## Key Changes
- **Function signature change**: `tgl_blit_to_argb32` now takes explicit parameters (`src`, `w`, `h`, `src_stride_px`) instead of a TinyGL context and buffer index
- **Removed internal dependencies**: Eliminated includes of `zbuffer.h` and `<GL/oscontext.h>` from the public header
- **Simplified implementation**: The function no longer extracts buffer metadata from ZBuffer structures; callers now provide this information directly
- **Updated documentation**: Clarified parameter meanings and removed references to internal TinyGL structures
- **Updated call sites**: Modified `tinygl_demo/main.c` to pass the scratch buffer and dimensions explicitly

## Implementation Details
The refactoring shifts responsibility from the function to the caller for providing:
- Pointer to the RGB565 pixel buffer
- Width and height in pixels
- Source stride in pixels (typically equal to width for non-padded buffers)

This makes the API more explicit and allows the function to work with any RGB565 buffer, not just those managed by TinyGL's context system.

https://claude.ai/code/session_01RyKFo1Zv9Phma5c2HBrmKT
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fpedrolucas95/atom/pull/88" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

Desacoplar o helper de blit TinyGL-para-ARGB32 das estruturas internas de contexto/ZBuffer do TinyGL, fazendo-o operar em buffers RGB565 explícitos e atualizando seu uso de acordo.

Melhorias:
- Alterar `tgl_blit_to_argb32` para aceitar um buffer fonte RGB565 bruto, dimensões e stride da fonte em vez de um contexto TinyGL e índice de buffer, removendo dependências de headers internos do TinyGL da API pública.
- Ajustar a documentação do header público do TinyGL para descrever a nova interface de blit baseada em buffer e remover referências a estruturas específicas do TinyGL.
- Atualizar o aplicativo `tinygl_demo` para chamar a função de blit refatorada com o buffer temporário (scratch buffer), dimensões e stride explicitamente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Decouple the TinyGL-to-ARGB32 blit helper from TinyGL’s internal context/ZBuffer structures by making it operate on explicit RGB565 buffers, and update its usage accordingly.

Enhancements:
- Change tgl_blit_to_argb32 to accept a raw RGB565 source buffer, dimensions, and source stride instead of a TinyGL context and buffer index, removing dependencies on internal TinyGL headers from the public API.
- Adjust the TinyGL public header documentation to describe the new buffer-based blit interface and remove references to TinyGL-specific structures.
- Update the tinygl_demo application to call the refactored blit function with the scratch buffer, dimensions, and stride explicitly.

</details>