### PR TITLE
Implementation of Ping Utility and Network Stack Evolution

### DIFF
--- a/userspace/libs/libipc/src/messages.rs
+++ b/userspace/libs/libipc/src/messages.rs
@@ -511,6 +511,10 @@ pub enum MessageType {
     NetResolve = 1420,
     /// netd -> app: resolve reply
     NetResolveReply = 1421,
+    /// app -> netd: ICMP Echo Request
+    NetIcmpEchoRequest = 1422,
+    /// netd -> app: ICMP Echo Reply
+    NetIcmpEchoReply = 1423,
 }
 
 impl MessageType {
@@ -653,6 +657,8 @@ impl MessageType {
             1419 => Some(Self::NetCloseReply),
             1420 => Some(Self::NetResolve),
             1421 => Some(Self::NetResolveReply),
+            1422 => Some(Self::NetIcmpEchoRequest),
+            1423 => Some(Self::NetIcmpEchoReply),
             _ => None,
         }
     }
@@ -2122,6 +2128,40 @@ impl WallpaperFailedMsg {
 // Networking Messages (1400-1499)
 // ============================================================================
 
+/// Network IP Address (IPv4 or IPv6)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub struct NetIpAddr {
+    pub family: u8, // 4 = IPv4, 6 = IPv6
+    pub data: [u8; 16],
+}
+
+impl NetIpAddr {
+    pub fn ipv4(addr: [u8; 4]) -> Self {
+        let mut data = [0u8; 16];
+        data[0..4].copy_from_slice(&addr);
+        Self { family: 4, data }
+    }
+
+    pub fn ipv6(addr: [u8; 16]) -> Self {
+        Self { family: 6, data: addr }
+    }
+
+    pub fn to_bytes(&self) -> [u8; 17] {
+        let mut bytes = [0u8; 17];
+        bytes[0] = self.family;
+        bytes[1..17].copy_from_slice(&self.data);
+        bytes
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < 17 { return None; }
+        let mut data = [0u8; 16];
+        data.copy_from_slice(&bytes[1..17]);
+        Some(Self { family: bytes[0], data })
+    }
+}
+
 /// netd -> nic_driver: Provide shared memory region for Ring Buffers
 #[derive(Debug, Clone, Copy)]
 pub struct NetAssignRingsMsg {
@@ -2144,6 +2184,102 @@ impl NetAssignRingsMsg {
         Some(Self {
             region_id: u64::from_le_bytes(bytes[0..8].try_into().ok()?),
             ring_capacity: u32::from_le_bytes(bytes[8..12].try_into().ok()?),
+        })
+    }
+}
+
+/// app -> netd: ICMP Echo Request
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct NetIcmpEchoRequestMsg {
+    pub reply_port: u64,
+    pub dest_ip: NetIpAddr,
+    pub sequence: u16,
+    pub timeout_ms: u32,
+    pub payload_len: u32,
+    pub payload: [u8; 64],
+}
+
+impl NetIcmpEchoRequestMsg {
+    pub const SIZE: usize = 8 + 17 + 2 + 4 + 4 + 64;
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(Self::SIZE);
+        bytes.extend_from_slice(&self.reply_port.to_le_bytes());
+        bytes.extend_from_slice(&self.dest_ip.to_bytes());
+        bytes.extend_from_slice(&self.sequence.to_le_bytes());
+        bytes.extend_from_slice(&self.timeout_ms.to_le_bytes());
+        bytes.extend_from_slice(&self.payload_len.to_le_bytes());
+        bytes.extend_from_slice(&self.payload);
+        bytes
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < Self::SIZE { return None; }
+        let reply_port = u64::from_le_bytes(bytes[0..8].try_into().ok()?);
+        let dest_ip = NetIpAddr::from_bytes(&bytes[8..25])?;
+        let sequence = u16::from_le_bytes(bytes[25..27].try_into().ok()?);
+        let timeout_ms = u32::from_le_bytes(bytes[27..31].try_into().ok()?);
+        let payload_len = u32::from_le_bytes(bytes[31..35].try_into().ok()?);
+        let mut payload = [0u8; 64];
+        payload.copy_from_slice(&bytes[35..99]);
+        Some(Self {
+            reply_port,
+            dest_ip,
+            sequence,
+            timeout_ms,
+            payload_len,
+            payload,
+        })
+    }
+}
+
+/// netd -> app: ICMP Echo Reply
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct NetIcmpEchoReplyMsg {
+    pub src_ip: NetIpAddr,
+    pub sequence: u16,
+    pub ttl: u8,
+    pub rtt_ms: u32,
+    pub error: u32, // 0 = success, 1 = timeout, 2 = other
+    pub payload_len: u32,
+    pub payload: [u8; 64],
+}
+
+impl NetIcmpEchoReplyMsg {
+    pub const SIZE: usize = 17 + 2 + 1 + 4 + 4 + 4 + 64;
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(Self::SIZE);
+        bytes.extend_from_slice(&self.src_ip.to_bytes());
+        bytes.extend_from_slice(&self.sequence.to_le_bytes());
+        bytes.push(self.ttl);
+        bytes.extend_from_slice(&self.rtt_ms.to_le_bytes());
+        bytes.extend_from_slice(&self.error.to_le_bytes());
+        bytes.extend_from_slice(&self.payload_len.to_le_bytes());
+        bytes.extend_from_slice(&self.payload);
+        bytes
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < Self::SIZE { return None; }
+        let src_ip = NetIpAddr::from_bytes(&bytes[0..17])?;
+        let sequence = u16::from_le_bytes(bytes[17..19].try_into().ok()?);
+        let ttl = bytes[19];
+        let rtt_ms = u32::from_le_bytes(bytes[20..24].try_into().ok()?);
+        let error = u32::from_le_bytes(bytes[24..28].try_into().ok()?);
+        let payload_len = u32::from_le_bytes(bytes[28..32].try_into().ok()?);
+        let mut payload = [0u8; 64];
+        payload.copy_from_slice(&bytes[32..96]);
+        Some(Self {
+            src_ip,
+            sequence,
+            ttl,
+            rtt_ms,
+            error,
+            payload_len,
+            payload,
         })
     }
 }

--- a/userspace/libs/libipc/src/messages.rs
+++ b/userspace/libs/libipc/src/messages.rs
@@ -515,6 +515,10 @@ pub enum MessageType {
     NetIcmpEchoRequest = 1422,
     /// netd -> app: ICMP Echo Reply
     NetIcmpEchoReply = 1423,
+    /// app -> netd: get current network config
+    NetGetConfig = 1424,
+    /// netd -> app: network config reply
+    NetGetConfigReply = 1425,
 }
 
 impl MessageType {
@@ -659,6 +663,8 @@ impl MessageType {
             1421 => Some(Self::NetResolveReply),
             1422 => Some(Self::NetIcmpEchoRequest),
             1423 => Some(Self::NetIcmpEchoReply),
+            1424 => Some(Self::NetGetConfig),
+            1425 => Some(Self::NetGetConfigReply),
             _ => None,
         }
     }
@@ -716,6 +722,69 @@ impl SurfaceAssignMsg {
             bytes_per_pixel: u32::from_le_bytes([bytes[24], bytes[25], bytes[26], bytes[27]]),
             compositor_port: u64::from_le_bytes([bytes[28], bytes[29], bytes[30], bytes[31], bytes[32], bytes[33], bytes[34], bytes[35]]),
             scale_factor: u32::from_le_bytes([bytes[36], bytes[37], bytes[38], bytes[39]]),
+        })
+    }
+}
+
+/// app -> netd: get current network config
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct NetGetConfigMsg {
+    pub reply_port: u64,
+}
+
+impl NetGetConfigMsg {
+    pub const SIZE: usize = 8;
+
+    pub fn to_bytes(&self) -> [u8; Self::SIZE] {
+        self.reply_port.to_le_bytes()
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < Self::SIZE { return None; }
+        Some(Self {
+            reply_port: u64::from_le_bytes(bytes[0..8].try_into().ok()?),
+        })
+    }
+}
+
+/// netd -> app: network config reply
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct NetGetConfigReplyMsg {
+    pub own_ip: u32,
+    pub netmask: u32,
+    pub gateway: u32,
+    pub dns_server: u32,
+    pub mac: [u8; 6],
+    pub _pad: [u8; 2],
+}
+
+impl NetGetConfigReplyMsg {
+    pub const SIZE: usize = 24;
+
+    pub fn to_bytes(&self) -> [u8; Self::SIZE] {
+        let mut bytes = [0u8; Self::SIZE];
+        bytes[0..4].copy_from_slice(&self.own_ip.to_le_bytes());
+        bytes[4..8].copy_from_slice(&self.netmask.to_le_bytes());
+        bytes[8..12].copy_from_slice(&self.gateway.to_le_bytes());
+        bytes[12..16].copy_from_slice(&self.dns_server.to_le_bytes());
+        bytes[16..22].copy_from_slice(&self.mac);
+        bytes[22..24].copy_from_slice(&self._pad);
+        bytes
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < Self::SIZE { return None; }
+        let mut mac = [0u8; 6];
+        mac.copy_from_slice(&bytes[16..22]);
+        Some(Self {
+            own_ip:     u32::from_le_bytes(bytes[0..4].try_into().ok()?),
+            netmask:    u32::from_le_bytes(bytes[4..8].try_into().ok()?),
+            gateway:    u32::from_le_bytes(bytes[8..12].try_into().ok()?),
+            dns_server: u32::from_le_bytes(bytes[12..16].try_into().ok()?),
+            mac,
+            _pad: [bytes[22], bytes[23]],
         })
     }
 }

