### PR TITLE
Fix TinyGL display list corruption by rendering gears directly

### DIFF
--- a/userspace/apps/tinygl_demo/main.c
+++ b/userspace/apps/tinygl_demo/main.c
@@ -269,8 +269,12 @@ static void wm_commit(uint64_t wm_port, uint32_t window_id)
 static GLfloat view_rotx = 20.0f;
 static GLfloat view_roty = 30.0f;
 static GLfloat view_rotz =  0.0f;
-static GLint   gear1, gear2, gear3;
 static GLfloat angle = 0.0f;
+
+/* Gear material colours — file-scope so both gears_init and gears_draw can use them */
+static GLfloat gear_red[4]   = { 0.8f,  0.1f,  0.0f, 1.0f };
+static GLfloat gear_green[4] = { 0.0f,  0.8f,  0.2f, 1.0f };
+static GLfloat gear_blue[4]  = { 0.2f,  0.2f,  1.0f, 1.0f };
 
 /*
  * gear() — draw a single gear wheel.
@@ -393,38 +397,18 @@ static void gear(GLfloat inner_radius, GLfloat outer_radius, GLfloat width,
     glEnd();
 }
 
-/* Build the three gear display lists and set up initial GL state. */
+/* Set up lighting and GL state.  The gear geometry is rendered directly each
+ * frame (no display lists) to avoid TinyGL's list-corruption bug that
+ * manifests as "list N: corrupt first_op_list" when glCallList is used. */
 static void gears_init(void)
 {
-    static GLfloat pos[4]   = { 5.0f,  5.0f, 10.0f, 0.0f };
-    static GLfloat red[4]   = { 0.8f,  0.1f,  0.0f, 1.0f };
-    static GLfloat green[4] = { 0.0f,  0.8f,  0.2f, 1.0f };
-    static GLfloat blue[4]  = { 0.2f,  0.2f,  1.0f, 1.0f };
+    static GLfloat pos[4] = { 5.0f, 5.0f, 10.0f, 0.0f };
 
     glLightfv(GL_LIGHT0, GL_POSITION, pos);
     glEnable(GL_CULL_FACE);
     glEnable(GL_LIGHTING);
     glEnable(GL_LIGHT0);
     glEnable(GL_DEPTH_TEST);
-
-    gear1 = glGenLists(1);
-    glNewList(gear1, GL_COMPILE);
-    glMaterialfv(GL_FRONT, GL_AMBIENT_AND_DIFFUSE, red);
-    gear(1.0f, 4.0f, 1.0f, 20, 0.7f);
-    glEndList();
-
-    gear2 = glGenLists(1);
-    glNewList(gear2, GL_COMPILE);
-    glMaterialfv(GL_FRONT, GL_AMBIENT_AND_DIFFUSE, green);
-    gear(0.5f, 2.0f, 2.0f, 10, 0.7f);
-    glEndList();
-
-    gear3 = glGenLists(1);
-    glNewList(gear3, GL_COMPILE);
-    glMaterialfv(GL_FRONT, GL_AMBIENT_AND_DIFFUSE, blue);
-    gear(1.3f, 2.0f, 0.5f, 10, 0.7f);
-    glEndList();
-
     glEnable(GL_NORMALIZE);
 }
 
@@ -442,7 +426,8 @@ static void gears_reshape(int w, int h)
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 }
 
-/* Render one frame (no swap — caller handles blit/commit). */
+/* Render one frame (no swap — caller handles blit/commit).
+ * Geometry is submitted directly each frame; display lists are not used. */
 static void gears_draw(void)
 {
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -455,19 +440,22 @@ static void gears_draw(void)
     glPushMatrix();
     glTranslatef(-3.0f, -2.0f, 0.0f);
     glRotatef(angle, 0.0f, 0.0f, 1.0f);
-    glCallList(gear1);
+    glMaterialfv(GL_FRONT, GL_AMBIENT_AND_DIFFUSE, gear_red);
+    gear(1.0f, 4.0f, 1.0f, 20, 0.7f);
     glPopMatrix();
 
     glPushMatrix();
     glTranslatef(3.1f, -2.0f, 0.0f);
     glRotatef(-2.0f * angle - 9.0f, 0.0f, 0.0f, 1.0f);
-    glCallList(gear2);
+    glMaterialfv(GL_FRONT, GL_AMBIENT_AND_DIFFUSE, gear_green);
+    gear(0.5f, 2.0f, 2.0f, 10, 0.7f);
     glPopMatrix();
 
     glPushMatrix();
     glTranslatef(-3.1f, 4.2f, 0.0f);
     glRotatef(-2.0f * angle - 25.0f, 0.0f, 0.0f, 1.0f);
-    glCallList(gear3);
+    glMaterialfv(GL_FRONT, GL_AMBIENT_AND_DIFFUSE, gear_blue);
+    gear(1.3f, 2.0f, 0.5f, 10, 0.7f);
     glPopMatrix();
 
     glPopMatrix();
@@ -528,6 +516,7 @@ int main(void)
         const uint32_t hw = WIN_W, hh = WIN_H;
         uint16_t *scratch = (uint16_t *)malloc((size_t)hw * hh * 2u);
         if (!scratch) { printf("[tinygl_demo] malloc failed\n"); return 1; }
+        memset(scratch, 0, (size_t)hw * hh * 2u);
 
         void     *fbs[1] = { scratch };
         ostgl_context *ctx = ostgl_create_context((int)hw, (int)hh, 16, fbs, 1);
@@ -590,6 +579,11 @@ int main(void)
         ipc_close_port(event_port);
         return 1;
     }
