### PR TITLE
Refactor sys_ipc_wait_any to use scheduler sleep queue

### DIFF
--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -543,6 +543,7 @@ pub fn drive_cooperative_tick() {
 pub fn mark_thread_ready(id: ThreadId) { if let Some(s) = scheduler_opt() { s.mark_ready(id); } }
 pub fn deschedule_thread(id: ThreadId) { if let Some(s) = scheduler_opt() { s.deschedule_thread(id); } }
 pub fn sleep_thread(id: ThreadId, wake_tick: u64) { if let Some(s) = scheduler_opt() { s.sleep_thread(id, wake_tick); } }
+pub fn cancel_sleep(id: ThreadId) { if let Some(s) = scheduler_opt() { s.sleep_queue.lock().retain(|(tid, _)| *tid != id); } }
 pub fn wake_sleeping_threads() { if let Some(s) = scheduler_opt() { s.wake_sleeping_threads(); } }
 pub fn current_thread() -> Option<ThreadId> { scheduler_opt().and_then(|s| s.current_thread()) }
 

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -4019,8 +4019,6 @@ fn sys_get_irq_count(irq: u8) -> u64 {
 /// Returns:
 ///   Index of the port with data (0-based), or error code
 fn sys_ipc_wait_any(ports_ptr: u64, count: u64, timeout_ms: u64) -> u64 {
-    const LOG_ORIGIN: &str = "syscall";
-
     if count == 0 || count > 64 {
         return EINVAL;
     }
@@ -4053,92 +4051,58 @@ fn sys_ipc_wait_any(ports_ptr: u64, count: u64, timeout_ms: u64) -> u64 {
         }
     }
 
-    // Calculate deadline
-    let deadline = if timeout_ms == u64::MAX {
+    // Fast path: check all ports for an immediately available message
+    for (idx, port_id) in ports.iter().enumerate() {
+        if let Ok(true) = crate::ipc::has_message(*port_id) {
+            return idx as u64;
+        }
+    }
+
+    // Non-blocking call with no message available
+    if timeout_ms == 0 {
+        return EWOULDBLOCK;
+    }
+
+    // Calculate deadline tick for finite timeouts
+    let deadline_tick = if timeout_ms == u64::MAX {
         None
-    } else if timeout_ms == 0 {
-        Some(crate::interrupts::get_ticks()) // Immediate check only
     } else {
         let ticks = timeout_ms.div_ceil(10);
         Some(crate::interrupts::get_ticks() + ticks)
     };
 
-    // Polling loop - check each port for messages (peek without consuming)
-    loop {
-        for (idx, port_id) in ports.iter().enumerate() {
-            // Use has_message to check without consuming the message
-            // This allows userspace to receive the message via try_recv after wait_any returns
-            match crate::ipc::has_message(*port_id) {
-                Ok(true) => {
-                    // Found a message! Unregister and return the port index
-                    crate::ipc::unregister_wait_any(caller, &ports);
-                    log_debug!(
-                        LOG_ORIGIN,
-                        "ipc_wait_any: port {} (index {}) has message",
-                        port_id,
-                        idx
-                    );
-                    return idx as u64;
-                }
-                Ok(false) => continue,
-                Err(_) => continue, // Skip invalid ports
-            }
-        }
+    // Register as waiter on all ports before blocking so senders can wake us
+    crate::ipc::register_wait_any(caller, &ports);
 
-        // Check timeout
-        if let Some(deadline_tick) = deadline {
-            if crate::interrupts::get_ticks() >= deadline_tick {
-                crate::ipc::unregister_wait_any(caller, &ports);
-                if timeout_ms == 0 {
-                    return EWOULDBLOCK;
-                } else {
-                    return ETIMEDOUT;
-                }
-            }
-        }
-
-        // Register as waiting on all ports BEFORE blocking
-        // This allows senders to wake us up
-        crate::ipc::register_wait_any(caller, &ports);
-
-        // Block this thread and yield to scheduler
-        // Mark as blocked so scheduler won't immediately pick us
+    // Block: use the scheduler sleep queue for finite timeouts so the timer
+    // interrupt can expire us via wake_sleeping_threads(); for infinite waits
+    // simply mark Blocked and wait for a sender to call mark_thread_ready.
+    if let Some(deadline) = deadline_tick {
+        crate::sched::sleep_thread(caller, deadline);
+    } else {
         crate::thread::set_thread_state(caller, crate::thread::ThreadState::Blocked);
-
-        // Try to switch to another thread
-        let (prev, next) = crate::sched::on_timer_tick();
-        if let (Some(prev_id), Some(next_id)) = (prev, next) {
-            if prev_id != next_id {
-                // Switch to different thread
-                crate::sched::perform_context_switch(prev_id, next_id);
-            } else {
-                // No other thread to run - wait for interrupt (avoid busy-loop)
-                // Enable interrupts and halt until next interrupt
-                unsafe {
-                    core::arch::asm!(
-                        "sti",      // Enable interrupts
-                        "hlt",      // Halt until interrupt
-                        "cli",      // Disable interrupts again
-                        options(nomem, nostack)
-                    );
-                }
-            }
-        } else {
-            // No threads available - halt and wait
-            unsafe {
-                core::arch::asm!(
-                    "sti",
-                    "hlt",
-                    "cli",
-                    options(nomem, nostack)
-                );
-            }
-        }
-
-        // Back from blocking - mark as ready and unregister
-        crate::thread::set_thread_state(caller, crate::thread::ThreadState::Ready);
-        // Note: We'll re-register on the next iteration if we loop again
     }
+
+    // Single context switch — returns when the scheduler picks us again
+    crate::sched::drive_cooperative_tick();
+
+    // Remove any pending sleep-queue entry to prevent a spurious second wakeup
+    // if a message arrived before the deadline expired.
+    if deadline_tick.is_some() {
+        crate::sched::cancel_sleep(caller);
+    }
+
+    // Clean up port wait registrations
+    crate::ipc::unregister_wait_any(caller, &ports);
+
+    // Check which port has a message (message wakeup) or return timeout
+    for (idx, port_id) in ports.iter().enumerate() {
+        if let Ok(true) = crate::ipc::has_message(*port_id) {
+            return idx as u64;
+        }
+    }
+
+    ETIMEDOUT
 }
 
 /// Spawn a new process from a registered driver


### PR DESCRIPTION
## Summary
Refactored the `sys_ipc_wait_any` syscall to use the scheduler's sleep queue mechanism instead of manual polling and context switching. This simplifies the implementation and improves efficiency by leveraging existing scheduler infrastructure for timeout handling.

## Key Changes
- **Removed manual polling loop**: Eliminated the busy-wait loop that repeatedly checked all ports for messages
- **Added fast path**: Check all ports immediately for available messages before blocking
- **Integrated scheduler sleep queue**: Use `crate::sched::sleep_thread()` for finite timeouts instead of manual deadline checking and context switching
- **Simplified blocking logic**: 
  - For finite timeouts: register as waiter, call `sleep_thread()`, then let the scheduler handle wakeup via timer interrupt
  - For infinite timeouts: simply mark thread as Blocked and wait for a sender to call `mark_thread_ready()`
- **Single context switch**: Replaced manual `on_timer_tick()` and `perform_context_switch()` calls with a single `drive_cooperative_tick()` call
- **Cleanup on return**: Added `cancel_sleep()` call to prevent spurious wakeups if a message arrives before the deadline expires
- **Removed debug logging**: Cleaned up the `LOG_ORIGIN` constant and associated debug log statement

## Implementation Details
The refactored flow is now:
1. Validate port count and copy port IDs from userspace
2. Fast path: check all ports for immediately available messages
3. Return `EWOULDBLOCK` if timeout is 0 and no messages available
4. Register as waiter on all ports
5. Block via scheduler (sleep queue for finite timeout, or simple Blocked state for infinite)
6. Single cooperative tick to yield control
7. Cancel any pending sleep entry
8. Unregister from ports
9. Check ports again and return appropriate result (port index or `ETIMEDOUT`)

This approach is cleaner and more maintainable while properly integrating with the kernel's scheduler infrastructure.

https://claude.ai/code/session_01LoXg3YARoAfEiQtrbFUJ5n

## Summary by Sourcery

Refatorar `sys_ipc_wait_any` para integrá-lo à fila de sleep do escalonador para bloqueios e timeouts, em vez de usar polling manual e troca de contexto ad hoc.

Correções de bugs:
- Evitar potenciais *spurious wakeups* e timeouts duplos cancelando qualquer sleep pendente após a thread ser retomada.

Melhorias:
- Adicionar um caminho rápido (*fast path*) que retorna imediatamente se qualquer porta de destino já tiver uma mensagem antes do bloqueio.
- Usar o tick cooperativo do escalonador e as APIs de fila de sleep para lidar com esperas de IPC finitas e infinitas com uma única troca de contexto e semântica de bloqueio mais limpa.
- Simplificar a lógica de registro e limpeza de espera de IPC centralizando o registro/cancelamento de *waiters* em torno de um único ponto de bloqueio.
- Remover logs de depuração desnecessários relacionados a `sys_ipc_wait_any`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor sys_ipc_wait_any to integrate with the scheduler’s sleep queue for blocking and timeouts instead of manual polling and ad‑hoc context switching.

Bug Fixes:
- Prevent potential spurious wakeups and double timeouts by canceling any pending sleep after the thread is resumed.

Enhancements:
- Add a fast path that returns immediately if any target port already has a message before blocking.
- Use the scheduler’s cooperative tick and sleep queue APIs to handle finite and infinite IPC waits with a single context switch and cleaner blocking semantics.
- Simplify IPC wait registration and cleanup logic by centralizing waiter registration/unregistration around a single blocking point.
- Remove unnecessary debug logging related to sys_ipc_wait_any.

</details>