--- a/userspace/libs/libnet/src/addr.rs
+++ b/userspace/libs/libnet/src/addr.rs
@@ -1,0 +1,53 @@
+use libipc::messages::NetIpAddr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IpAddr {
+    V4([u8; 4]),
+    V6([u8; 16]),
+}
+
+impl IpAddr {
+    pub fn from_u32(ip: u32) -> Self {
+        Self::V4(ip.to_be_bytes())
+    }
+
+    pub fn to_u32(&self) -> Option<u32> {
+        match self {
+            Self::V4(bytes) => Some(u32::from_be_bytes(*bytes)),
+            Self::V6(_) => None,
+        }
+    }
+
+    pub fn from_net_ip_addr(net_ip: NetIpAddr) -> Self {
+        if net_ip.family == 6 {
+            Self::V6(net_ip.data)
+        } else {
+            let mut bytes = [0u8; 4];
+            bytes.copy_from_slice(&net_ip.data[0..4]);
+            Self::V4(bytes)
+        }
+    }
+
+    pub fn to_net_ip_addr(&self) -> NetIpAddr {
+        match self {
+            Self::V4(bytes) => NetIpAddr::ipv4(*bytes),
+            Self::V6(bytes) => NetIpAddr::ipv6(*bytes),
+        }
+    }
+}
+
+impl core::fmt::Display for IpAddr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::V4(b) => write!(f, "{}.{}.{}.{}", b[0], b[1], b[2], b[3]),
+            Self::V6(b) => {
+                for i in 0..8 {
+                    let word = u16::from_be_bytes([b[i*2], b[i*2+1]]);
+                    write!(f, "{:x}", word)?;
+                    if i < 7 { write!(f, ":")?; }
+                }
+                Ok(())
+            }
+        }
+    }
+}

--- a/userspace/libs/libnet/src/config.rs
+++ b/userspace/libs/libnet/src/config.rs
@@ -1,0 +1,58 @@
+use atom_syscall::ipc::PortId;
+use libipc::messages::{MessageType, NetGetConfigMsg, NetGetConfigReplyMsg};
+use libipc::protocol::{send_message, get_payload};
+use crate::{NetError, IpAddr};
+
+#[derive(Debug, Clone)]
+pub struct NetworkConfig {
+    pub ip: IpAddr,
+    pub netmask: IpAddr,
+    pub gateway: IpAddr,
+    pub dns: IpAddr,
+    pub mac: [u8; 6],
+}
+
+pub fn net_get_config(netd_port: PortId) -> Result<NetworkConfig, NetError> {
+    let reply_port = atom_syscall::ipc::create_port().map_err(|_| NetError::IpcError)?;
+
+    let msg = NetGetConfigMsg {
+        reply_port: reply_port as u64,
+    };
+
+    if let Err(_) = send_message(netd_port, MessageType::NetGetConfig, &msg.to_bytes()) {
+        let _ = atom_syscall::ipc::close_port(reply_port);
+        return Err(NetError::IpcError);
+    }
+
+    let mut buf = [0u8; 64];
+    let ports = [reply_port];
+
+    match atom_syscall::ipc::wait_any(&ports, 1000) {
+        Ok(_) => {
+            if let Ok(len) = atom_syscall::ipc::recv(reply_port, &mut buf) {
+                if let Some(header) = libipc::messages::MessageHeader::from_bytes(&buf) {
+                    if header.msg_type == MessageType::NetGetConfigReply {
+                        let payload = get_payload(&buf, len);
+                        if let Some(reply) = NetGetConfigReplyMsg::from_bytes(payload) {
+                            let config = NetworkConfig {
+                                ip: IpAddr::from_u32(reply.own_ip),
+                                netmask: IpAddr::from_u32(reply.netmask),
+                                gateway: IpAddr::from_u32(reply.gateway),
+                                dns: IpAddr::from_u32(reply.dns_server),
+                                mac: reply.mac,
+                            };
+                            let _ = atom_syscall::ipc::close_port(reply_port);
+                            return Ok(config);
+                        }
+                    }
+                }
+            }
+            let _ = atom_syscall::ipc::close_port(reply_port);
+            Err(NetError::IpcError)
+        }
+        _ => {
+            let _ = atom_syscall::ipc::close_port(reply_port);
+            Err(NetError::Timeout)
+        }
+    }
+}

--- a/userspace/libs/libnet/src/dns.rs
+++ b/userspace/libs/libnet/src/dns.rs
@@ -7,9 +7,11 @@ fn ipc_err(_e: atom_syscall::SyscallError) -> NetError {
     NetError::IpcError
 }
 
-/// Resolve a hostname to an IPv4 address (host byte order u32).
+use crate::IpAddr;
+
+/// Resolve a hostname to an IP address.
 /// hostname must be <= 255 bytes.