+    /* Zero the pixel buffer before handing it to TinyGL.  Some TinyGL
+     * versions read from pbuf during ZBuffer initialisation; an
+     * uninitialised buffer can leave internal state in an undefined
+     * condition. */
+    memset(scratch, 0, (size_t)tw * th * 2u);
 
     /* ------------------------------------------------------------------ */
     /* 5. Initialise TinyGL context                                        */


### PR DESCRIPTION
## Summary
This PR addresses a TinyGL display list corruption bug by refactoring the gears demo to render geometry directly each frame instead of using compiled display lists. Additionally, it ensures pixel buffers are properly initialized before being passed to TinyGL.

## Key Changes
- **Removed display list usage**: Eliminated `glGenLists()`, `glNewList()`, `glEndList()`, and `glCallList()` calls that were triggering TinyGL's "list N: corrupt first_op_list" error
- **Direct geometry rendering**: Moved gear rendering from display lists to immediate-mode calls in `gears_draw()`, with material colors set per-gear
- **Promoted color constants**: Moved gear material color arrays (`gear_red`, `gear_green`, `gear_blue`) from local scope in `gears_init()` to file-scope so they can be accessed by both initialization and drawing functions
- **Removed gear list variables**: Deleted static `GLint gear1, gear2, gear3` variables that are no longer needed
- **Buffer initialization**: Added `memset()` calls to zero-initialize pixel buffers before passing them to TinyGL, preventing undefined internal state during ZBuffer initialization

## Implementation Details
- The gear geometry function remains unchanged; only how it's invoked differs
- Each gear now has its material color set immediately before rendering via `glMaterialfv()`
- Updated comments in `gears_init()` and `gears_draw()` to document the workaround for the display list bug
- Buffer initialization is performed at two points: after initial allocation and before TinyGL context creation

https://claude.ai/code/session_01Tmfmo1AW7cd7Zm4PgvU1BE
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fpedrolucas95/atom/pull/89" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

Renderize as engrenagens do TinyGL diretamente a cada frame em vez de usar display lists e garanta que os buffers de pixels sejam inicializados com zero antes da criação do contexto TinyGL para evitar corrupção de display lists e estado indefinido do ZBuffer.

Correções de bugs:
- Evitar corrupção de display lists do TinyGL na demonstração das engrenagens substituindo o uso de display lists por renderização direta de geometria.
- Prevenir estado indefinido do ZBuffer do TinyGL inicializando com zero os buffers de pixels antes de criar o contexto de renderização.

Melhorias:
- Promover as definições de cor do material das engrenagens para o escopo de arquivo para que tanto as rotinas de inicialização quanto as de desenho possam reutilizá-las.
- Esclarecer comentários sobre a inicialização e renderização do TinyGL para documentar a solução alternativa às display lists e as expectativas sobre os buffers.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Render TinyGL gears directly each frame instead of using display lists, and ensure pixel buffers are zero-initialized before TinyGL context creation to avoid display list corruption and undefined ZBuffer state.

Bug Fixes:
- Avoid TinyGL display list corruption in the gears demo by replacing display list usage with direct geometry rendering.
- Prevent undefined TinyGL ZBuffer state by zero-initializing pixel buffers before creating the rendering context.

Enhancements:
- Promote gear material color definitions to file scope so both initialization and draw routines can reuse them.
- Clarify comments around TinyGL initialization and rendering to document the display list workaround and buffer expectations.

</details>