### PR TITLE
Fix AP trampoline executable mapping and scheduler invariant check

### DIFF
--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -371,12 +371,12 @@ impl Scheduler {
                 thread::set_thread_state(prev, ThreadState::Ready);
                 self.ownership.lock().insert(prev, NO_CPU_OWNER);
             }
-        }
 
-        // INVARIANT: A thread transitioning to Running must not be in any run queue.
-        #[cfg(debug_assertions)]
-        if self.is_in_any_ready_queue(prev) {
-            panic!("SMP INVARIANT VIOLATION: thread {:?} Running but still in ready queue", prev);
+            // INVARIANT: A thread transitioning to Running must not be in any run queue.
+            #[cfg(debug_assertions)]
+            if self.is_in_any_ready_queue(prev) {
+                panic!("SMP INVARIANT VIOLATION: thread {:?} Running but still in ready queue", prev);
+            }
         }
 
         if let Some(next) = chosen {

--- a/kernel/src/smp.rs
+++ b/kernel/src/smp.rs
@@ -431,7 +431,8 @@ fn prepare_trampoline(stack_top: u64, entry: u64) {
     page[..AP_TRAMPOLINE.len()].copy_from_slice(AP_TRAMPOLINE);
 
     let cr3 = crate::arch::read_cr3();
-    let pml4_phys = (cr3 & crate::arch::CR3_PML4_ADDR_MASK) as u32;
+    let pml4_phys_full = (cr3 & crate::arch::CR3_PML4_ADDR_MASK) as usize;
+    let pml4_phys = pml4_phys_full as u32;
 
     patch_u32(&mut page, TRAMPOLINE_PML4_MAGIC, pml4_phys);
     patch_u64(&mut page, TRAMPOLINE_STACK_MAGIC, stack_top);
@@ -441,6 +442,18 @@ fn prepare_trampoline(stack_top: u64, entry: u64) {
     unsafe {
         core::ptr::copy_nonoverlapping(page.as_ptr(), dst, page.len());
     }
+
+    // Conventional-memory identity mappings carry the NX bit. The AP executes
+    // this page after enabling paging, so the identity mapping must be
+    // executable. remap_page_in_pml4 creates the entry if absent (e.g. when
+    // the firmware did not report 0x8000 as a usable RAM region).
+    crate::mm::vm::remap_page_in_pml4(
+        pml4_phys_full,
+        TRAMPOLINE_PHYS,
+        TRAMPOLINE_PHYS,
+        crate::mm::vm::PageFlags::kernel_rw(),
+    )
+    .expect("failed to make AP trampoline page executable");
 }
 
 fn alloc_stack_top(pages: usize) -> Option<u64> {


### PR DESCRIPTION
## Summary
This PR fixes two issues: ensuring the AP (Application Processor) trampoline page is executable after paging is enabled, and correcting the scope of a scheduler invariant check.

## Key Changes

- **AP Trampoline Executable Mapping**: Added a call to `remap_page_in_pml4` in `prepare_trampoline` to ensure the trampoline page is executable. This is necessary because conventional-memory identity mappings may carry the NX (No-Execute) bit, which would prevent the AP from executing the trampoline code after paging is enabled. The remapping creates the PML4 entry if absent (e.g., when firmware doesn't report 0x8000 as usable RAM).

- **Type Correction**: Changed the intermediate `cr3` mask result from `u32` to `usize` (`pml4_phys_full`) before casting to `u32`, improving type safety and clarity.

- **Scheduler Invariant Check Fix**: Moved the debug-only invariant check for threads in ready queues inside the conditional block where it's relevant. The check now only executes when a thread is actually transitioning to the Running state, fixing the scope and ensuring the invariant is checked in the correct context.

## Implementation Details

The trampoline remapping uses `PageFlags::kernel_rw()` to create a readable and writable mapping that is also executable (as kernel code pages should be). The operation is expected to succeed, with a panic if it fails.

https://claude.ai/code/session_01VHMoMx6hsdF3nWgGArFrpA

## Summary by Sourcery

Garantir que a página de trampolim do AP seja executável após a paginação e apertar uma invariante de depuração do escalonador em torno de transições de estado de thread.

Correções de bugs:
- Garantir que a página de identidade mapeada do trampolim do AP seja executável após a paginação, remapeando-a explicitamente no PML4.
- Restringir a verificação da invariante de depuração do escalonador para rodar apenas quando uma thread realmente faz a transição para o estado Running, evitando condições incorretas de pânico.

Melhorias:
- Melhorar a segurança de tipos e a clareza ao extrair o endereço físico do PML4 a partir do CR3, usando um `usize` intermediário antes de converter para `u32`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the AP trampoline page is executable after paging and tighten a scheduler debug invariant around thread state transitions.

Bug Fixes:
- Ensure the AP trampoline identity-mapped page is executable after paging by explicitly remapping it in the PML4.
- Restrict the scheduler debug invariant check to only run when a thread actually transitions to the Running state, avoiding incorrect panic conditions.

Enhancements:
- Improve type safety and clarity when extracting the PML4 physical address from CR3 by using an intermediate usize before casting to u32.

</details>