-pub fn net_resolve(netd_port: PortId, hostname: &str) -> Result<u32, NetError> {
+pub fn net_resolve(netd_port: PortId, hostname: &str) -> Result<IpAddr, NetError> {
     let hostname_bytes = hostname.as_bytes();
     if hostname_bytes.len() > 255 {
         return Err(NetError::InvalidArgument);
@@ -39,7 +41,7 @@ pub fn net_resolve(netd_port: PortId, hostname: &str) -> Result<u32, NetError> {
             let payload = get_payload(&buf, len);
             if let Some(reply) = NetResolveReplyMsg::from_bytes(payload) {
                 if reply.error == 0 && reply.ip != 0 {
-                    result = Ok(reply.ip);
+                    result = Ok(IpAddr::from_u32(reply.ip));
                 } else {
                     result = Err(NetError::DnsResolutionFailed);
                 }

--- a/userspace/libs/libnet/src/icmp.rs
+++ b/userspace/libs/libnet/src/icmp.rs
@@ -1,0 +1,89 @@
+use alloc::vec::Vec;
+use atom_syscall::ipc::PortId;
+use libipc::messages::{
+    MessageType,
+    NetIcmpEchoRequestMsg, NetIcmpEchoReplyMsg,
+};
+use libipc::protocol::{send_message, get_payload};
+use crate::{NetError, IpAddr};
+
+#[derive(Debug, Clone)]
+pub struct IcmpEchoReply {
+    pub src_ip: IpAddr,
+    pub sequence: u16,
+    pub ttl: u8,
+    pub rtt_ms: u32,
+    pub payload: Vec<u8>,
+}
+
+/// Send an ICMP Echo Request and wait for the reply (blocking).
+pub fn net_icmp_echo(
+    netd_port: PortId,
+    dest_ip: IpAddr,
+    sequence: u16,
+    payload: &[u8],
+    timeout_ms: u32,
+) -> Result<IcmpEchoReply, NetError> {
+    let reply_port = atom_syscall::ipc::create_port().map_err(|_| NetError::IpcError)?;
+
+    let mut msg = NetIcmpEchoRequestMsg {
+        reply_port: reply_port as u64,
+        dest_ip: dest_ip.to_net_ip_addr(),
+        sequence,
+        timeout_ms,
+        payload_len: payload.len() as u32,
+        payload: [0u8; 64],
+    };
+    let copy_len = payload.len().min(64);
+    msg.payload[..copy_len].copy_from_slice(&payload[..copy_len]);
+
+    if let Err(_) = send_message(netd_port, MessageType::NetIcmpEchoRequest, &msg.to_bytes()) {
+        let _ = atom_syscall::ipc::close_port(reply_port);
+        return Err(NetError::IpcError);
+    }
+
+    // Blocking wait using kernel-level timeout
+    let mut response_buf = [0u8; 256];
+    let ports = [reply_port];
+
+    match atom_syscall::ipc::wait_any(&ports, timeout_ms as u64) {
+        Ok(_) => {
+            if let Ok(len) = atom_syscall::ipc::recv(reply_port, &mut response_buf) {
+                if let Some(header) = libipc::messages::MessageHeader::from_bytes(&response_buf) {
+                    if header.msg_type == MessageType::NetIcmpEchoReply {
+                        let payload_bytes = get_payload(&response_buf, len);
+                        if let Some(reply_msg) = NetIcmpEchoReplyMsg::from_bytes(payload_bytes) {
+                            if reply_msg.error == 0 {
+                                let mut reply_payload = Vec::with_capacity(reply_msg.payload_len as usize);
+                                reply_payload.extend_from_slice(&reply_msg.payload[..reply_msg.payload_len as usize]);
+
+                                let result = IcmpEchoReply {
+                                    src_ip: IpAddr::from_net_ip_addr(reply_msg.src_ip),
+                                    sequence: reply_msg.sequence,
+                                    ttl: reply_msg.ttl,
+                                    rtt_ms: reply_msg.rtt_ms,
+                                    payload: reply_payload,
+                                };
+                                let _ = atom_syscall::ipc::close_port(reply_port);
+                                return Ok(result);
+                            } else if reply_msg.error == 1 {
+                                let _ = atom_syscall::ipc::close_port(reply_port);
+                                return Err(NetError::Timeout);
+                            }
+                        }
+                    }
+                }
+            }
+            let _ = atom_syscall::ipc::close_port(reply_port);
+            Err(NetError::IpcError)
+        }
+        Err(atom_syscall::SyscallError::TimedOut) => {
+            let _ = atom_syscall::ipc::close_port(reply_port);
+            Err(NetError::Timeout)
+        }
+        Err(_) => {
+            let _ = atom_syscall::ipc::close_port(reply_port);
+            Err(NetError::IpcError)
+        }
+    }
+}

--- a/userspace/libs/libnet/src/lib.rs
+++ b/userspace/libs/libnet/src/lib.rs
@@ -6,12 +6,14 @@ pub mod socket;
 pub mod dns;
 pub mod http;
 pub mod icmp;
+pub mod config;
 
 pub use addr::*;
 pub use socket::*;
 pub use dns::*;
 pub use http::*;
 pub use icmp::*;
+pub use config::*;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum NetError {

--- a/userspace/libs/libnet/src/lib.rs
+++ b/userspace/libs/libnet/src/lib.rs
@@ -1,13 +1,17 @@
 #![no_std]
 extern crate alloc;
 
+pub mod addr;
 pub mod socket;
 pub mod dns;
 pub mod http;
+pub mod icmp;
 
+pub use addr::*;
 pub use socket::*;
 pub use dns::*;
 pub use http::*;
+pub use icmp::*;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum NetError {

--- a/userspace/libs/libnet/src/socket.rs
+++ b/userspace/libs/libnet/src/socket.rs
@@ -52,14 +52,18 @@ pub fn net_socket(netd_port: PortId) -> Result<u32, NetError> {
     result
 }
 
+use crate::IpAddr;
+
 /// Connect a TCP socket to remote_ip:remote_port.
-pub fn net_connect(netd_port: PortId, socket_id: u32, remote_ip: u32, remote_port: u16) -> Result<(), NetError> {
+pub fn net_connect(netd_port: PortId, socket_id: u32, remote_ip: IpAddr, remote_port: u16) -> Result<(), NetError> {
     let reply_port = atom_syscall::ipc::create_port().map_err(ipc_err)?;
+
+    let ipv4 = remote_ip.to_u32().ok_or(NetError::InvalidArgument)?;
 
     let msg = NetConnectMsg {
         reply_port: reply_port as u64,
         socket_id,
-        remote_ip,
+        remote_ip: ipv4,
         remote_port,
         _pad: [0u8; 2],
     };

--- a/userspace/services/netd/src/icmp.rs
+++ b/userspace/services/netd/src/icmp.rs
@@ -1,48 +1,79 @@
 use crate::ip::ipv4_checksum;
 
-pub const ICMP_ECHO_REQUEST: u8 = 8;
-pub const ICMP_ECHO_REPLY: u8 = 0;
-pub const ICMP_HEADER_LEN: usize = 8;
+pub mod v4 {
+    use crate::ip::ipv4_checksum;
 
-/// ICMP packet header
-#[derive(Debug, Clone, Copy)]
-pub struct IcmpPacket {
-    pub icmp_type: u8,
-    pub code: u8,
-    pub checksum: u16,
-    pub id: u16,
-    pub seq: u16,
-}
+    pub const ICMPV4_ECHO_REQUEST: u8 = 8;
+    pub const ICMPV4_ECHO_REPLY: u8 = 0;
+    pub const ICMPV4_HEADER_LEN: usize = 8;
 
-/// Build an ICMP Echo Request into `out`. Returns length written.
-pub fn build_icmp_echo_request(id: u16, seq: u16, out: &mut [u8]) -> usize {
-    if out.len() < ICMP_HEADER_LEN {
-        return 0;
+    /// ICMPv4 packet header
+    #[derive(Debug, Clone, Copy)]
+    pub struct Icmpv4Packet {
+        pub icmp_type: u8,
+        pub code: u8,
+        pub checksum: u16,
+        pub id: u16,
+        pub seq: u16,
     }
-    out[0] = ICMP_ECHO_REQUEST;
-    out[1] = 0; // code
-    out[2..4].copy_from_slice(&0u16.to_be_bytes()); // checksum placeholder
-    out[4..6].copy_from_slice(&id.to_be_bytes());
-    out[6..8].copy_from_slice(&seq.to_be_bytes());
-    // Compute checksum over the 8-byte ICMP header
-    let csum = ipv4_checksum(&out[0..ICMP_HEADER_LEN]);
-    out[2..4].copy_from_slice(&csum.to_be_bytes());
-    ICMP_HEADER_LEN
+
+    /// Build an ICMPv4 Echo Request into `out`. Returns length written.
+    pub fn build_echo_request(id: u16, seq: u16, payload: &[u8], out: &mut [u8]) -> usize {
+        let total_len = ICMPV4_HEADER_LEN + payload.len();
+        if out.len() < total_len {
+            return 0;
+        }
+        out[0] = ICMPV4_ECHO_REQUEST;
+        out[1] = 0; // code
+        out[2..4].copy_from_slice(&0u16.to_be_bytes()); // checksum placeholder
+        out[4..6].copy_from_slice(&id.to_be_bytes());
+        out[6..8].copy_from_slice(&seq.to_be_bytes());
+
+        if !payload.is_empty() {
+            out[ICMPV4_HEADER_LEN..total_len].copy_from_slice(payload);
+        }
+
+        // Compute checksum over the whole ICMP packet
+        let csum = ipv4_checksum(&out[0..total_len]);
+        out[2..4].copy_from_slice(&csum.to_be_bytes());
+        total_len
+    }
+
+    /// Parse an ICMPv4 packet. Returns (header, payload) or None if data < 8 bytes.
+    pub fn parse_icmp(data: &[u8]) -> Option<(Icmpv4Packet, &[u8])> {
+        if data.len() < ICMPV4_HEADER_LEN {
+            return None;
+        }
+        // Validate checksum
+        if ipv4_checksum(data) != 0 {
+            return None;
+        }
+
+        let pkt = Icmpv4Packet {
+            icmp_type: data[0],
+            code: data[1],
+            checksum: u16::from_be_bytes([data[2], data[3]]),
+            id: u16::from_be_bytes([data[4], data[5]]),
+            seq: u16::from_be_bytes([data[6], data[7]]),
+        };
+        Some((pkt, &data[ICMPV4_HEADER_LEN..]))
+    }
 }
 
-/// Parse an ICMP packet. Returns None if data < 8 bytes.
-pub fn parse_icmp(data: &[u8]) -> Option<IcmpPacket> {
-    if data.len() < ICMP_HEADER_LEN {
-        return None;
-    }
-    Some(IcmpPacket {
-        icmp_type: data[0],
-        code: data[1],
-        checksum: u16::from_be_bytes([data[2], data[3]]),
-        id: u16::from_be_bytes([data[4], data[5]]),
-        seq: u16::from_be_bytes([data[6], data[7]]),
-    })
+pub mod v6 {
+    // Reserved for future ICMPv6 implementation
 }
+
+// Re-export v4 types as default for now to minimize breakage
+pub use v4::{
+    ICMPV4_ECHO_REQUEST as ICMP_ECHO_REQUEST,
+    ICMPV4_ECHO_REPLY as ICMP_ECHO_REPLY,
+    ICMPV4_HEADER_LEN as ICMP_HEADER_LEN,
+    Icmpv4Packet as IcmpPacket,
+    build_echo_request as build_icmp_echo_request,
+    parse_icmp,
+};
+
 
 #[cfg(test)]
 mod tests {
@@ -50,16 +81,18 @@ mod tests {
 
     #[test]
     fn build_parse_echo_request() {
-        let mut buf = [0u8; 8];
-        let len = build_icmp_echo_request(0x1234, 1, &mut buf);
-        assert_eq!(len, 8);
-        let pkt = parse_icmp(&buf).unwrap();
+        let mut buf = [0u8; 12];
+        let payload = [0xAA, 0xBB, 0xCC, 0xDD];
+        let len = build_icmp_echo_request(0x1234, 1, &payload, &mut buf);
+        assert_eq!(len, 12);
+        let (pkt, pld) = parse_icmp(&buf[..len]).unwrap();
         assert_eq!(pkt.icmp_type, ICMP_ECHO_REQUEST);
         assert_eq!(pkt.code, 0);
         assert_eq!(pkt.id, 0x1234);
         assert_eq!(pkt.seq, 1);
-        // Verify checksum: re-computing over the header with checksum included should give 0
-        let csum = ipv4_checksum(&buf[0..8]);
+        assert_eq!(pld, &payload);
+        // Verify checksum: re-computing over the packet with checksum included should give 0
+        let csum = ipv4_checksum(&buf[..len]);
         assert_eq!(csum, 0);
     }
 
@@ -67,5 +100,13 @@ mod tests {
     fn parse_too_short_returns_none() {
         let data = [0u8; 4];
         assert!(parse_icmp(&data).is_none());
+    }
+
+    #[test]
+    fn parse_bad_checksum_returns_none() {
+        let mut buf = [0u8; 8];
+        build_icmp_echo_request(0x1234, 1, &[], &mut buf);
+        buf[2] ^= 0xFF; // Corrupt checksum
+        assert!(parse_icmp(&buf).is_none());
     }
 }

--- a/userspace/services/netd/src/main.rs
+++ b/userspace/services/netd/src/main.rs
@@ -205,7 +205,7 @@ fn main() -> ! {
     {
         let mut pkt_buf = [0u8; 1600];
         let mut icmp_buf = [0u8; 8];
-        let icmp_len = build_icmp_echo_request(1, 1, &mut icmp_buf);
+        let icmp_len = build_icmp_echo_request(1, 1, &[], &mut icmp_buf);
         let mut ip_buf = [0u8; 64];
         let ip_len = build_ipv4(cfg.own_ip, cfg.gateway, IP_PROTO_ICMP, 64, &icmp_buf[..icmp_len], &mut ip_buf);
         let broadcast = [0xff, 0xff, 0xff, 0xff, 0xff, 0xff];
@@ -310,6 +310,13 @@ fn main() -> ! {
         // ARP eviction: 60s = 6000 ticks at 100Hz
         arp_table.evict_expired(now, 6000);
 
+        // ICMP timeouts
+        let timed_out = sock_mgr.check_icmp_timeouts(now);
+        for (reply_port, reply_bytes) in timed_out {
+            send_message(reply_port, MessageType::NetIcmpEchoReply, &reply_bytes).ok();
+            log("netd: ICMP timeout notification sent");
+        }
+
         // TCP tick
         let mut tcp_out = [0u8; 1600];
         if let Some((pkt_len, event)) = tcp_mgr.tick(cfg.own_ip, now, &mut tcp_out) {
@@ -391,9 +398,23 @@ fn dispatch_rx(
                 match ip_hdr.protocol {
                     IP_PROTO_ICMP => {
                         log("netd: RX ICMP");
-                        if let Some(icmp_pkt) = parse_icmp(ip_payload) {
+                        if let Some((icmp_pkt, icmp_payload)) = parse_icmp(ip_payload) {
                             if icmp_pkt.icmp_type == ICMP_ECHO_REPLY {
-                                log("netd: gateway reachable (ping ok)");
+                                log("netd: ICMP Echo Reply received");
+                                let now = atom_syscall::thread::get_ticks();
+                                if let Some((reply_port, reply_bytes)) = sock_mgr.notify_icmp_reply(
+                                    ip_hdr.src,
+                                    icmp_pkt.id,
+                                    icmp_pkt.seq,
+                                    ip_hdr.ttl,
+                                    now,
+                                    icmp_payload,
+                                ) {
+                                    send_message(reply_port, MessageType::NetIcmpEchoReply, &reply_bytes).ok();
+                                    log("netd: NetIcmpEchoReply sent to app");
+                                } else {
+                                    log("netd: gateway reachable (smoke ping ok)");
+                                }
                             }
                         }
                     }
@@ -731,6 +752,37 @@ fn handle_ipc(
             if let Some(msg) = libipc::messages::NetConfigureMsg::from_bytes(payload) {
                 let _ = msg; // Would update cfg, but cfg is not mut here
                 // In a real implementation, we'd update the config
+            }
+        }
+        MessageType::NetIcmpEchoRequest => {
+            let now = atom_syscall::thread::get_ticks();
+            log("netd: received NetIcmpEchoRequest");
+            if let Some((dest_ip, id, seq, icmp_payload)) = sock_mgr.handle_net_icmp_echo(payload, now) {
+                let mut icmp_buf = [0u8; 128];
+                // In handle_net_icmp_echo we didn't return the payload easily,
+                // but for now we'll just re-parse it from the original payload if needed.
+                // Or just use empty payload for now as an MVP improvement.
+                let mut echo_payload = [0u8; 64];
+                let mut echo_payload_len = 0;
+                if let Some(msg) = libipc::messages::NetIcmpEchoRequestMsg::from_bytes(payload) {
+                    echo_payload_len = msg.payload_len as usize;
+                    let copy_len = echo_payload_len.min(64);
+                    echo_payload[..copy_len].copy_from_slice(&msg.payload[..copy_len]);
+                }
+
+                let icmp_len = build_icmp_echo_request(id, seq, &echo_payload[..echo_payload_len], &mut icmp_buf);
+
+                let mut ip_buf = [0u8; 200];
+                let ip_len = build_ipv4(cfg.own_ip, dest_ip, IP_PROTO_ICMP, 64, &icmp_buf[..icmp_len], &mut ip_buf);
+
+                let hop = next_hop(dest_ip, cfg.own_ip, cfg.netmask, cfg.gateway);
+                let dst_mac = get_or_broadcast_mac(hop, tx_producer, cfg);
+
+                let mut eth_buf = [0u8; 256];
+                let eth_len = build_eth_frame(dst_mac, cfg.own_mac, 0x0800, &ip_buf[..ip_len], &mut eth_buf);
+
+                push_to_tx(tx_producer, &eth_buf[..eth_len]);
+                log("netd: ICMP Echo Request pushed to TX");
             }
         }
         _ => {}

--- a/userspace/services/netd/src/main.rs
+++ b/userspace/services/netd/src/main.rs
@@ -402,7 +402,9 @@ fn dispatch_rx(
                             if icmp_pkt.icmp_type == ICMP_ECHO_REPLY {
                                 log("netd: ICMP Echo Reply received");
                                 let now = atom_syscall::thread::get_ticks();
-                                if let Some((reply_port, reply_bytes)) = sock_mgr.notify_icmp_reply(
+
+                                use crate::socket::IcmpMatchResult;
+                                match sock_mgr.notify_icmp_reply(
                                     ip_hdr.src,
                                     icmp_pkt.id,
                                     icmp_pkt.seq,
@@ -410,9 +412,23 @@ fn dispatch_rx(
                                     now,
                                     icmp_payload,
                                 ) {
-                                    send_message(reply_port, MessageType::NetIcmpEchoReply, &reply_bytes).ok();
-                                } else {
-                                    log("netd: gateway reachable (smoke ping ok)");
+                                    IcmpMatchResult::Matched(reply_port, reply_bytes) => {
+                                        send_message(reply_port, MessageType::NetIcmpEchoReply, &reply_bytes).ok();
+                                    }
+                                    IcmpMatchResult::Duplicate => {
+                                        log(&format!("[netd] Duplicate ICMP reply ignored: id=0x{:04x} seq={}", icmp_pkt.id, icmp_pkt.seq));
+                                    }
+                                    IcmpMatchResult::Late => {
+                                        log(&format!("[netd] Late ICMP reply ignored (grace period): id=0x{:04x} seq={}", icmp_pkt.id, icmp_pkt.seq));
+                                    }
+                                    IcmpMatchResult::NoMatch => {
+                                        if icmp_pkt.id == 1 {
+                                            log("netd: gateway reachable (smoke ping ok)");
+                                        } else {
+                                            log(&format!("[netd] Unmatched ICMP reply: id=0x{:04x} seq={} src={}",
+                                                icmp_pkt.id, icmp_pkt.seq, ip_hdr.src));
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/userspace/services/netd/src/main.rs
+++ b/userspace/services/netd/src/main.rs
@@ -439,9 +439,6 @@ fn dispatch_rx(
                             if udp_hdr.src_port == 53 {
                                 log("netd: received UDP from port 53 (DNS response)");
                                 if let Some(dns_resp) = parse_dns_response(udp_payload) {
-                                    let now = atom_syscall::thread::get_ticks();
-                                    let ttl = dns_resp.ttl.max(30);
-
                                     if let Some((reply_port, reply_bytes)) =
                                         sock_mgr.notify_dns_resolved(dns_resp.id, dns_resp.ip)
                                     {
@@ -778,6 +775,20 @@ fn handle_ipc(
 
                 push_to_tx(tx_producer, &eth_buf[..eth_len]);
                 log("netd: ICMP Echo Request pushed to TX");
+            }
+        }
+        MessageType::NetGetConfig => {
+            log("netd: received NetGetConfig");
+            if let Some(msg) = libipc::messages::NetGetConfigMsg::from_bytes(payload) {
+                let reply = libipc::messages::NetGetConfigReplyMsg {
+                    own_ip: cfg.own_ip,
+                    netmask: cfg.netmask,
+                    gateway: cfg.gateway,
+                    dns_server: cfg.dns_server,
+                    mac: cfg.own_mac,
+                    _pad: [0u8; 2],
+                };
+                send_message(msg.reply_port, MessageType::NetGetConfigReply, &reply.to_bytes()).ok();
             }
         }
         _ => {}

--- a/userspace/services/netd/src/main.rs
+++ b/userspace/services/netd/src/main.rs
@@ -9,6 +9,7 @@
 extern crate alloc;
 
 use core::panic::PanicInfo;
+use alloc::format;
 use atom_syscall::debug::log;
 use libring::{RingHeader, RingEntry, RingProducer, RingConsumer};
 use libipc::protocol::{register_service, lookup_service, send_message, try_recv_message, get_payload};
@@ -397,7 +398,6 @@ fn dispatch_rx(
             if let Some((ip_hdr, ip_payload)) = parse_ipv4(payload) {
                 match ip_hdr.protocol {
                     IP_PROTO_ICMP => {
-                        log("netd: RX ICMP");
                         if let Some((icmp_pkt, icmp_payload)) = parse_icmp(ip_payload) {
                             if icmp_pkt.icmp_type == ICMP_ECHO_REPLY {
                                 log("netd: ICMP Echo Reply received");
@@ -411,7 +411,6 @@ fn dispatch_rx(
                                     icmp_payload,
                                 ) {
                                     send_message(reply_port, MessageType::NetIcmpEchoReply, &reply_bytes).ok();
-                                    log("netd: NetIcmpEchoReply sent to app");
                                 } else {
                                     log("netd: gateway reachable (smoke ping ok)");
                                 }
@@ -427,38 +426,17 @@ fn dispatch_rx(
                                     let now = atom_syscall::thread::get_ticks();
                                     let ttl = dns_resp.ttl.max(30);
 
-                                    // Find the pending resolve name that matches this response
-                                    // by checking all pending resolves and trying to match
-                                    let mut resolved_name_buf = [0u8; 256];
-                                    let mut resolved_name_len = 0usize;
-                                    for pr in sock_mgr.pending_resolves.iter() {
-                                        if pr.in_use {
-                                            resolved_name_buf[..pr.name_len].copy_from_slice(&pr.name[..pr.name_len]);
-                                            resolved_name_len = pr.name_len;
-                                            break; // Take the first pending resolve (FIFO)
-                                        }
-                                    }
-
-                                    if resolved_name_len > 0 {
-                                        if let Ok(name) = core::str::from_utf8(&resolved_name_buf[..resolved_name_len]) {
-                                            // Insert into DNS cache
-                                            dns_cache.insert(name, dns_resp.ip, ttl, now);
-                                            log("netd: DNS response matched, notifying pending resolve");
-
-                                            // Notify pending resolve
-                                            if let Some((reply_port, reply_bytes)) =
-                                                sock_mgr.notify_dns_resolved(name, dns_resp.ip)
-                                            {
-                                                send_message(
-                                                    reply_port,
-                                                    MessageType::NetResolveReply,
-                                                    &reply_bytes,
-                                                ).ok();
-                                                log("netd: NetResolveReply sent");
-                                            }
-                                        }
+                                    if let Some((reply_port, reply_bytes)) =
+                                        sock_mgr.notify_dns_resolved(dns_resp.id, dns_resp.ip)
+                                    {
+                                        log(&format!("[netd] DNS match found: id=0x{:04x} -> delivering to client", dns_resp.id));
+                                        send_message(
+                                            reply_port,
+                                            MessageType::NetResolveReply,
+                                            &reply_bytes,
+                                        ).ok();
                                     } else {
-                                        log("netd: DNS response arrived but no pending resolve found");
+                                        log(&format!("[netd] Duplicate or late DNS response ignored: id=0x{:04x}", dns_resp.id));
                                     }
                                 }
                             }
@@ -699,51 +677,52 @@ fn handle_ipc(
         MessageType::NetResolve => {
             let now = atom_syscall::thread::get_ticks();
             log("netd: received NetResolve request");
-            // handle_net_resolve returns Some on cache hit, None on miss (pending stored)
-            let cache_reply = sock_mgr.handle_net_resolve(payload, dns_cache, now);
 
-            if let Some((reply_port, reply_bytes)) = cache_reply {
-                // Cache hit — reply immediately
-                log("netd: DNS cache hit, replying immediately");
-                send_message(reply_port, MessageType::NetResolveReply, &reply_bytes).ok();
-            } else {
-                // Cache miss — send DNS query; reply will come when DNS response arrives
-                log("netd: DNS cache miss, sending query");
-                if let Some(msg) = libipc::messages::NetResolveMsg::from_bytes(payload) {
-                    let name_len = msg.name_len as usize;
-                    let name_bytes = &msg.name[..name_len.min(256)];
-                    if let Ok(name) = core::str::from_utf8(name_bytes) {
-                        let query_id = (atom_syscall::thread::get_ticks() & 0xFFFF) as u16;
-                        let mut dns_buf = [0u8; 512];
-                        let dns_len = build_dns_query(query_id, name, &mut dns_buf);
-                        if dns_len > 0 {
-                            let mut udp_buf = [0u8; 600];
-                            let udp_len = build_udp_with_checksum(
-                                cfg.own_ip, cfg.dns_server,
-                                49000, 53,
-                                &dns_buf[..dns_len],
-                                &mut udp_buf,
-                            );
-                            let mut ip_buf = [0u8; 700];
-                            let ip_len = build_ipv4(
-                                cfg.own_ip, cfg.dns_server,
-                                IP_PROTO_UDP, 64,
-                                &udp_buf[..udp_len],
-                                &mut ip_buf,
-                            );
-                            let broadcast = [0xff, 0xff, 0xff, 0xff, 0xff, 0xff];
-                            let mut eth_buf = [0u8; 800];
-                            let eth_len = build_eth_frame(
-                                broadcast, cfg.own_mac, 0x0800,
-                                &ip_buf[..ip_len],
-                                &mut eth_buf,
-                            );
-                            push_to_tx(tx_producer, &eth_buf[..eth_len]);
-                            log("netd: DNS query pushed to TX");
-                        } else {
-                            log("netd: ERROR build_dns_query returned 0");
+            match sock_mgr.handle_net_resolve(payload, dns_cache, now) {
+                Some(Ok((reply_port, reply_bytes))) => {
+                    log("netd: DNS cache hit, replying immediately");
+                    send_message(reply_port, MessageType::NetResolveReply, &reply_bytes).ok();
+                }
+                Some(Err(query_id)) => {
+                    log("netd: DNS cache miss, sending query");
+                    if let Some(msg) = libipc::messages::NetResolveMsg::from_bytes(payload) {
+                        let name_len = msg.name_len as usize;
+                        let name_bytes = &msg.name[..name_len.min(256)];
+                        if let Ok(name) = core::str::from_utf8(name_bytes) {
+                            let mut dns_buf = [0u8; 512];
+                            let dns_len = build_dns_query(query_id, name, &mut dns_buf);
+                            if dns_len > 0 {
+                                let mut udp_buf = [0u8; 600];
+                                let udp_len = build_udp_with_checksum(
+                                    cfg.own_ip, cfg.dns_server,
+                                    49000, 53,
+                                    &dns_buf[..dns_len],
+                                    &mut udp_buf,
+                                );
+                                let mut ip_buf = [0u8; 700];
+                                let ip_len = build_ipv4(
+                                    cfg.own_ip, cfg.dns_server,
+                                    IP_PROTO_UDP, 64,
+                                    &udp_buf[..udp_len],
+                                    &mut ip_buf,
+                                );
+                                let broadcast = [0xff, 0xff, 0xff, 0xff, 0xff, 0xff];
+                                let mut eth_buf = [0u8; 800];
+                                let eth_len = build_eth_frame(
+                                    broadcast, cfg.own_mac, 0x0800,
+                                    &ip_buf[..ip_len],
+                                    &mut eth_buf,
+                                );
+                                push_to_tx(tx_producer, &eth_buf[..eth_len]);
+                                log("netd: DNS query pushed to TX");
+                            } else {
+                                log("netd: ERROR build_dns_query returned 0");
+                            }
                         }
                     }
+                }
+                None => {
+                    log("netd: NetResolve failed (no resources)");
                 }
             }
         }

--- a/userspace/services/netd/src/socket.rs
+++ b/userspace/services/netd/src/socket.rs
@@ -84,6 +84,9 @@ pub struct PendingIcmp {
     pub start_tick: u64,
     pub timeout_ticks: u64,
     pub in_use: bool,
+    pub delivered: bool,
+    pub timed_out: bool,
+    pub completed_at: Option<u64>,
 }
 
 impl PendingIcmp {
@@ -96,6 +99,9 @@ impl PendingIcmp {
             start_tick: 0,
             timeout_ticks: 0,
             in_use: false,
+            delivered: false,
+            timed_out: false,
+            completed_at: None,
         }
     }
 }
@@ -396,8 +402,20 @@ impl SocketManager {
     ) -> Option<(u64, Vec<u8>)> {
         for pi in self.pending_icmps.iter_mut() {
             if pi.in_use && pi.identifier == id && pi.sequence == seq && pi.dest_ip == src_ip {
+                if pi.delivered {
+                    log(&format!("[netd] Duplicate ICMP reply ignored: id=0x{:04x} seq={}", id, seq));
+                    return None;
+                }
+
+                if pi.timed_out {
+                    log(&format!("[netd] Late ICMP reply ignored (grace period): id=0x{:04x} seq={}", id, seq));
+                    // Entry will be cleaned up by check_icmp_timeouts after grace period
+                    return None;
+                }
+
                 let reply_port = pi.reply_port;
-                pi.in_use = false;
+                pi.delivered = true;
+                pi.completed_at = Some(now_ticks);
 
                 log_netd_icmp_match(id, seq, src_ip);
 
@@ -422,12 +440,23 @@ impl SocketManager {
         None
     }
 
-    /// Periodic cleanup of timed out ICMP requests.
+    /// Periodic cleanup of timed out ICMP requests and completed entries.
     pub fn check_icmp_timeouts(&mut self, now_ticks: u64) -> alloc::vec::Vec<(u64, Vec<u8>)> {
-        let mut timed_out = alloc::vec::Vec::new();
+        let mut notifications = alloc::vec::Vec::new();
+        const GRACE_PERIOD_TICKS: u64 = 50; // 500ms at 100Hz
+
         for pi in self.pending_icmps.iter_mut() {
-            if pi.in_use && now_ticks.saturating_sub(pi.start_tick) >= pi.timeout_ticks {
-                pi.in_use = false;
+            if !pi.in_use { continue; }
+
+            let elapsed = now_ticks.saturating_sub(pi.start_tick);
+
+            // Case 1: Active request exceeds timeout
+            if !pi.delivered && !pi.timed_out && elapsed >= pi.timeout_ticks {
+                pi.timed_out = true;
+                pi.completed_at = Some(now_ticks);
+
+                log(&format!("[netd] ICMP timeout: id=0x{:04x} seq={}", pi.identifier, pi.sequence));
+
                 let reply = NetIcmpEchoReplyMsg {
                     src_ip: NetIpAddr::ipv4(pi.dest_ip.to_be_bytes()),
                     sequence: pi.sequence,
@@ -437,10 +466,19 @@ impl SocketManager {
                     payload_len: 0,
                     payload: [0u8; 64],
                 };
-                timed_out.push((pi.reply_port, reply.to_bytes()));
+                notifications.push((pi.reply_port, reply.to_bytes()));
+                continue;
+            }
+
+            // Case 2: Entry is completed (either delivered or timed out) and exceeds grace period
+            if let Some(done_at) = pi.completed_at {
+                if now_ticks.saturating_sub(done_at) >= GRACE_PERIOD_TICKS {
+                    pi.in_use = false;
+                    // Registry entry finally freed
+                }
             }
         }
-        timed_out
+        notifications
     }
 
     /// Check if there's a pending recv for this socket; if so, fulfill it.

--- a/userspace/services/netd/src/socket.rs
+++ b/userspace/services/netd/src/socket.rs
@@ -1,4 +1,6 @@
 use alloc::vec::Vec;
+use alloc::format;
+use atom_syscall::debug::log;
 use crate::tcp::TcpManager;
 use crate::dns::DnsCache;
 use libipc::messages::{
@@ -33,6 +35,7 @@ impl PendingRecv {
 
 /// A pending DNS resolve: waiting for DNS response to arrive
 pub struct PendingResolve {
+    pub transaction_id: u16,
     pub name: [u8; 256],
     pub name_len: usize,
     pub reply_port: u64,
@@ -44,6 +47,7 @@ pub struct PendingResolve {
 impl PendingResolve {
     const fn new() -> Self {
         Self {
+            transaction_id: 0,
             name: [0u8; 256],
             name_len: 0,
             reply_port: 0,
@@ -100,8 +104,25 @@ pub struct SocketManager {
     pub pending_recvs: [PendingRecv; 8],
     pub pending_resolves: [PendingResolve; 4],
     pub pending_connects: [PendingConnect; 8],
+    next_dns_id: u16,
     pub pending_icmps: [PendingIcmp; 8],
     next_icmp_id: u16,
+}
+
+fn log_netd_icmp_registered(id: u16, seq: u16, dest: u32, client: u64) {
+    let dest_b = dest.to_be_bytes();
+    log(&format!(
+        "[netd] ICMP request registered: id=0x{:04x} seq={} dest={}.{}.{}.{} client=Port({})",
+        id, seq, dest_b[0], dest_b[1], dest_b[2], dest_b[3], client
+    ));
+}
+
+fn log_netd_icmp_match(id: u16, seq: u16, src: u32) {
+    let src_b = src.to_be_bytes();
+    log(&format!(
+        "[netd] ICMP match found: id=0x{:04x} seq={} src={}.{}.{}.{} -> delivering to client",
+        id, seq, src_b[0], src_b[1], src_b[2], src_b[3]
+    ));
 }
 
 impl SocketManager {
@@ -124,6 +145,7 @@ impl SocketManager {
                 PendingIcmp::new(), PendingIcmp::new(), PendingIcmp::new(), PendingIcmp::new(),
             ],
             next_icmp_id: 1000,
+            next_dns_id: 0xABCD,
         }
     }
 
@@ -271,7 +293,7 @@ impl SocketManager {
         payload: &[u8],
         dns: &mut DnsCache,
         now_ticks: u64,
-    ) -> Option<(u64, [u8; NetResolveReplyMsg::SIZE])> {
+    ) -> Option<Result<(u64, [u8; NetResolveReplyMsg::SIZE]), u16>> {
         let msg = NetResolveMsg::from_bytes(payload)?;
         let name_len = (msg.name_len as usize).min(256);
         let name_bytes = &msg.name[..name_len];
@@ -280,32 +302,37 @@ impl SocketManager {
         if let Some(ip) = dns.lookup(name, now_ticks) {
             // Cache hit — reply immediately
             let reply = NetResolveReplyMsg { ip, error: 0 };
-            return Some((msg.reply_port, reply.to_bytes()));
+            return Some(Ok((msg.reply_port, reply.to_bytes())));
         }
 
         // Cache miss — store pending resolve, caller will send DNS query
         for pr in self.pending_resolves.iter_mut() {
             if !pr.in_use {
+                let tid = self.next_dns_id;
+                self.next_dns_id = self.next_dns_id.wrapping_add(1);
+
+                pr.transaction_id = tid;
                 pr.name[..name_len].copy_from_slice(name_bytes);
                 pr.name_len = name_len;
                 pr.reply_port = msg.reply_port;
                 pr.in_use = true;
-                break;
+
+                // Return transaction ID to caller so they can build the packet
+                return Some(Err(tid));
             }
         }
 
-        None // No reply yet; will be sent when DNS response arrives
+        None // No free slots
     }
 
-    /// Called when a DNS response arrives — fulfill any pending resolve for this name.
+    /// Called when a DNS response arrives — fulfill any pending resolve for this ID.
     pub fn notify_dns_resolved(
         &mut self,
-        name: &str,
+        transaction_id: u16,
         ip: u32,
     ) -> Option<(u64, [u8; NetResolveReplyMsg::SIZE])> {
-        let name_bytes = name.as_bytes();
         for pr in self.pending_resolves.iter_mut() {
-            if pr.in_use && &pr.name[..pr.name_len] == name_bytes {
+            if pr.in_use && pr.transaction_id == transaction_id {
                 let reply_port = pr.reply_port;
                 pr.in_use = false;
                 let reply = NetResolveReplyMsg { ip, error: 0 };
@@ -341,6 +368,8 @@ impl SocketManager {
                 pi.identifier = id;
                 pi.sequence = msg.sequence;
                 pi.start_tick = now_ticks;
+
+                log_netd_icmp_registered(id, msg.sequence, dest_ip, msg.reply_port);
                 pi.timeout_ticks = msg.timeout_ms as u64 / 10;
                 pi.in_use = true;
 
@@ -369,6 +398,8 @@ impl SocketManager {
             if pi.in_use && pi.identifier == id && pi.sequence == seq && pi.dest_ip == src_ip {
                 let reply_port = pi.reply_port;
                 pi.in_use = false;
+
+                log_netd_icmp_match(id, seq, src_ip);
 
                 let rtt_ticks = now_ticks.saturating_sub(pi.start_tick);
                 let rtt_ms = (rtt_ticks * 10) as u32;

--- a/userspace/services/netd/src/socket.rs
+++ b/userspace/services/netd/src/socket.rs
@@ -106,6 +106,13 @@ impl PendingIcmp {
     }
 }
 
+pub enum IcmpMatchResult {
+    Matched(u64, Vec<u8>),
+    Duplicate,
+    Late,
+    NoMatch,
+}
+
 pub struct SocketManager {
     pub pending_recvs: [PendingRecv; 8],
     pub pending_resolves: [PendingResolve; 4],
@@ -374,6 +381,9 @@ impl SocketManager {
                 pi.identifier = id;
                 pi.sequence = msg.sequence;
                 pi.start_tick = now_ticks;
+                pi.delivered = false;
+                pi.timed_out = false;
+                pi.completed_at = None;
 
                 log_netd_icmp_registered(id, msg.sequence, dest_ip, msg.reply_port);
                 pi.timeout_ticks = msg.timeout_ms as u64 / 10;
@@ -399,18 +409,15 @@ impl SocketManager {
         ttl: u8,
         now_ticks: u64,
         icmp_payload: &[u8],
-    ) -> Option<(u64, Vec<u8>)> {
+    ) -> IcmpMatchResult {
         for pi in self.pending_icmps.iter_mut() {
             if pi.in_use && pi.identifier == id && pi.sequence == seq && pi.dest_ip == src_ip {
                 if pi.delivered {
-                    log(&format!("[netd] Duplicate ICMP reply ignored: id=0x{:04x} seq={}", id, seq));
-                    return None;
+                    return IcmpMatchResult::Duplicate;
                 }
 
                 if pi.timed_out {
-                    log(&format!("[netd] Late ICMP reply ignored (grace period): id=0x{:04x} seq={}", id, seq));
-                    // Entry will be cleaned up by check_icmp_timeouts after grace period
-                    return None;
+                    return IcmpMatchResult::Late;
                 }
 
                 let reply_port = pi.reply_port;
@@ -434,10 +441,10 @@ impl SocketManager {
                 let copy_len = icmp_payload.len().min(64);
                 reply.payload[..copy_len].copy_from_slice(&icmp_payload[..copy_len]);
 
-                return Some((reply_port, reply.to_bytes()));
+                return IcmpMatchResult::Matched(reply_port, reply.to_bytes());
             }
         }
-        None
+        IcmpMatchResult::NoMatch
     }
 
     /// Periodic cleanup of timed out ICMP requests and completed entries.

--- a/userspace/services/netd/src/socket.rs
+++ b/userspace/services/netd/src/socket.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use crate::tcp::TcpManager;
 use crate::dns::DnsCache;
 use libipc::messages::{
@@ -7,6 +8,8 @@ use libipc::messages::{
     NetRecvMsg, NetRecvReplyMsg,
     NetCloseMsg, NetCloseReplyMsg,
     NetResolveMsg, NetResolveReplyMsg,
+    NetIcmpEchoRequestMsg, NetIcmpEchoReplyMsg,
+    NetIpAddr,
 };
 
 /// A pending deferred recv: socket waiting for data
@@ -68,10 +71,37 @@ impl PendingConnect {
     }
 }
 
+/// A pending ICMP echo request: waiting for Echo Reply
+pub struct PendingIcmp {
+    pub reply_port: u64,
+    pub dest_ip: u32,
+    pub identifier: u16,
+    pub sequence: u16,
+    pub start_tick: u64,
+    pub timeout_ticks: u64,
+    pub in_use: bool,
+}
+
+impl PendingIcmp {
+    const fn new() -> Self {
+        Self {
+            reply_port: 0,
+            dest_ip: 0,
+            identifier: 0,
+            sequence: 0,
+            start_tick: 0,
+            timeout_ticks: 0,
+            in_use: false,
+        }
+    }
+}
+
 pub struct SocketManager {
     pub pending_recvs: [PendingRecv; 8],
     pub pending_resolves: [PendingResolve; 4],
     pub pending_connects: [PendingConnect; 8],
+    pub pending_icmps: [PendingIcmp; 8],
+    next_icmp_id: u16,
 }
 
 impl SocketManager {
@@ -89,6 +119,11 @@ impl SocketManager {
                 PendingConnect::new(), PendingConnect::new(), PendingConnect::new(), PendingConnect::new(),
                 PendingConnect::new(), PendingConnect::new(), PendingConnect::new(), PendingConnect::new(),
             ],
+            pending_icmps: [
+                PendingIcmp::new(), PendingIcmp::new(), PendingIcmp::new(), PendingIcmp::new(),
+                PendingIcmp::new(), PendingIcmp::new(), PendingIcmp::new(), PendingIcmp::new(),
+            ],
+            next_icmp_id: 1000,
         }
     }
 
@@ -278,6 +313,103 @@ impl SocketManager {
             }
         }
         None
+    }
+
+    /// Handle NetIcmpEchoRequest: register pending and return ICMP info for sending.
+    pub fn handle_net_icmp_echo(
+        &mut self,
+        payload: &[u8],
+        now_ticks: u64,
+    ) -> Option<(u32, u16, u16, &[u8])> {
+        let msg = NetIcmpEchoRequestMsg::from_bytes(payload)?;
+
+        // IPv4 only for now
+        if msg.dest_ip.family != 4 {
+            return None;
+        }
+        let dest_ip = u32::from_be_bytes([msg.dest_ip.data[0], msg.dest_ip.data[1], msg.dest_ip.data[2], msg.dest_ip.data[3]]);
+
+        // Find free slot
+        for pi in self.pending_icmps.iter_mut() {
+            if !pi.in_use {
+                let id = self.next_icmp_id;
+                self.next_icmp_id = self.next_icmp_id.wrapping_add(1);
+                if self.next_icmp_id < 1000 { self.next_icmp_id = 1000; }
+
+                pi.reply_port = msg.reply_port;
+                pi.dest_ip = dest_ip;
+                pi.identifier = id;
+                pi.sequence = msg.sequence;
+                pi.start_tick = now_ticks;
+                pi.timeout_ticks = msg.timeout_ms as u64 / 10;
+                pi.in_use = true;
+
+                // We need to return a reference to the payload, but msg is local.
+                // Actually, the payload is part of the msg which is part of payload buffer.
+                // We can't return it easily if we want to return a slice.
+                // Let's change the signature to return the full msg or just the needed parts.
+                // For now, let's just return what we need.
+                return Some((dest_ip, pi.identifier, pi.sequence, &[]));
+            }
+        }
+        None
+    }
+
+    /// Called when an ICMP Echo Reply arrives — fulfill any pending ICMP request.
+    pub fn notify_icmp_reply(
+        &mut self,
+        src_ip: u32,
+        id: u16,
+        seq: u16,
+        ttl: u8,
+        now_ticks: u64,
+        icmp_payload: &[u8],
+    ) -> Option<(u64, Vec<u8>)> {
+        for pi in self.pending_icmps.iter_mut() {
+            if pi.in_use && pi.identifier == id && pi.sequence == seq && pi.dest_ip == src_ip {
+                let reply_port = pi.reply_port;
+                pi.in_use = false;
+
+                let rtt_ticks = now_ticks.saturating_sub(pi.start_tick);
+                let rtt_ms = (rtt_ticks * 10) as u32;
+
+                let mut reply = NetIcmpEchoReplyMsg {
+                    src_ip: NetIpAddr::ipv4(src_ip.to_be_bytes()),
+                    sequence: seq,
+                    ttl,
+                    rtt_ms,
+                    error: 0,
+                    payload_len: icmp_payload.len() as u32,
+                    payload: [0u8; 64],
+                };
+                let copy_len = icmp_payload.len().min(64);
+                reply.payload[..copy_len].copy_from_slice(&icmp_payload[..copy_len]);
+
+                return Some((reply_port, reply.to_bytes()));
+            }
+        }
+        None
+    }
+
+    /// Periodic cleanup of timed out ICMP requests.
+    pub fn check_icmp_timeouts(&mut self, now_ticks: u64) -> alloc::vec::Vec<(u64, Vec<u8>)> {
+        let mut timed_out = alloc::vec::Vec::new();
+        for pi in self.pending_icmps.iter_mut() {
+            if pi.in_use && now_ticks.saturating_sub(pi.start_tick) >= pi.timeout_ticks {
+                pi.in_use = false;
+                let reply = NetIcmpEchoReplyMsg {
+                    src_ip: NetIpAddr::ipv4(pi.dest_ip.to_be_bytes()),
+                    sequence: pi.sequence,
+                    ttl: 0,
+                    rtt_ms: 0,
+                    error: 1, // Timeout
+                    payload_len: 0,
+                    payload: [0u8; 64],
+                };
+                timed_out.push((pi.reply_port, reply.to_bytes()));
+            }
+        }
+        timed_out
     }
 
     /// Check if there's a pending recv for this socket; if so, fulfill it.

--- a/userspace/system_apps/terminal/Cargo.toml
+++ b/userspace/system_apps/terminal/Cargo.toml
@@ -11,6 +11,7 @@ description = "Atom OS userspace terminal emulator"
 atom_abi = { path = "../../../shared/abi" }
 atom_syscall = { path = "../../libs/syscall" }
 libipc = { path = "../../libs/libipc" }
+libnet = { path = "../../libs/libnet" }
 
 [[bin]]
 name = "terminal"

--- a/userspace/system_apps/terminal/src/commands/mod.rs
+++ b/userspace/system_apps/terminal/src/commands/mod.rs
@@ -5,6 +5,7 @@
 pub mod system;
 pub mod process;
 pub mod filesystem;
+pub mod ping;
 
 use crate::buffer::DisplayBuffer;
 use crate::ipc_client::IpcClient;
@@ -89,6 +90,9 @@ pub fn execute(cmd: &ParsedCommand<'_>, ctx: &mut CommandContext<'_>) -> Command
     }
     if cmd_eq(c, "caps") {
         return system::cmd_caps(cmd, ctx);
+    }
+    if cmd_eq(c, "ping") {
+        return ping::cmd_ping(cmd, ctx);
     }
 
     // ── Process management ──────────────────────────────────────────────────
@@ -241,4 +245,5 @@ static COMMANDS: &[(&str, &str, &str)] = &[
     ("exit",     "exit",                   "Exit the terminal"),
     ("ports",    "ports",                  "List IPC ports"),
     ("caps",     "caps",                   "List process capabilities"),
+    ("ping",     "ping <host> [options]",  "Send ICMP ECHO_REQUEST to network hosts"),
 ];

--- a/userspace/system_apps/terminal/src/commands/mod.rs
+++ b/userspace/system_apps/terminal/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod system;
 pub mod process;
 pub mod filesystem;
 pub mod ping;
+pub mod net;
 
 use crate::buffer::DisplayBuffer;
 use crate::ipc_client::IpcClient;
@@ -93,6 +94,9 @@ pub fn execute(cmd: &ParsedCommand<'_>, ctx: &mut CommandContext<'_>) -> Command
     }
     if cmd_eq(c, "ping") {
         return ping::cmd_ping(cmd, ctx);
+    }
+    if cmd_eq(c, "ifconfig") || cmd_eq(c, "netinfo") {
+        return net::cmd_ifconfig(cmd, ctx);
     }
 
     // ── Process management ──────────────────────────────────────────────────
@@ -246,4 +250,5 @@ static COMMANDS: &[(&str, &str, &str)] = &[
     ("ports",    "ports",                  "List IPC ports"),
     ("caps",     "caps",                   "List process capabilities"),
     ("ping",     "ping <host> [options]",  "Send ICMP ECHO_REQUEST to network hosts"),
+    ("ifconfig", "ifconfig",               "Display network interface configuration"),
 ];

--- a/userspace/system_apps/terminal/src/commands/net.rs
+++ b/userspace/system_apps/terminal/src/commands/net.rs
@@ -1,0 +1,33 @@
+use crate::commands::{CommandContext, CommandResult};
+use crate::parser::ParsedCommand;
+use libnet::net_get_config;
+use libipc::protocol::lookup_service;
+use alloc::format;
+
+pub fn cmd_ifconfig(_cmd: &ParsedCommand<'_>, ctx: &mut CommandContext<'_>) -> CommandResult {
+    let netd_port = match lookup_service("netd") {
+        Ok(port) => port,
+        Err(_) => {
+            ctx.error("ifconfig: network daemon (netd) not found");
+            return CommandResult::Error;
+        }
+    };
+
+    match net_get_config(netd_port) {
+        Ok(cfg) => {
+            ctx.println("");
+            ctx.println("eth0: flags=UP,BROADCAST,RUNNING");
+            ctx.println(&format!("        inet {}  netmask {}", cfg.ip, cfg.netmask));
+            ctx.println(&format!("        gateway {}", cfg.gateway));
+            ctx.println(&format!("        dns {}", cfg.dns));
+            ctx.println(&format!("        ether {:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+                cfg.mac[0], cfg.mac[1], cfg.mac[2], cfg.mac[3], cfg.mac[4], cfg.mac[5]));
+            ctx.println("");
+            CommandResult::Ok
+        }
+        Err(e) => {
+            ctx.error(&format!("ifconfig: failed to get config: {:?}", e));
+            CommandResult::Error
+        }
+    }
+}

--- a/userspace/system_apps/terminal/src/commands/ping.rs
+++ b/userspace/system_apps/terminal/src/commands/ping.rs
@@ -1,0 +1,121 @@
+use crate::commands::{CommandContext, CommandResult};
+use crate::parser::ParsedCommand;
+use libnet::{net_resolve, net_icmp_echo, IpAddr, NetError};
+use libipc::protocol::lookup_service;
+use alloc::format;
+use alloc::vec::Vec;
+
+pub fn cmd_ping(cmd: &ParsedCommand<'_>, ctx: &mut CommandContext<'_>) -> CommandResult {
+    if cmd.args.is_empty() {
+        ctx.error("Usage: ping <host> [-c count] [-i interval_ms] [-t timeout_ms]");
+        return CommandResult::Error;
+    }
+
+    let host = cmd.args[0];
+    let mut count = 4;
+    let mut interval_ms = 1000;
+    let mut timeout_ms = 1000;
+
+    // Simple arg parsing
+    let mut i = 1;
+    while i < cmd.args.len() {
+        match cmd.args[i] {
+            "-c" if i + 1 < cmd.args.len() => {
+                if let Ok(val) = cmd.args[i + 1].parse::<u32>() {
+                    count = val;
+                    i += 2;
+                } else { i += 1; }
+            }
+            "-i" if i + 1 < cmd.args.len() => {
+                if let Ok(val) = cmd.args[i + 1].parse::<u32>() {
+                    interval_ms = val;
+                    i += 2;
+                } else { i += 1; }
+            }
+            "-t" if i + 1 < cmd.args.len() => {
+                if let Ok(val) = cmd.args[i + 1].parse::<u32>() {
+                    timeout_ms = val;
+                    i += 2;
+                } else { i += 1; }
+            }
+            _ => { i += 1; }
+        }
+    }
+
+    // 1. Lookup netd
+    let netd_port = match lookup_service("netd") {
+        Ok(port) => port,
+        Err(_) => {
+            ctx.error("ping: network daemon (netd) not found");
+            return CommandResult::Error;
+        }
+    };
+
+    // 2. Resolve host
+    ctx.println(&format!("PING {}...", host));
+    let dest_ip = match net_resolve(netd_port, host) {
+        Ok(ip) => ip,
+        Err(_) => {
+            ctx.error(&format!("ping: unknown host {}", host));
+            return CommandResult::Error;
+        }
+    };
+
+    ctx.println(&format!("PING {} ({}): 56 data bytes", host, dest_ip));
+
+    let mut transmitted = 0;
+    let mut received = 0;
+    let mut rtts = Vec::new();
+
+    for seq in 1..=count {
+        transmitted += 1;
+        let payload = [0u8; 56]; // Standard ping payload size
+
+        match net_icmp_echo(netd_port, dest_ip, seq as u16, &payload, timeout_ms) {
+            Ok(reply) => {
+                received += 1;
+                rtts.push(reply.rtt_ms);
+                ctx.println(&format!(
+                    "64 bytes from {}: icmp_seq={} ttl={} time={}.0 ms",
+                    reply.src_ip, reply.sequence, reply.ttl, reply.rtt_ms
+                ));
+            }
+            Err(NetError::Timeout) => {
+                ctx.println(&format!("Request timeout for icmp_seq {}", seq));
+            }
+            Err(e) => {
+                ctx.error(&format!("ping: error {:?}", e));
+                break;
+            }
+        }
+
+        if seq < count {
+            atom_syscall::thread::sleep_ms(interval_ms as u64);
+        }
+    }
+
+    // Statistics
+    ctx.println(&format!("\n--- {} ping statistics ---", host));
+    let loss = if transmitted > 0 {
+        (transmitted - received) * 100 / transmitted
+    } else {
+        0
+    };
+    ctx.println(&format!(
+        "{} packets transmitted, {} received, {}% packet loss",
+        transmitted, received, loss
+    ));
+
+    if !rtts.is_empty() {
+        let min = rtts.iter().min().unwrap();
+        let max = rtts.iter().max().unwrap();
+        let sum: u32 = rtts.iter().sum();
+        let avg = sum / rtts.len() as u32;
+        ctx.println(&format!(
+            "rtt min/avg/max = {}.0/{}.0/{}.0 ms",
+            min, avg, max
+        ));
+    }
+
+    CommandResult::Ok
+}

--- a/userspace/system_apps/terminal/src/commands/ping.rs
+++ b/userspace/system_apps/terminal/src/commands/ping.rs
@@ -1,6 +1,6 @@
 use crate::commands::{CommandContext, CommandResult};
 use crate::parser::ParsedCommand;
-use libnet::{net_resolve, net_icmp_echo, IpAddr, NetError};
+use libnet::{net_resolve, net_icmp_echo, NetError};
 use libipc::protocol::lookup_service;
 use alloc::format;
 use alloc::vec::Vec;

--- a/userspace/system_apps/terminal/src/commands/ping.rs
+++ b/userspace/system_apps/terminal/src/commands/ping.rs
@@ -14,7 +14,7 @@ pub fn cmd_ping(cmd: &ParsedCommand<'_>, ctx: &mut CommandContext<'_>) -> Comman
     let host = cmd.args[0];
     let mut count = 4;
     let mut interval_ms = 1000;
-    let mut timeout_ms = 1000;
+    let mut timeout_ms = 2000;
 
     // Simple arg parsing
     let mut i = 1;

--- a/userspace/system_apps/terminal/src/commands/system.rs
+++ b/userspace/system_apps/terminal/src/commands/system.rs
@@ -60,6 +60,7 @@ pub fn cmd_help(cmd: &ParsedCommand<'_>, ctx: &mut CommandContext<'_>) -> Comman
         // Category headers and their members
         let categories: &[(&str, &[&str])] = &[
             ("System", &["help","version","uptime","date","sysinfo","clear","echo","log"]),
+            ("Network", &["ping", "ifconfig"]),
             ("Process", &["ps","kill","exec","mem","services"]),
             ("Navigation & Read", &["ls","cd","pwd","cat","head","tail","wc","stat","find","tree"]),
             ("Write & Manage", &["mkdir","rmdir","rm","mv","cp","touch","fsync","chmod","ln","df","du"]),
@@ -288,6 +289,20 @@ fn show_command_help(topic: &str, ctx: &mut CommandContext<'_>) {
             ctx.println("  du /home/user");
             ctx.println("  du -sh /var");
             ctx.println("  du -h /tmp");
+        }
+        "ping" => {
+            ctx.println_colored("Options:", Theme::TEXT_DIM);
+            ctx.println("  -c N   Stop after sending N ECHO_REQUEST packets");
+            ctx.println("  -i MS  Wait MS milliseconds between sending each packet");
+            ctx.println("  -t MS  Timeout in MS milliseconds for each packet");
+            ctx.println("");
+            ctx.println_colored("Examples:", Theme::PROMPT_USER);
+            ctx.println("  ping 8.8.8.8");
+            ctx.println("  ping www.google.com -c 10");
+        }
+        "ifconfig" | "netinfo" => {
+            ctx.println_colored("Examples:", Theme::PROMPT_USER);
+            ctx.println("  ifconfig");
         }
         "ps" | "procs" => {
             ctx.println_colored("Examples:", Theme::PROMPT_USER);
@@ -606,6 +621,14 @@ pub fn cmd_sysinfo(_cmd: &ParsedCommand<'_>, ctx: &mut CommandContext<'_>) -> Co
     let uptime = unsafe { core::str::from_utf8_unchecked(&uptime_buf[..len]) };
     ctx.print("Uptime:       ");
     ctx.println(uptime);
+
+    // Network
+    if let Ok(netd_port) = libipc::protocol::lookup_service("netd") {
+        if let Ok(config) = libnet::net_get_config(netd_port) {
+            ctx.print("Network:      ");
+            ctx.println(&alloc::format!("{}", config.ip));
+        }
+    }
 
     ctx.println("");
 


### PR DESCRIPTION
I have implemented a complete, production-ready `ping` utility for the Atom OS. This task involved evolving several layers of the system's network stack:

1.  **IPC Protocol (`libipc`)**: Defined new message types and structures for ICMP Echo Request/Reply. Crucially, I introduced `NetIpAddr`, a structure designed to handle both IPv4 and IPv6 addresses from the start.
2.  **Network Client Library (`libnet`)**: Implemented a high-level `IpAddr` enum and the `net_icmp_echo` function. Following your requirements, I replaced the legacy `yield`-based polling with a real blocking mechanism using the `SYS_IPC_WAIT_ANY` syscall with a timeout.
3.  **Network Daemon (`netd`)**: 
    - Implemented a `PendingIcmp` registry to track outgoing requests.
    - `netd` now acts as the central authority for ICMP identifiers, preventing collisions between concurrent `ping` instances.
    - Enhanced ICMP parsing with mandatory checksum validation.
    - Refactored the ICMP module into `v4` and `v6` submodules to facilitate future expansion.
    - Added a lifecycle manager to the main loop to clean up timed-out requests.
4.  **Terminal App**: Created a new `ping` command module that handles CLI arguments (`-c`, `-i`, `-t`), performs host resolution, and displays real-time RTT statistics and a final summary.

This implementation provides a solid foundation for further network diagnostics tools and ensures the Atom OS network stack is evolved without technical debt.

---
*PR created automatically by Jules for task [1260887574647076993](https://jules.google.com/task/1260887574647076993) started by @fpedrolucas95*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fpedrolucas95/atom/pull/112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

Adicionar uma funcionalidade de eco ICMP (ping) bloqueante em toda a pilha de rede e expô-la por meio de um novo comando de ping no terminal.

Novos recursos:
- Introduzir `NetIpAddr` unificado e mensagens IPC para requisição/resposta de eco ICMP entre apps e `netd`.
- Adicionar uma abstração de alto nível `IpAddr` e o helper `net_icmp_echo` em `libnet` para operações síncronas de eco ICMP.
- Implementar um comando de ping no terminal com suporte a opções básicas, resolução de host e saída de estatísticas de RTT.

Melhorias:
- Estender o `netd` com rastreamento centralizado de eco ICMP, tratamento de timeout e parsing de ICMPv4 com validação de checksum, preparando o módulo ICMP para suporte futuro a IPv6.
- Atualizar as APIs de resolução DNS e conexão TCP em `libnet` para usar o novo tipo `IpAddr` em vez de inteiros IPv4 brutos.

Testes:
- Ampliar os testes de unidade de ICMP em `netd` para cobrir tratamento de payload e erros de validação de checksum.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a blocking ICMP echo (ping) capability across the networking stack and expose it via a new terminal ping command.

New Features:
- Introduce unified NetIpAddr and IPC messages for ICMP echo request/reply between apps and netd.
- Add a high-level IpAddr abstraction and net_icmp_echo helper in libnet for synchronous ICMP echo operations.
- Implement a terminal ping command supporting basic options, host resolution, and RTT statistics output.

Enhancements:
- Extend netd with centralized ICMP echo tracking, timeout handling, and checksum-validated ICMPv4 parsing, preparing the ICMP module for future IPv6 support.
- Update DNS resolution and TCP connect APIs in libnet to use the new IpAddr type instead of raw IPv4 integers.

Tests:
- Expand ICMP unit tests in netd to cover payload handling and checksum validation errors.

</details>