### PR TITLE
Clarify capability-based access control for input, display, and spawn

### DIFF
--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -4987,11 +4987,13 @@ fn apply_spawn_grants(
 //   binary that is present on the filesystem at runtime.
 //
 // Security model:
-//   This syscall does NOT perform caller-identity checks itself.  Privilege
-//   restriction is enforced at the IPC layer: only app_launcher (a trusted
-//   system service) is expected to call this syscall.  In a future hardening
-//   pass a capability check (ResourceType::Spawn or similar) can be added
-//   here to prevent rogue processes from abusing it.
+//   Gated by the SpawnFromPath capability in the syscall policy table
+//   (syscall_policy -> Requires(SpawnFromPath)). That capability is granted only
+//   to app_launcher via the SystemServiceManifest, so any other caller is
+//   denied EPERM before this handler runs. The handler additionally rejects
+//   path traversal and system-service image paths (is_system_service_path), so
+//   SpawnFromPath can never be used as a back door to start a privileged
+//   service image.
 //
 // Error returns:
 //   EINVAL   — path is NULL, empty, too long, or not valid UTF-8

--- a/kernel/src/syscall/policy.rs
+++ b/kernel/src/syscall/policy.rs
@@ -185,16 +185,15 @@ pub(super) fn syscall_policy(num: u64) -> SysPolicy {
             => ExplicitlyUnrestricted,
 
         // ── Input devices ─────────────────────────────────────────────────
-        // Gated by InputDevice capability type.
-        // Note: all processes currently receive these caps at spawn time
-        // (over-provisioning — see P1-A TODO in spawn_process_internal).
-        // Fixing over-provisioning will automatically tighten access here
-        // without further changes to this table.
+        // Gated by InputDevice capability type. These caps are granted only to
+        // the compositor (ui_shell) through the SystemServiceManifest; ordinary
+        // apps hold none and are denied EPERM here. There are no ambient grants.
         SYS_MOUSE_POLL | SYS_MOUSE_GET_ID   => Requires(InputMouse),
         SYS_KEYBOARD_POLL                    => Requires(InputKeyboard),
 
         // ── Framebuffer / display ──────────────────────────────────────────
-        // Gated by Framebuffer cap.  Same over-provisioning caveat applies.
+        // Gated by Framebuffer cap, granted only to the compositor (ui_shell)
+        // via the manifest's FramebufferMap environment grant.
         SYS_GET_FRAMEBUFFER | SYS_MAP_FRAMEBUFFER
             => Requires(FramebufferMap),
         SYS_SET_VIDEO_MODE
@@ -417,27 +416,34 @@ pub(super) fn validate_ipc_send_with_cap_permissions(
         return Err(EPERM);
     }
 
-    if !crate::thread::thread_has_capability(sender, cap_handle) {
-        log_warn!(
-            "syscall",
-            "ipc_send_with_cap: denied (sender does not own capability cap={:#x})",
-            cap_handle_raw
-        );
-        return Err(EPERM);
-    }
-
-    let has_grant_permission = crate::thread::validate_thread_capability_by_type(
+    // The capability being delegated must itself be owned by the sender AND
+    // carry GRANT. Holding GRANT on some *other* capability must never authorise
+    // delegating this one — that would defeat per-capability least privilege and
+    // let a sender escalate a non-delegable handle. `validate_thread_capability`
+    // checks both ownership (handle present in the caller's table) and the
+    // GRANT permission on that exact handle in one step.
+    match crate::thread::validate_thread_capability(
         sender,
+        cap_handle,
         crate::cap::CapPermissions::GRANT,
-        |_resource| true,
-    );
-
-    if !has_grant_permission {
-        log_warn!(
-            "syscall",
-            "ipc_send_with_cap: denied (missing GRANT permission)"
-        );
-        return Err(EPERM);
+    ) {
+        Ok(()) => {}
+        Err(crate::cap::CapError::PermissionDenied) => {
+            log_warn!(
+                "syscall",
+                "ipc_send_with_cap: denied (capability cap={:#x} lacks GRANT permission)",
+                cap_handle_raw
+            );
+            return Err(EPERM);
+        }
+        Err(_) => {
+            log_warn!(
+                "syscall",
+                "ipc_send_with_cap: denied (sender does not own capability cap={:#x})",
+                cap_handle_raw
+            );
+            return Err(EPERM);
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
This PR updates documentation and implementation details for capability-based access control in the kernel's syscall policy layer. The changes clarify how input devices, framebuffer access, and process spawning are gated by specific capabilities granted only to trusted system services, removing outdated references to over-provisioning.

## Key Changes

- **Input device and framebuffer access**: Updated comments to clarify that `InputMouse`, `InputKeyboard`, and `FramebufferMap` capabilities are granted exclusively to the compositor (ui_shell) via the SystemServiceManifest, with no ambient grants to ordinary applications.

- **IPC capability delegation**: Refactored `validate_ipc_send_with_cap_permissions()` to use a single `validate_thread_capability()` call that atomically checks both ownership and GRANT permission on the specific capability being delegated. This prevents privilege escalation where holding GRANT on one capability could be misused to delegate an unrelated capability.

- **Process spawning**: Updated security model documentation for `spawn_from_path` to clarify that it is gated by the `SpawnFromPath` capability (granted only to app_launcher), with additional path traversal and system-service image validation in the handler itself.

## Implementation Details

The refactored capability validation now uses a match statement on `validate_thread_capability()` to distinguish between permission denial (capability exists but lacks GRANT) and ownership failure (capability not in sender's table), providing more precise error logging while maintaining the same security guarantees.

https://claude.ai/code/session_014n6FLdxgT9YFXREv2c9htE

## Summary by Sourcery

Esclarecer o controle de acesso baseado em capacidades para entrada, exibição e criação de processos, e tornar mais rigorosos a delegação de capacidades de IPC e o registro em log.

Melhorias:
- Refinar a delegação de capacidades de IPC para exigir propriedade e GRANT exatamente no identificador de capacidade que está sendo enviado, com relatórios de erro mais precisos.
- Esclarecer os comentários da política de syscalls para entrada, framebuffer e `spawn-from-path`, descrevendo seu controle por capacidades e as restrições de serviços de sistema confiáveis.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify capability-based access control for input, display, and process spawning, and tighten IPC capability delegation semantics and logging.

Enhancements:
- Refine IPC capability delegation to require ownership and GRANT on the exact capability handle being sent, with more precise error reporting.
- Clarify syscall policy comments for input, framebuffer, and spawn-from-path to describe their capability gating and trusted system service restrictions.

</details>