### PR TITLE
Implement double-buffering for tear-free animation

### DIFF
--- a/userspace/apps/fileman/src/main.rs
+++ b/userspace/apps/fileman/src/main.rs
@@ -23,7 +23,7 @@ mod fs;
 use fs::{Dir, DirEntry};
 
 use atom_syscall::graphics::{Color, SharedSurface};
-use atom_syscall::ipc::{create_port, try_recv, send, PortId};
+use atom_syscall::ipc::{create_port, try_recv, send, wait_any, PortId};
 use atom_syscall::thread::{exit, yield_now, get_ticks};
 use atom_syscall::debug::log;
 
@@ -824,6 +824,12 @@ fn main() -> ! {
                 }
             }
         }
-        yield_now();
+        // Block until input arrives (or a short timeout) instead of busy-spinning
+        // with yield_now(). A pure yield loop keeps this thread perpetually
+        // runnable, burning a full scheduler quantum every pass and starving the
+        // compositor — which is what drags the cursor down to ~10 fps once the
+        // file manager is open. wait_any() parks the thread so an idle window
+        // costs no CPU; the 16 ms ceiling keeps input feeling responsive.
+        let _ = wait_any(&[local_port], 16);
     }
 }

--- a/userspace/libs/libgui/src/surface.rs
+++ b/userspace/libs/libgui/src/surface.rs
@@ -18,7 +18,13 @@ use libipc::protocol::send_message_async;
 /// Internal state for a drawing surface
 pub(crate) struct SurfaceInner {
     pub window_id: WindowId,
+    /// Private back buffer that all drawing operations target. Decoupling the
+    /// draw target from the compositor's region is what makes animation tear
+    /// free: the compositor only ever sees a finished frame (see `present`).
     pub shared: SharedSurface,
+    /// The compositor-owned region the window is actually displayed from. A
+    /// completed frame is copied here in one shot on `present`.
+    pub front: SharedSurface,
     pub wm_port: PortId,
     pub dirty: bool,
     pub scale_factor: u32,
@@ -36,12 +42,19 @@ impl Surface {
         resp: WmCreateWindowResponse,
         wm_port: PortId,
     ) -> Result<Self, atom_syscall::SyscallError> {
-        let shared = SharedSurface::from_region(resp.region_id, resp.width, resp.height)?;
+        let front = SharedSurface::from_region(resp.region_id, resp.width, resp.height)?;
+        // Private, app-owned back buffer with the same geometry. Apps draw here
+        // across many (potentially slow) operations; only `present` publishes a
+        // finished frame to `front`, so the compositor can never snapshot a
+        // half-drawn surface (which is what makes direct-to-surface animations
+        // flicker).
+        let shared = SharedSurface::create(resp.width, resp.height)?;
 
         Ok(Self {
             inner: Rc::new(RefCell::new(SurfaceInner {
                 window_id: resp.window_id,
                 shared,
+                front,
                 wm_port,
                 dirty: false,
                 scale_factor: 1000, // 1.0 default
@@ -385,10 +398,30 @@ impl Surface {
         inner.dirty = true;
     }
 
-    /// Present the surface (signal compositor to display)
+    /// Present the surface (signal compositor to display).
+    ///
+    /// Publishes the finished frame by copying the private back buffer into the
+    /// compositor's region in a single pass, then signals the commit. Because
+    /// the copy is the only time `front` is written — and it happens while the
+    /// app is between draws — the compositor never reads a partially drawn
+    /// frame, eliminating the flicker seen when animating directly on the
+    /// shared surface.
     pub fn present(&mut self) {
         let mut inner = self.inner.borrow_mut();
         if inner.dirty {
+            // Back and front are created with identical geometry (stride ==
+            // width, 4 bytes/pixel), so the pixel data is contiguous and can be
+            // published with one copy.
+            if let (Some(src), Some(dst)) = (inner.shared.address(), inner.front.address()) {
+                let count = (inner.shared.stride() * inner.shared.height()) as usize;
+                unsafe {
+                    core::ptr::copy_nonoverlapping(
+                        src as usize as *const u32,
+                        dst as usize as *mut u32,
+                        count,
+                    );
+                }
+            }
             let msg = WmCommitFrameMsg {
                 window_id: inner.window_id,
             };


### PR DESCRIPTION
## Summary
This PR implements double-buffering in the GUI surface rendering system to eliminate animation flicker and tearing. The compositor now reads from a stable front buffer while the application draws to a private back buffer, with frame publication happening atomically via a single memory copy.

## Key Changes

**libgui surface rendering:**
- Added a private back buffer (`shared`) that all drawing operations target, decoupled from the compositor's display region
- Added a compositor-owned front buffer (`front`) that represents the currently displayed frame
- Modified surface initialization to create both buffers with identical geometry
- Implemented atomic frame publication in `present()` by copying the completed back buffer to the front buffer in a single pass before signaling the compositor

**fileman application:**
- Replaced busy-spinning `yield_now()` loop with `wait_any()` blocking call to reduce CPU consumption
- Added a 16ms timeout to maintain input responsiveness while allowing the compositor to run
- This prevents the file manager from starving the compositor and causing cursor lag (~10 fps)

## Implementation Details

The double-buffering approach ensures the compositor never observes a partially-drawn frame:
- All drawing operations target the private back buffer, which the compositor never reads
- Only during `present()` is the front buffer written to, via a single contiguous memory copy
- The compositor reads exclusively from the front buffer between `present()` calls
- This eliminates the flicker that occurred when animating directly on the shared surface

The file manager change improves system responsiveness by allowing the compositor thread to run when the UI is idle, rather than being starved by a perpetually-runnable input loop.

https://claude.ai/code/session_01M4N6ojuxx7YT4jqX21nfeS

## Summary by Sourcery

Introduz renderização de superfícies de GUI com dupla memória buffer e melhora o agendamento do loop de eventos do gerenciador de arquivos para eliminar rasgos visuais e reduzir a falta de tempo de CPU para o compositor.

Novos recursos:
- Adiciona um buffer frontal dedicado para o compositor e um buffer traseiro privado para as superfícies de GUI, a fim de oferecer suporte à renderização com dupla memória buffer sem rasgos.

Correções de bugs:
- Evita cintilação e rasgos na animação das superfícies garantindo que o compositor exiba apenas frames totalmente renderizados.

Melhorias:
- Otimiza a apresentação das superfícies publicando frames concluídos por meio de uma única cópia de memória contígua entre os buffers traseiro e frontal.
- Reduz o uso de CPU e a contenção do escalonador no gerenciador de arquivos substituindo um loop de espera com busy-spin por uma espera bloqueante em eventos de entrada com um pequeno tempo limite.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce double-buffered GUI surface rendering and improve file manager event loop scheduling to eliminate visual tearing and reduce compositor starvation.

New Features:
- Add a dedicated compositor front buffer and private back buffer for GUI surfaces to support tear-free double-buffered rendering.

Bug Fixes:
- Prevent surface animation flicker and tearing by ensuring the compositor only displays fully rendered frames.

Enhancements:
- Optimize surface presentation by publishing completed frames via a single contiguous memory copy between back and front buffers.
- Reduce CPU usage and scheduler contention in the file manager by replacing a busy-spin yield loop with a blocking wait on input events with a short timeout.

</details>