### PR TITLE
Replace display_settings with unified System Settings panel

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -102,7 +102,7 @@ SYSTEM_APPS=(
     "keyboard"
     "mouse"
     "display"
-    "display_settings"
+    "system_settings"
     "terminal"
     "ui_shell"
     "demo_rects"

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -300,19 +300,33 @@ pub extern "C" fn idle_thread_entry() -> ! {
 }
 
 extern "C" fn smp_smoke_thread_entry() -> ! {
+    // Heartbeat period in timer ticks (~1s at the 100Hz scheduler tick). The
+    // thread exists only to prove the scheduler keeps each CPU live under SMP,
+    // so it must sleep between beats: a yield-only loop never blocks, leaving
+    // the thread permanently Ready, which pins its core at 100% and starves
+    // real work — the opposite of what a health check should demonstrate.
+    const HEARTBEAT_TICKS: u64 = 100;
     let mut iter: u64 = 0;
     loop {
-        if (iter & 0x3FF) == 0 {
-            log_info!(
-                LOG_SMP,
-                "smoke thread tid={:?} running on cpu={} iter={}",
-                sched::current_thread(),
-                smp::current_cpu_id(),
-                iter
-            );
-        }
+        log_info!(
+            LOG_SMP,
+            "smoke thread tid={:?} running on cpu={} iter={}",
+            sched::current_thread(),
+            smp::current_cpu_id(),
+            iter
+        );
         iter = iter.wrapping_add(1);
-        sched::yield_current();
+
+        // Park on the sleep queue until the next beat. The timer interrupt
+        // expires us via wake_sleeping_threads(), so the CPU is free to run
+        // other threads (or halt) in the meantime.
+        if let Some(tid) = sched::current_thread() {
+            let wake_tick = interrupts::get_ticks() + HEARTBEAT_TICKS;
+            sched::sleep_thread(tid, wake_tick);
+            sched::drive_cooperative_tick();
+        } else {
+            sched::yield_current();
+        }
     }
 }
 

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -6692,6 +6692,8 @@ const FS_MSG_RENAME: u32 = 1120;
 const FS_MSG_READDIR: u32 = 1122;
 const FS_MSG_TRUNCATE: u32 = 1124;
 const FS_MSG_FSYNC: u32 = 1126;
+const FS_MSG_STATVFS: u32 = 1142;
+const FS_STATVFS_WIRE_SIZE: usize = 72;
 
 static FS_WIRE_SEQUENCE: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(1);
 
@@ -6815,6 +6817,17 @@ fn fsd_parse_reply_stat(reply: &[u8]) -> Result<&[u8], u64> {
         return Err(error);
     }
     Ok(&reply[8..8 + FS_STAT_WIRE_SIZE])
+}
+
+fn fsd_parse_reply_statvfs(reply: &[u8]) -> Result<&[u8], u64> {
+    if reply.len() < 8 + FS_STATVFS_WIRE_SIZE {
+        return Err(EIO);
+    }
+    let error = u64::from_le_bytes(reply[0..8].try_into().unwrap());
+    if error != ESUCCESS {
+        return Err(error);
+    }
+    Ok(&reply[8..8 + FS_STATVFS_WIRE_SIZE])
 }
 
 fn fsd_sys_fs_open(path_ptr: u64, path_len: usize, flags: u32, mode: u32) -> u64 {
@@ -8416,9 +8429,40 @@ fn sys_fs_utimes(_path_ptr: u64, _path_len: usize, _atime: i64, _mtime: i64) -> 
     ENOTSUP
 }
 
-/// Get filesystem statistics
-fn sys_fs_statvfs(_path_ptr: u64, _path_len: usize, _buf_ptr: u64) -> u64 {
-    ENOTSUP
+/// Get filesystem statistics — forwarded to FSD via IPC.
+fn sys_fs_statvfs(path_ptr: u64, path_len: usize, buf_ptr: u64) -> u64 {
+    let buf_ptr = match validate_user_ptr::<u8>(buf_ptr) {
+        Ok(ptr) => ptr,
+        Err(_) => return EINVAL,
+    };
+    let buf_range = match validate_user_byte_range(buf_ptr, FS_STATVFS_WIRE_SIZE) {
+        Ok(range) => range,
+        Err(_) => return EINVAL,
+    };
+    let path_range = match validate_user_path_range(path_ptr, path_len) {
+        Ok(range) => range,
+        Err(e) => return e,
+    };
+    let (path_buf, path_blen) = match copy_path_from_user(path_range) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let path = path_buf_as_str(&path_buf, path_blen);
+    let mut req = Vec::with_capacity(4 + path.len());
+    req.extend_from_slice(&(path.len() as u32).to_le_bytes());
+    req.extend_from_slice(path.as_bytes());
+    let reply = match fsd_rpc(FS_MSG_STATVFS, &req) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let svfs = match fsd_parse_reply_statvfs(&reply) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    if let Err(e) = write_buffer_to_user(buf_range, svfs) {
+        return e;
+    }
+    ESUCCESS
 }
 // ============================================================================
 // Video Mode Management Syscall Handlers

--- a/kernel/src/system_manifest.rs
+++ b/kernel/src/system_manifest.rs
@@ -367,14 +367,14 @@ pub struct TrustedAppProfile {
     pub environment_grants: &'static [EnvGrant],
 }
 
-// display_settings legitimately changes resolution → DisplayModeSet only.
+// system_settings legitimately changes resolution → DisplayModeSet only.
 // Video-mode queries are public, so it needs no further capability. It gets no
 // framebuffer map and no input.
-const DISPLAY_SETTINGS_CAPS: &[InitialCapability] = &[MODESET];
+const SYSTEM_SETTINGS_CAPS: &[InitialCapability] = &[MODESET];
 
 pub static TRUSTED_APPS: &[TrustedAppProfile] = &[TrustedAppProfile {
-    canonical_path: "/apps/system/display_settings.atxf",
-    capabilities: DISPLAY_SETTINGS_CAPS,
+    canonical_path: "/apps/system/system_settings.atxf",
+    capabilities: SYSTEM_SETTINGS_CAPS,
     environment_grants: NO_ENV,
 }];
 
@@ -578,7 +578,7 @@ mod tests {
 
     #[test]
     fn trusted_apps_are_exact_path_and_minimal() {
-        let p = lookup_trusted_app("/apps/system/display_settings.atxf").unwrap();
+        let p = lookup_trusted_app("/apps/system/system_settings.atxf").unwrap();
         assert!(p
             .capabilities
             .iter()

--- a/userspace/apps/fileman/src/main.rs
+++ b/userspace/apps/fileman/src/main.rs
@@ -23,7 +23,7 @@ mod fs;
 use fs::{Dir, DirEntry};
 
 use atom_syscall::graphics::{Color, SharedSurface};
-use atom_syscall::ipc::{create_port, try_recv, send, PortId};
+use atom_syscall::ipc::{create_port, try_recv, send, wait_any, PortId};
 use atom_syscall::thread::{exit, yield_now, get_ticks};
 use atom_syscall::debug::log;
 
@@ -824,6 +824,12 @@ fn main() -> ! {
                 }
             }
         }
-        yield_now();
+        // Block until input arrives (or a short timeout) instead of busy-spinning
+        // with yield_now(). A pure yield loop keeps this thread perpetually
+        // runnable, burning a full scheduler quantum every pass and starving the
+        // compositor — which is what drags the cursor down to ~10 fps once the
+        // file manager is open. wait_any() parks the thread so an idle window
+        // costs no CPU; the 16 ms ceiling keeps input feeling responsive.
+        let _ = wait_any(&[local_port], 16);
     }
 }

--- a/userspace/libs/libgui/src/application.rs
+++ b/userspace/libs/libgui/src/application.rs
@@ -261,12 +261,21 @@ impl Application {
 
     /// Wait for the next event (blocking)
     pub fn wait_event(&mut self) -> Event {
+        // Idle re-poll cadence. Long enough that a parked app costs ~no CPU,
+        // short enough to stay responsive to state not tied to an incoming
+        // message.
+        const WAIT_EVENT_TIMEOUT_MS: u64 = 100;
         loop {
             let event = self.poll_event();
             if !matches!(event, Event::None) {
                 return event;
             }
-            atom_syscall::thread::yield_now();
+            // Park on the event port instead of spinning on yield_now(): a
+            // yield-only wait keeps the thread permanently Ready, so the
+            // scheduler never lets its CPU halt and the core sits at 100%
+            // while the app is "idle". wait_any blocks until a message lands
+            // (or the timeout elapses), so an idle app consumes no CPU.
+            self.wait_for_event(WAIT_EVENT_TIMEOUT_MS);
         }
     }
 

--- a/userspace/libs/libgui/src/surface.rs
+++ b/userspace/libs/libgui/src/surface.rs
@@ -18,7 +18,13 @@ use libipc::protocol::send_message_async;
 /// Internal state for a drawing surface
 pub(crate) struct SurfaceInner {
     pub window_id: WindowId,
+    /// Private back buffer that all drawing operations target. Decoupling the
+    /// draw target from the compositor's region is what makes animation tear
+    /// free: the compositor only ever sees a finished frame (see `present`).
     pub shared: SharedSurface,
+    /// The compositor-owned region the window is actually displayed from. A
+    /// completed frame is copied here in one shot on `present`.
+    pub front: SharedSurface,
     pub wm_port: PortId,
     pub dirty: bool,
     pub scale_factor: u32,
@@ -36,12 +42,19 @@ impl Surface {
         resp: WmCreateWindowResponse,
         wm_port: PortId,
     ) -> Result<Self, atom_syscall::SyscallError> {
-        let shared = SharedSurface::from_region(resp.region_id, resp.width, resp.height)?;
+        let front = SharedSurface::from_region(resp.region_id, resp.width, resp.height)?;
+        // Private, app-owned back buffer with the same geometry. Apps draw here
+        // across many (potentially slow) operations; only `present` publishes a
+        // finished frame to `front`, so the compositor can never snapshot a
+        // half-drawn surface (which is what makes direct-to-surface animations
+        // flicker).
+        let shared = SharedSurface::create(resp.width, resp.height)?;
 
         Ok(Self {
             inner: Rc::new(RefCell::new(SurfaceInner {
                 window_id: resp.window_id,
                 shared,
+                front,
                 wm_port,
                 dirty: false,
                 scale_factor: 1000, // 1.0 default
@@ -385,10 +398,30 @@ impl Surface {
         inner.dirty = true;
     }
 
-    /// Present the surface (signal compositor to display)
+    /// Present the surface (signal compositor to display).
+    ///
+    /// Publishes the finished frame by copying the private back buffer into the
+    /// compositor's region in a single pass, then signals the commit. Because
+    /// the copy is the only time `front` is written — and it happens while the
+    /// app is between draws — the compositor never reads a partially drawn
+    /// frame, eliminating the flicker seen when animating directly on the
+    /// shared surface.
     pub fn present(&mut self) {
         let mut inner = self.inner.borrow_mut();
         if inner.dirty {
+            // Back and front are created with identical geometry (stride ==
+            // width, 4 bytes/pixel), so the pixel data is contiguous and can be
+            // published with one copy.
+            if let (Some(src), Some(dst)) = (inner.shared.address(), inner.front.address()) {
+                let count = (inner.shared.stride() * inner.shared.height()) as usize;
+                unsafe {
+                    core::ptr::copy_nonoverlapping(
+                        src as usize as *const u32,
+                        dst as usize as *mut u32,
+                        count,
+                    );
+                }
+            }
             let msg = WmCommitFrameMsg {
                 window_id: inner.window_id,
             };

--- a/userspace/services/fsd/src/backend.rs
+++ b/userspace/services/fsd/src/backend.rs
@@ -21,6 +21,8 @@ pub trait FsBackend {
     fn rename(&self, old_path: &str, new_path: &str) -> Result<(), FsError>;
     fn sync_fs(&self) -> Result<(), FsError>;
     fn flush_block_cache(&self) -> Result<(), FsError>;
+    /// Return a 72-byte FsStatvfsBuf in wire format, or None if unsupported.
+    fn statvfs(&self) -> Option<[u8; 72]>;
 }
 
 fn encode_stat(path: &str, stat_buf: &mut [u8; 80], size: u64, is_dir: bool) {
@@ -198,5 +200,9 @@ impl FsBackend for UserspaceFatBackend {
             Some(true) => Ok(()),
             _ => Err(FsError::Io),
         }
+    }
+
+    fn statvfs(&self) -> Option<[u8; 72]> {
+        crate::fat32::statvfs_buf()
     }
 }

--- a/userspace/services/fsd/src/fat32.rs
+++ b/userspace/services/fsd/src/fat32.rs
@@ -198,6 +198,7 @@ struct FsInfo {
     total_sectors: u32,
     total_clusters: u32,
     partition_start: u64,
+    fs_info_sector: u32,  // absolute LBA of the FAT32 FSInfo sector
 }
 
 #[derive(Clone, Copy)]
@@ -293,6 +294,8 @@ fn init_partition(start_sector: u64) -> bool {
     let data_sectors = total_sectors.saturating_sub(reserved_sectors + num_fats * fat_size);
     let total_clusters = data_sectors / sectors_per_cluster;
 
+    let fs_info_sector = start_sector as u32 + u16::from_le(bpb.fs_info) as u32;
+
     unsafe {
         FS_INFO = Some(FsInfo {
             bytes_per_sector,
@@ -306,6 +309,7 @@ fn init_partition(start_sector: u64) -> bool {
             total_sectors,
             total_clusters,
             partition_start: start_sector,
+            fs_info_sector,
         });
     }
 
@@ -1415,4 +1419,58 @@ pub fn read_file_range(
     }
 
     Ok(copied)
+}
+
+// ── Filesystem statistics (statvfs) ──────────────────────────────────────────
+
+/// Read the FAT32 FSInfo sector and return the cached free-cluster count.
+/// Returns None if the FSInfo is absent or marks the count as unknown (0xFFFFFFFF).
+fn read_fsinfo_free_count(info: &FsInfo) -> Option<u32> {
+    let sector = ahci::read_sectors(info.fs_info_sector as u64, 1)?;
+    if sector.len() < 512 { return None; }
+    let lead  = u32::from_le_bytes([sector[0],   sector[1],   sector[2],   sector[3]]);
+    let struc = u32::from_le_bytes([sector[484], sector[485], sector[486], sector[487]]);
+    if lead != 0x4161_5252 || struc != 0x6141_7272 { return None; }
+    let free = u32::from_le_bytes([sector[488], sector[489], sector[490], sector[491]]);
+    if free == 0xFFFF_FFFF { None } else { Some(free) }
+}
+
+/// Scan the entire FAT to count free clusters (slow fallback for corrupted FSInfo).
+fn count_free_clusters_scan(info: &FsInfo) -> u32 {
+    let mut free = 0u32;
+    for cluster in 2u32..(2 + info.total_clusters) {
+        if let Some(entry) = read_fat_entry(cluster) {
+            if entry == FAT_FREE { free += 1; }
+        }
+    }
+    free
+}
+
+/// Return a 72-byte FsStatvfsBuf (wire format, little-endian) for the mounted FAT32.
+/// - bsize:  sector size (bytes)
+/// - frsize: cluster size (bytes) — the unit used by `blocks`, `bfree`, `bavail`
+/// - blocks: total data clusters
+/// - bfree/bavail: free clusters (FAT32 has no root reservation)
+/// - namemax: 255 (FAT32 LFN)
+pub fn statvfs_buf() -> Option<[u8; 72]> {
+    let info = fs_info()?;
+    let free = read_fsinfo_free_count(info)
+        .unwrap_or_else(|| count_free_clusters_scan(info));
+
+    let bsize:   u64 = info.bytes_per_sector as u64;
+    let frsize:  u64 = (info.bytes_per_sector * info.sectors_per_cluster) as u64;
+    let blocks:  u64 = info.total_clusters as u64;
+    let bfree:   u64 = free as u64;
+    let namemax: u32 = 255;
+
+    let mut buf = [0u8; 72];
+    buf[0..8].copy_from_slice(&bsize.to_le_bytes());
+    buf[8..16].copy_from_slice(&frsize.to_le_bytes());
+    buf[16..24].copy_from_slice(&blocks.to_le_bytes());
+    buf[24..32].copy_from_slice(&bfree.to_le_bytes());
+    buf[32..40].copy_from_slice(&bfree.to_le_bytes()); // bavail == bfree on FAT32
+    // files / ffree / favail: FAT32 has no inode table — leave as 0
+    buf[64..68].copy_from_slice(&namemax.to_le_bytes());
+    // flags = 0 (read-write)
+    Some(buf)
 }

--- a/userspace/services/fsd/src/ipc.rs
+++ b/userspace/services/fsd/src/ipc.rs
@@ -129,7 +129,8 @@ impl<'a, 'b> FsdIpcHandler<'a, 'b> {
             MessageType::FsRename  => self.handle_fs_rename(payload),
             MessageType::FsReaddir => self.handle_fs_readdir(payload),
             MessageType::FsTruncate => self.handle_fs_truncate(payload),
-            MessageType::FsFsync  => self.handle_fs_fsync(payload),
+            MessageType::FsFsync   => self.handle_fs_fsync(payload),
+            MessageType::FsStatvfs => self.handle_fs_statvfs(payload),
             _ => {
                 atom_syscall::debug::log("fsd: unsupported msg_type, returning ENOTSUP");
                 Self::make_reply(ENOTSUP, 0)
@@ -984,6 +985,32 @@ impl<'a, 'b> FsdIpcHandler<'a, 'b> {
                 Err(_) => Self::make_reply(EIO, 0),
             },
             Err(_) => Self::make_reply(EIO, 0),
+        }
+    }
+
+    // ── Statvfs ───────────────────────────────────────────────────────────
+    //
+    // Request: [path_len(4) | path_bytes]  (path is accepted but ignored —
+    //          there is one mount point "/" and the backend always reports it)
+    // Reply:   [error(8) | statvfs_buf(72)]
+
+    fn handle_fs_statvfs(&mut self, payload: &[u8]) -> Vec<u8> {
+        if payload.len() < 4 {
+            return Self::make_reply(EINVAL, 0);
+        }
+        // Parse but otherwise ignore the path (single-mount system).
+        let path_len = u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]) as usize;
+        if payload.len() < 4 + path_len {
+            return Self::make_reply(EINVAL, 0);
+        }
+        match self.backend.statvfs() {
+            Some(buf) => {
+                let mut resp = Vec::with_capacity(8 + 72);
+                resp.extend_from_slice(&ESUCCESS.to_le_bytes());
+                resp.extend_from_slice(&buf);
+                resp
+            }
+            None => Self::make_reply(ENOTSUP, 0),
         }
     }
 }

--- a/userspace/system_apps/system_settings/.cargo/config.toml
+++ b/userspace/system_apps/system_settings/.cargo/config.toml
@@ -1,0 +1,21 @@
+# Build for bare-metal userspace (Ring 3)
+[build]
+target = "x86_64-unknown-none"
+
+[unstable]
+build-std = ["core", "alloc"]
+build-std-features = ["compiler-builtins-mem"]
+
+# Use custom linker script to place code at 0x400000
+[target.x86_64-unknown-none]
+rustflags = [
+    "-C", "link-arg=-T../../userspace.ld",
+    "-C", "relocation-model=pic",
+    "-C", "code-model=small",
+    "-C", "panic=abort",
+    "-C", "link-arg=-pie",
+    "-C", "link-arg=-Bstatic",
+    "-C", "link-arg=--no-dynamic-linker",
+    "-C", "link-arg=--gc-sections",
+    "-C", "link-arg=-z", "-C", "link-arg=norelro"
+]

--- a/userspace/system_apps/system_settings/Cargo.toml
+++ b/userspace/system_apps/system_settings/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "system_settings"
+version = "0.1.0"
+edition = "2021"
+description = "Atom OS System Settings – unified settings panel with sidebar navigation"
+
+[workspace]
+
+[dependencies]
+atom_syscall = { path = "../../libs/syscall" }
+libipc       = { path = "../../libs/libipc" }
+libimage     = { path = "../../libs/libimage" }
+libnet       = { path = "../../libs/libnet" }
+
+[[bin]]
+name = "system_settings"
+path = "src/main.rs"

--- a/userspace/system_apps/system_settings/src/main.rs
+++ b/userspace/system_apps/system_settings/src/main.rs
@@ -7,10 +7,17 @@
 //     Desktop Background  – solid-colour swatches + wallpaper browser + scaling
 //
 //   SYSTEM SETTINGS
+//     Network             – connection status + IP/DNS info + DNS preset buttons
 //     Display Resolution  – scrollable video-mode list
 //     About System        – OS / hardware / network summary
 //
-// IPC service name: "system_settings"
+// Performance notes
+// -----------------
+//   * Heavy IPC (net config) is deferred to after the first frame renders.
+//   * wait_any uses a 32 ms budget (was 16) – settings panel, not a game.
+//   * Dynamic data (network, memory, uptime) is refreshed every 5 s only while
+//     the relevant page is active; static CPU/arch data is collected once.
+//   * The wallpaper directory scan is also deferred to after first render.
 
 #![no_std]
 #![no_main]
@@ -40,8 +47,9 @@ use libipc::messages::{
     OpenInTabMsg,
     WallpaperAppliedMsg, WallpaperFailedMsg,
     ScalingMode, ApplyWallpaperMsg, WallpaperSourceType,
+    NetGetConfigMsg, NetGetConfigReplyMsg, NetConfigureMsg,
 };
-use libnet::net_get_config;
+use libipc::protocol::{get_payload, send_message};
 
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -84,98 +92,91 @@ fn alloc_error(_: Layout) -> ! { loop {} }
 
 mod theme {
     use atom_syscall::graphics::Color;
-    // Backgrounds
-    pub const BG:          Color = Color::new(0x0B, 0x0E, 0x13);   // main content bg
-    pub const SURFACE:     Color = Color::new(0x14, 0x19, 0x22);   // card / tile bg
-    pub const SURFACE_ALT: Color = Color::new(0x1C, 0x22, 0x32);   // elevated surface
-    pub const SIDEBAR_BG:  Color = Color::new(0x0D, 0x11, 0x1A);   // sidebar bg (darker)
-    pub const HDR_BG:      Color = Color::new(0x0D, 0x11, 0x1A);   // status bar bg
-    // Borders / dividers
-    pub const BORDER:      Color = Color::new(0x28, 0x30, 0x42);
-    pub const DIVIDER:     Color = Color::new(0x1A, 0x20, 0x30);
-    // Text
-    pub const TEXT:        Color = Color::new(0xE8, 0xEC, 0xF4);
-    pub const TEXT_SEC:    Color = Color::new(0xA0, 0xAA, 0xC0);
-    pub const TEXT_MUTED:  Color = Color::new(0x55, 0x60, 0x7A);
-    // Accent
-    pub const ACCENT:      Color = Color::new(0x4C, 0x8D, 0xFF);
-    pub const ACCENT_DIM:  Color = Color::new(0x25, 0x4A, 0x88);
-    pub const SEL_BG:      Color = Color::new(0x1A, 0x2A, 0x4E);
-    // Sidebar active item
+    pub const BG:           Color = Color::new(0x0B, 0x0E, 0x13);
+    pub const SURFACE:      Color = Color::new(0x14, 0x19, 0x22);
+    pub const SIDEBAR_BG:   Color = Color::new(0x0D, 0x11, 0x1A);
+    pub const HDR_BG:       Color = Color::new(0x0D, 0x11, 0x1A);
+    pub const BORDER:       Color = Color::new(0x28, 0x30, 0x42);
+    pub const DIVIDER:      Color = Color::new(0x1A, 0x20, 0x30);
+    pub const TEXT:         Color = Color::new(0xE8, 0xEC, 0xF4);
+    pub const TEXT_SEC:     Color = Color::new(0xA0, 0xAA, 0xC0);
+    pub const TEXT_MUTED:   Color = Color::new(0x55, 0x60, 0x7A);
+    pub const ACCENT:       Color = Color::new(0x4C, 0x8D, 0xFF);
+    pub const ACCENT_DIM:   Color = Color::new(0x25, 0x4A, 0x88);
+    pub const SEL_BG:       Color = Color::new(0x1A, 0x2A, 0x4E);
     pub const ITEM_ACTIVE_BG: Color = Color::new(0x1C, 0x2C, 0x50);
-    // Status
-    pub const SUCCESS:     Color = Color::new(0x22, 0xC5, 0x5E);
-    pub const WARNING:     Color = Color::new(0xF5, 0x9E, 0x0B);
-    // Scrollbar
-    pub const SB_TRACK:    Color = Color::new(0x16, 0x1C, 0x2A);
-    pub const SB_THUMB:    Color = Color::new(0x38, 0x46, 0x64);
-    pub const SB_THUMB_ACT:Color = Color::new(0x4C, 0x8D, 0xFF);
-    // Buttons
-    pub const BTN_PRIMARY: Color = Color::new(0x4C, 0x8D, 0xFF);
-    pub const BTN_GHOST:   Color = Color::new(0x1E, 0x26, 0x3C);
-    pub const BTN_TEXT:    Color = Color::new(0xFF, 0xFF, 0xFF);
-    // About page info
-    pub const INFO_KEY:    Color = Color::new(0x70, 0x80, 0xA8);
-    pub const INFO_VAL:    Color = Color::new(0xD4, 0xDC, 0xF0);
+    pub const SUCCESS:      Color = Color::new(0x22, 0xC5, 0x5E);
+    pub const WARNING:      Color = Color::new(0xF5, 0x9E, 0x0B);
+    pub const SB_TRACK:     Color = Color::new(0x16, 0x1C, 0x2A);
+    pub const SB_THUMB:     Color = Color::new(0x38, 0x46, 0x64);
+    pub const SB_THUMB_ACT: Color = Color::new(0x4C, 0x8D, 0xFF);
+    pub const BTN_PRIMARY:  Color = Color::new(0x4C, 0x8D, 0xFF);
+    pub const BTN_GHOST:    Color = Color::new(0x1E, 0x26, 0x3C);
+    pub const BTN_TEXT:     Color = Color::new(0xFF, 0xFF, 0xFF);
+    pub const INFO_KEY:     Color = Color::new(0x70, 0x80, 0xA8);
+    pub const INFO_VAL:     Color = Color::new(0xD4, 0xDC, 0xF0);
+    pub const NET_OK:       Color = Color::new(0x22, 0xC5, 0x5E);
+    pub const NET_FAIL:     Color = Color::new(0xF5, 0x9E, 0x0B);
+    pub const CARD_BG:      Color = Color::new(0x10, 0x15, 0x20);
 }
 
 // ── Layout constants ──────────────────────────────────────────────────────────
 
-const CW:     u32 = 8;   // character width
-const CH:     u32 = 8;   // character height
+const CW: u32 = 8;
+const CH: u32 = 8;
 
-// Sidebar (LEFT side, no header)
-const SIDEBAR_W:  u32 = 200;  // sidebar width
-const SB_PAD:     u32 = 12;   // sidebar inner padding
-const ITEM_H:     u32 = 30;   // nav item height
+const SIDEBAR_W: u32 = 200;
+const SB_PAD:    u32 = 12;
+const ITEM_H:    u32 = 30;
+const STAT_H:    u32 = 22;
+const PAD:       u32 = 16;
 
-// Status bar (full-width, bottom)
-const STAT_H:     u32 = 22;
+const PTITLE_H:  u32 = CH + 14;  // page title block height
+const SEC_LBL_H: u32 = CH + 8;   // section label row height
 
-// Content area inner padding
-const PAD:        u32 = 16;
+// Desktop Background – mode toggle
+const MTOG_H: u32 = 26;
+const MTOG_W: u32 = 118;
+const MTOG_G: u32 = 2;
 
-// Resolution page
-const ROW_H:      u32 = 22;
-const VIS_ROWS:   usize = 12;
-const SBW:        u32 = 8;    // scrollbar width
+// Color swatches – 4 × 4
+const CSZ:  u32 = 40;
+const CGAP: u32 = 8;
 
-const PTITLE_H:  u32 = CH + 14;  // 22 — page title block height
-const SEC_LBL_H: u32 = CH + 8;   // 16 — section label row height
-
-// Desktop Background mode toggle
-const MTOG_H:  u32 = 26;   // toggle pill height
-const MTOG_W:  u32 = 118;  // each option width
-const MTOG_G:  u32 = 2;    // gap between options
-
-// Color swatches — 4 columns × 4 rows = 16 swatches
-const CSZ:   u32 = 40;   // swatch size
-const CGAP:  u32 = 8;    // gap
-
-// Scaling buttons — single row of 5
-const SBTN_W:  u32 = 58;
-const SBTN_H:  u32 = 22;
-const SBTN_G:  u32 = 6;
+// Scaling buttons – single row of 5
+const SBTN_W: u32 = 58;
+const SBTN_H: u32 = 22;
+const SBTN_G: u32 = 6;
 
 // Wallpaper image tiles
-const TW:     u32 = 84;
-const TH:     u32 = 72;
-const TG:     u32 = 8;
-const TCOLS:  usize = 4;
+const TW:    u32 = 84;
+const TH:    u32 = 72;
+const TG:    u32 = 8;
+const TCOLS: usize = 4;
 
-// Apply / Restore buttons
-const BTN_H:   u32 = 28;
-const BTN_W:   u32 = 90;
-const RBTN_W:  u32 = 128;
+// Resolution page
+const ROW_H:    u32 = 22;
+const VIS_ROWS: usize = 12;
+const SBW:      u32 = 8;
 
-// Default resolution
+// Apply / ghost buttons
+const BTN_H:  u32 = 28;
+const BTN_W:  u32 = 90;
+const RBTN_W: u32 = 128;
+
+// About page icon size
+const ICON_R: u32 = 28;  // outer icon radius
+
+// Refresh interval: 500 ticks ≈ 5 s (get_ticks returns centiseconds)
+const REFRESH_TICKS: u64 = 500;
+
 const DEF_W: u16 = 1024;
 const DEF_H: u16 = 768;
 
 // ── Data types ────────────────────────────────────────────────────────────────
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-enum Page { DesktopBg, DisplayRes, AboutSys }
+enum Page { DesktopBg, Network, DisplayRes, AboutSys }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum WpMode { Color, Image }
@@ -192,11 +193,14 @@ impl Status {
         self.kind = kind;
         self.len = msg.len().min(63);
         self.buf[..self.len].copy_from_slice(&msg[..self.len]);
-        self.ticks = 200;
+        self.ticks = 300;
     }
-    fn tick(&mut self) {
-        if self.ticks > 0 { self.ticks -= 1; }
-        if self.ticks == 0 { self.kind = StatusKind::None; }
+    fn tick(&mut self) -> bool {
+        if self.ticks > 0 {
+            self.ticks -= 1;
+            if self.ticks == 0 { self.kind = StatusKind::None; return true; }
+        }
+        false
     }
     fn as_str(&self) -> &str { core::str::from_utf8(&self.buf[..self.len]).unwrap_or("") }
 }
@@ -207,7 +211,7 @@ struct Mode { w: u16, h: u16 }
 #[derive(Clone, PartialEq, Eq)]
 enum WpSrc { Color { rgb: u32 }, Image { path: String } }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy)]
 enum ThumbSt { Pending, Loaded { w: u16, h: u16 }, Fail }
 
 struct WpImage { name: String, path: String, thumb: ThumbSt }
@@ -225,16 +229,16 @@ impl WpState {
         Self {
             mode: WpMode::Color,
             swatches: [
-                // Row 1: deep darks
+                // deep darks
                 Color::new(0x0B,0x0E,0x13), Color::new(0x11,0x11,0x11),
                 Color::new(0x1A,0x1A,0x2E), Color::new(0x16,0x21,0x3E),
-                // Row 2: mid-dark tones
+                // mid-dark
                 Color::new(0x1F,0x2D,0x4E), Color::new(0x2C,0x1A,0x3E),
                 Color::new(0x0F,0x2F,0x27), Color::new(0x3D,0x1A,0x1A),
-                // Row 3: medium / warm
+                // medium / warm
                 Color::new(0x4A,0x4A,0x5A), Color::new(0x5A,0x46,0x3A),
                 Color::new(0x3A,0x4E,0x3A), Color::new(0x6A,0x55,0x44),
-                // Row 4: light
+                // light
                 Color::new(0xC8,0xCC,0xD8), Color::new(0xE8,0xE4,0xD8),
                 Color::new(0xC4,0xDC,0xF4), Color::new(0xF4,0xF4,0xF4),
             ],
@@ -284,65 +288,109 @@ impl WpState {
     }
 }
 
-// Cached system info for the About page
+// ── Network state ─────────────────────────────────────────────────────────────
+//
+// Holds the last known network configuration (raw u32 values + formatted
+// strings).  Refreshed on demand via refresh(); DNS can be updated via set_dns().
+// "Auto DNS" is the value returned by netd at first successful query.
+
+struct NetState {
+    connected: bool,
+    ip_raw:  u32,
+    nm_raw:  u32,
+    gw_raw:  u32,
+    dns_raw: u32,
+    auto_dns: u32,   // DNS received from DHCP – restored when user picks "Auto"
+    mac: [u8; 6],
+    // Pre-formatted display strings (no_std: no format! macro)
+    ip_s:  [u8; 20], ip_l:  usize,
+    nm_s:  [u8; 20], nm_l:  usize,
+    gw_s:  [u8; 20], gw_l:  usize,
+    dns_s: [u8; 20], dns_l: usize,
+    mac_s: [u8; 20], mac_l: usize,
+}
+impl NetState {
+    fn new() -> Self {
+        Self {
+            connected: false,
+            ip_raw: 0, nm_raw: 0, gw_raw: 0, dns_raw: 0, auto_dns: 0,
+            mac: [0; 6],
+            ip_s:  [0;20], ip_l:  0,
+            nm_s:  [0;20], nm_l:  0,
+            gw_s:  [0;20], gw_l:  0,
+            dns_s: [0;20], dns_l: 0,
+            mac_s: [0;20], mac_l: 0,
+        }
+    }
+    fn refresh(&mut self) {
+        match query_net_fast() {
+            Some(cfg) => {
+                use libnet::IpAddr;
+                let to_raw = |a: &IpAddr| a.to_u32().unwrap_or(0);
+                self.ip_raw  = to_raw(&cfg.ip);
+                self.nm_raw  = to_raw(&cfg.netmask);
+                self.gw_raw  = to_raw(&cfg.gateway);
+                self.dns_raw = to_raw(&cfg.dns);
+                self.mac     = cfg.mac;
+                self.connected = self.ip_raw != 0;
+                if self.auto_dns == 0 { self.auto_dns = self.dns_raw; }
+                self.ip_l  = fmt_ipv4(&mut self.ip_s,  self.ip_raw);
+                self.nm_l  = fmt_ipv4(&mut self.nm_s,  self.nm_raw);
+                self.gw_l  = fmt_ipv4(&mut self.gw_s,  self.gw_raw);
+                self.dns_l = fmt_ipv4(&mut self.dns_s, self.dns_raw);
+                self.mac_l = fmt_mac(&mut self.mac_s,  &self.mac);
+            }
+            None => { self.connected = false; }
+        }
+    }
+    fn set_dns(&mut self, new_dns_raw: u32) {
+        if let Ok(port) = libipc::protocol::lookup_service("netd") {
+            let msg = NetConfigureMsg {
+                own_ip: self.ip_raw,
+                netmask: self.nm_raw,
+                gateway: self.gw_raw,
+                dns_server: new_dns_raw,
+            };
+            let _ = send_message(port, MessageType::NetConfigure, &msg.to_bytes());
+            self.dns_raw = new_dns_raw;
+            self.dns_l = fmt_ipv4(&mut self.dns_s, new_dns_raw);
+        }
+    }
+    fn ip_str(&self)  -> &str { core::str::from_utf8(&self.ip_s[..self.ip_l]).unwrap_or("-") }
+    fn nm_str(&self)  -> &str { core::str::from_utf8(&self.nm_s[..self.nm_l]).unwrap_or("-") }
+    fn gw_str(&self)  -> &str { core::str::from_utf8(&self.gw_s[..self.gw_l]).unwrap_or("-") }
+    fn dns_str(&self) -> &str { core::str::from_utf8(&self.dns_s[..self.dns_l]).unwrap_or("-") }
+    fn mac_str(&self) -> &str { core::str::from_utf8(&self.mac_s[..self.mac_l]).unwrap_or("-") }
+}
+
+// ── Static system info (collected once at startup, fast syscalls only) ────────
+
 struct SysInfo {
     cpu_buf: [u8; 64], cpu_len: usize,
-    cores: u64,
+    cores:   u64,
     mem_total: u64, mem_used: u64,
-    up_buf: [u8; 32], up_len: usize,
-    ip_buf: [u8; 48], ip_len: usize,
+    up_buf:  [u8; 32], up_len: usize,
 }
 impl SysInfo {
-    fn collect() -> Self {
-        let mut cpu_buf = [0u8; 64];
-        let cpu_len = get_cpu_brand(&mut cpu_buf);
-        let cores   = get_cpu_count();
+    fn empty() -> Self {
+        Self { cpu_buf: [0;64], cpu_len: 0, cores: 0,
+               mem_total: 0, mem_used: 0, up_buf: [0;32], up_len: 0 }
+    }
+    fn collect_static(&mut self) {
+        self.cpu_len = get_cpu_brand(&mut self.cpu_buf);
+        self.cores   = get_cpu_count();
         let (total, free) = get_memory_info();
-        let mut up_buf = [0u8; 32];
-        let up_len = fmt_uptime(&mut up_buf);
-        let mut ip_buf = [0u8; 48];
-        let ip_len = collect_ip(&mut ip_buf);
-        SysInfo { cpu_buf, cpu_len, cores, mem_total: total, mem_used: total.saturating_sub(free),
-                  up_buf, up_len, ip_buf, ip_len }
+        self.mem_total = total;
+        self.mem_used  = total.saturating_sub(free);
+    }
+    fn refresh_uptime(&mut self) {
+        self.up_len = fmt_uptime(&mut self.up_buf);
+        let (total, free) = get_memory_info();
+        self.mem_total = total;
+        self.mem_used  = total.saturating_sub(free);
     }
     fn cpu(&self) -> &str { core::str::from_utf8(&self.cpu_buf[..self.cpu_len]).unwrap_or("x86_64") }
     fn uptime(&self) -> &str { core::str::from_utf8(&self.up_buf[..self.up_len]).unwrap_or("-") }
-    fn ip(&self) -> &str { core::str::from_utf8(&self.ip_buf[..self.ip_len]).unwrap_or("unavailable") }
-}
-
-fn fmt_uptime(buf: &mut [u8; 32]) -> usize {
-    let s = get_ticks() / 100;
-    let h = s / 3600; let m = (s % 3600) / 60; let ss = s % 60;
-    let mut p = 0usize;
-    p += fmt_u64(&mut buf[p..], h); buf[p]=b'h'; p+=1; buf[p]=b' '; p+=1;
-    if m<10 { buf[p]=b'0'; p+=1; }
-    p += fmt_u64(&mut buf[p..], m); buf[p]=b'm'; p+=1; buf[p]=b' '; p+=1;
-    if ss<10 { buf[p]=b'0'; p+=1; }
-    p += fmt_u64(&mut buf[p..], ss); buf[p]=b's'; p+=1;
-    p
-}
-
-fn collect_ip(buf: &mut [u8; 48]) -> usize {
-    let port = match libipc::protocol::lookup_service("netd") {
-        Ok(p) => p,
-        Err(_) => { let m = b"unavailable"; buf[..m.len()].copy_from_slice(m); return m.len(); }
-    };
-    match net_get_config(port) {
-        Ok(cfg) => {
-            use libnet::IpAddr;
-            match cfg.ip {
-                IpAddr::V4(b) => {
-                    let mut p = 0usize;
-                    p+=fmt_u64(&mut buf[p..],b[0]as u64); buf[p]=b'.'; p+=1;
-                    p+=fmt_u64(&mut buf[p..],b[1]as u64); buf[p]=b'.'; p+=1;
-                    p+=fmt_u64(&mut buf[p..],b[2]as u64); buf[p]=b'.'; p+=1;
-                    p+=fmt_u64(&mut buf[p..],b[3]as u64); p
-                }
-                IpAddr::V6(_) => { let m=b"(IPv6)"; buf[..6].copy_from_slice(m); 6 }
-            }
-        }
-        Err(_) => { let m=b"unavailable"; buf[..m.len()].copy_from_slice(m); m.len() }
-    }
 }
 
 // ── App state ─────────────────────────────────────────────────────────────────
@@ -368,12 +416,15 @@ struct App {
     sbdrag: bool,
     sboff:  i32,
 
-    // Wallpaper page
-    wp:      WpState,
-    wpscr:   usize,
+    // Desktop background
+    wp:    WpState,
+    wpscr: usize,
 
-    // About page
-    sinfo:  SysInfo,
+    // Network + About data
+    net:          NetState,
+    sinfo:        SysInfo,
+    last_refresh: u64,   // last get_ticks() value when data was refreshed
+    deferred_done: bool, // slow init completed
 }
 
 impl App {
@@ -387,33 +438,63 @@ impl App {
             page: Page::DesktopBg, status: Status::new(),
             modes, mcnt, sel, scroll: 0, sbdrag: false, sboff: 0,
             wp: WpState::new(), wpscr: 0,
-            sinfo: SysInfo::collect(),
+            net: NetState::new(), sinfo: SysInfo::empty(),
+            last_refresh: 0, deferred_done: false,
         };
         a.clamp_scroll();
-        a.wp.discover();
         a
     }
 
-    // ── Geometry ──────────────────────────────────────────────────────────────
+    // Deferred initialisation – called once after the first frame is shown so
+    // the window appears instantly and the IPC calls don't block startup.
+    fn deferred_init(&mut self) {
+        self.sinfo.collect_static();
+        self.sinfo.refresh_uptime();
+        self.net.refresh();
+        self.wp.discover();
+        self.last_refresh = get_ticks();
+        self.deferred_done = true;
+        self.dirty = true;
+    }
 
-    // Sidebar occupies x ∈ [0, SIDEBAR_W)
-    // Content occupies x ∈ [SIDEBAR_W+1, sw)
-    fn cx(&self) -> u32 { SIDEBAR_W + 1 }          // content left edge (absolute)
-    fn cw(&self) -> u32 { self.sw.saturating_sub(SIDEBAR_W + 1) }  // content width
-    fn content_h(&self) -> u32 { self.sh.saturating_sub(STAT_H) }  // usable height
+    // Periodic refresh for dynamic data (memory, uptime, network).
+    // Only runs while on pages that actually display the live data.
+    fn maybe_refresh(&mut self) {
+        if !self.deferred_done { return; }
+        let now = get_ticks();
+        if now.wrapping_sub(self.last_refresh) < REFRESH_TICKS { return; }
+        match self.page {
+            Page::Network => {
+                self.net.refresh();
+                self.dirty = true;
+            }
+            Page::AboutSys => {
+                self.sinfo.refresh_uptime();
+                self.net.refresh();
+                self.dirty = true;
+            }
+            _ => {}
+        }
+        self.last_refresh = now;
+    }
 
-    // ── Sidebar item hit-test ─────────────────────────────────────────────────
+    // ── Geometry helpers ──────────────────────────────────────────────────────
 
-    // Returns (page, absolute_y, item_height) for each nav item
-    fn nav_items(&self) -> [(Page, u32); 3] {
-        let top = SB_PAD;
-        let cat  = CH + 10;   // category label row + gap below
-        let igap = 4;         // gap between items
+    fn cx(&self) -> u32 { SIDEBAR_W + 1 }
+    fn cw(&self) -> u32 { self.sw.saturating_sub(SIDEBAR_W + 1) }
+    fn content_h(&self) -> u32 { self.sh.saturating_sub(STAT_H) }
 
-        let y0 = top + cat;                           // Desktop Bg
-        let y1 = y0 + ITEM_H + igap + 14 + cat;      // Display Res  (+gap + next category)
-        let y2 = y1 + ITEM_H + igap;                  // About Sys
-        [(Page::DesktopBg, y0), (Page::DisplayRes, y1), (Page::AboutSys, y2)]
+    // ── Sidebar hit-test ──────────────────────────────────────────────────────
+
+    fn nav_items(&self) -> [(Page, u32); 4] {
+        let cat  = CH + 10;
+        let igap = 4;
+        let y0 = SB_PAD + cat;                        // Desktop Bg
+        let y1 = y0 + ITEM_H + igap + 14 + cat;       // Network
+        let y2 = y1 + ITEM_H + igap;                  // Display Res
+        let y3 = y2 + ITEM_H + igap;                  // About Sys
+        [(Page::DesktopBg, y0), (Page::Network, y1),
+         (Page::DisplayRes, y2), (Page::AboutSys, y3)]
     }
 
     fn nav_hit(&self, mx: i32, my: i32) -> Option<Page> {
@@ -424,44 +505,69 @@ impl App {
         None
     }
 
-    // ── Wallpaper page element positions (absolute) ───────────────────────────
-    //
-    // y layout:
-    //   0              : page title
-    //   PTITLE_H+8     : mode toggle  [Solid Color | Wallpaper Image]
-    //   +MTOG_H+12     : body start — colour swatches (Color mode)
-    //                                 OR scale picker + image tiles (Image mode)
-    //   sh-STAT_H-BTN_H-10 : Apply button
+    // ── Desktop Background layout helpers ─────────────────────────────────────
 
     fn wp_toggle_y(&self) -> u32 { PTITLE_H + 8 }
     fn wp_body_y(&self)   -> u32 { self.wp_toggle_y() + MTOG_H + 12 }
 
-    // Color mode: 4×4 swatch grid (label at wp_body_y, swatches below it)
     fn wp_swatch_row_y(&self, row: u32) -> u32 {
         self.wp_body_y() + SEC_LBL_H + row * (CSZ + CGAP)
     }
     fn swatch_rect(&self, i: usize) -> (u32, u32) {
-        let col = (i % 4) as u32;
-        let row = (i / 4) as u32;
+        let col = (i % 4) as u32; let row = (i / 4) as u32;
         (self.cx() + PAD + col * (CSZ + CGAP), self.wp_swatch_row_y(row))
     }
 
-    // Image mode: scale row then tiles
-    fn wp_scale_y(&self)    -> u32 { self.wp_body_y() }
-    fn wp_sbtn_y(&self)     -> u32 { self.wp_scale_y() + SEC_LBL_H }
-    fn wp_tiles_label_y(&self) -> u32 { self.wp_sbtn_y() + SBTN_H + 12 }
+    fn wp_scale_y(&self)      -> u32 { self.wp_body_y() }
+    fn wp_sbtn_y(&self)       -> u32 { self.wp_scale_y() + SEC_LBL_H }
+    fn wp_tiles_label_y(&self)-> u32 { self.wp_sbtn_y() + SBTN_H + 12 }
     fn wp_tile_row_y(&self, row: u32) -> u32 {
         self.wp_tiles_label_y() + SEC_LBL_H + row * (TH + TG)
     }
     fn sbtn_rect(&self, i: usize) -> (u32, u32) {
-        // All 5 scaling options in a single row
         (self.cx() + PAD + i as u32 * (SBTN_W + SBTN_G), self.wp_sbtn_y())
     }
     fn tile_rect(&self, vis: usize) -> (u32, u32) {
-        let col = (vis % TCOLS) as u32;
-        let row = (vis / TCOLS) as u32;
+        let col = (vis % TCOLS) as u32; let row = (vis / TCOLS) as u32;
         (self.cx() + PAD + col * (TW + TG), self.wp_tile_row_y(row))
     }
+
+    // ── Resolution page helpers ───────────────────────────────────────────────
+
+    fn res_list_top(&self) -> u32 { PTITLE_H + SEC_LBL_H + 6 }
+    fn res_geom(&self) -> (u32, u32, u32, u32) {
+        let top = self.res_list_top();
+        let h   = VIS_ROWS as u32 * ROW_H;
+        let w   = self.cw().saturating_sub(PAD * 2 + SBW + 4);
+        let sbx = self.cx() + self.cw().saturating_sub(PAD + SBW);
+        (top, h, w, sbx)
+    }
+    fn sb_geom(&self) -> (u32, u32, u32) {
+        let (top, lh, _, _) = self.res_geom();
+        let total = self.mcnt as u32; let vis = VIS_ROWS as u32;
+        let th = if total > 0 { ((lh * vis) / total).max(14).min(lh) } else { lh };
+        let tr = lh.saturating_sub(th);
+        let ms = self.mcnt.saturating_sub(VIS_ROWS) as u32;
+        let ty = if ms > 0 { top + tr * self.scroll as u32 / ms } else { top };
+        (ty, th, tr)
+    }
+    fn clamp_scroll(&mut self) {
+        let max = self.mcnt.saturating_sub(VIS_ROWS);
+        if self.scroll > max { self.scroll = max; }
+        if self.sel < self.scroll { self.scroll = self.sel; }
+        if self.sel >= self.scroll + VIS_ROWS { self.scroll = self.sel + 1 - VIS_ROWS; }
+    }
+    fn set_scroll_from_drag(&mut self, y: i32) {
+        let (top, _, _, _) = self.res_geom();
+        let (_, _, tr) = self.sb_geom();
+        let max = self.mcnt.saturating_sub(VIS_ROWS);
+        if tr == 0 || max == 0 { self.scroll = 0; return; }
+        let rel = (y - top as i32).clamp(0, tr as i32) as u32;
+        self.scroll = ((rel as u64 * max as u64 + tr as u64 / 2) / tr as u64) as usize;
+        self.dirty = true;
+    }
+
+    // ── Button positions ──────────────────────────────────────────────────────
 
     fn apply_btn(&self) -> (u32, u32) {
         let y = self.sh.saturating_sub(STAT_H + BTN_H + 10);
@@ -473,45 +579,7 @@ impl App {
         (ax.saturating_sub(8 + RBTN_W), ay)
     }
 
-    // ── Resolution helpers ────────────────────────────────────────────────────
-
-    fn res_list_top(&self) -> u32 { PTITLE_H + SEC_LBL_H + 6 }
-
-    fn res_geom(&self) -> (u32, u32, u32, u32) {
-        let top = self.res_list_top();
-        let h   = VIS_ROWS as u32 * ROW_H;
-        let w   = self.cw().saturating_sub(PAD * 2 + SBW + 4);
-        let sbx = self.cx() + self.cw().saturating_sub(PAD + SBW);
-        (top, h, w, sbx)
-    }
-
-    fn sb_geom(&self) -> (u32, u32, u32) {
-        let (top, lh, _, _) = self.res_geom();
-        let total = self.mcnt as u32;
-        let vis   = VIS_ROWS as u32;
-        let th = if total > 0 { ((lh * vis) / total).max(14).min(lh) } else { lh };
-        let tr = lh.saturating_sub(th);
-        let ms = self.mcnt.saturating_sub(VIS_ROWS) as u32;
-        let ty = if ms > 0 { top + tr * self.scroll as u32 / ms } else { top };
-        (ty, th, tr)
-    }
-
-    fn clamp_scroll(&mut self) {
-        let max = self.mcnt.saturating_sub(VIS_ROWS);
-        if self.scroll > max { self.scroll = max; }
-        if self.sel < self.scroll { self.scroll = self.sel; }
-        if self.sel >= self.scroll + VIS_ROWS { self.scroll = self.sel + 1 - VIS_ROWS; }
-    }
-
-    fn set_scroll_from_drag(&mut self, y: i32) {
-        let (top, _, _, _) = self.res_geom();
-        let (_, _, tr) = self.sb_geom();
-        let max = self.mcnt.saturating_sub(VIS_ROWS);
-        if tr == 0 || max == 0 { self.scroll = 0; return; }
-        let rel = (y - top as i32).clamp(0, tr as i32) as u32;
-        self.scroll = ((rel as u64 * max as u64 + tr as u64 / 2) / tr as u64) as usize;
-        self.dirty = true;
-    }
+    // ── Actions ───────────────────────────────────────────────────────────────
 
     fn apply_resolution(&mut self) {
         if self.mcnt == 0 { return; }
@@ -585,15 +653,12 @@ impl App {
         let sp = match self.surf { Some(ref s) => s as *const SharedSurface, None => return };
         let s = unsafe { &*sp };
 
-        // Full-window background reset
         s.fill_rect(0, 0, self.sw, self.sh, theme::BG);
-
         self.draw_sidebar(s);
-        self.draw_divider(s);
+        s.fill_rect(SIDEBAR_W, 0, 1, self.content_h(), theme::BORDER);
         self.draw_content(s);
         self.draw_status(s);
 
-        // Present
         let msg = SurfacePresentMsg { window_id: self.wid };
         let hdr = MessageHeader::new(MessageType::SurfacePresent, SurfacePresentMsg::SIZE as u32);
         let mut b = [0u8; MessageHeader::SIZE + SurfacePresentMsg::SIZE];
@@ -609,17 +674,15 @@ impl App {
         s.fill_rect(0, 0, SIDEBAR_W, h, theme::SIDEBAR_BG);
 
         let items = self.nav_items();
+        let cat2_y = items[1].1.saturating_sub(CH + 10 + 4);
 
-        // Category 1
-        let cat1_y = SB_PAD;
-        self.draw_cat_label(s, cat1_y, "PERSONALIZATION");
+        self.draw_cat_label(s, SB_PAD, "PERSONALIZATION");
         self.draw_nav_item(s, items[0].1, "Desktop Background", items[0].0 == self.page);
 
-        // Category 2
-        let cat2_y = items[1].1.saturating_sub(CH + 10 + 4);
         self.draw_cat_label(s, cat2_y, "SYSTEM SETTINGS");
-        self.draw_nav_item(s, items[1].1, "Display Resolution", items[1].0 == self.page);
-        self.draw_nav_item(s, items[2].1, "About System",       items[2].0 == self.page);
+        self.draw_nav_item(s, items[1].1, "Network",            items[1].0 == self.page);
+        self.draw_nav_item(s, items[2].1, "Display Resolution", items[2].0 == self.page);
+        self.draw_nav_item(s, items[3].1, "About System",       items[3].0 == self.page);
     }
 
     fn draw_cat_label(&self, s: &SharedSurface, y: u32, label: &str) {
@@ -628,70 +691,60 @@ impl App {
 
     fn draw_nav_item(&self, s: &SharedSurface, y: u32, label: &str, active: bool) {
         if active {
-            // Rounded-rect highlight spanning most of sidebar width
             s.fill_rect_rounded_aa(6, y, SIDEBAR_W - 12, ITEM_H, 6, theme::ITEM_ACTIVE_BG);
-            // Left accent bar
             s.fill_rect_rounded_aa(4, y + 4, 3, ITEM_H - 8, 2, theme::ACCENT);
         }
         let fg = if active { theme::TEXT } else { theme::TEXT_SEC };
         let bg = if active { theme::ITEM_ACTIVE_BG } else { theme::SIDEBAR_BG };
-        let lx = SB_PAD + 10;
-        s.draw_string(lx, y + (ITEM_H - CH) / 2, label, fg, bg);
-    }
-
-    fn draw_divider(&self, s: &SharedSurface) {
-        s.fill_rect(SIDEBAR_W, 0, 1, self.content_h(), theme::BORDER);
+        s.draw_string(SB_PAD + 10, y + (ITEM_H - CH) / 2, label, fg, bg);
     }
 
     // ── Content dispatch ──────────────────────────────────────────────────────
 
     fn draw_content(&self, s: &SharedSurface) {
-        // Clear content area
-        let cx = self.cx();
-        let cw = self.cw();
-        let ch = self.content_h();
+        let cx = self.cx(); let cw = self.cw(); let ch = self.content_h();
         s.fill_rect(cx, 0, cw, ch, theme::BG);
-
         match self.page {
             Page::DesktopBg  => self.draw_desktop_bg(s),
+            Page::Network    => self.draw_network(s),
             Page::DisplayRes => self.draw_display_res(s),
             Page::AboutSys   => self.draw_about(s),
         }
     }
 
-    // ── Page title helper ─────────────────────────────────────────────────────
+    // ── Shared drawing helpers ────────────────────────────────────────────────
 
     fn draw_page_title(&self, s: &SharedSurface, title: &str) {
-        let cx = self.cx();
-        let cw = self.cw();
+        let cx = self.cx(); let cw = self.cw();
         let ty = (PTITLE_H - CH) / 2;
         s.draw_string(cx + PAD, ty, title, theme::TEXT, theme::BG);
-        // Thin accent-colored underline, only under the title text
         let lw = (title.len() as u32 * CW).min(cw.saturating_sub(PAD * 2));
         s.fill_rect(cx + PAD, PTITLE_H - 2, lw, 2, theme::ACCENT_DIM);
     }
 
-    // Section label inside a content page
     fn draw_sec_label(&self, s: &SharedSurface, y: u32, label: &str) {
-        let cx = self.cx();
-        s.draw_string(cx + PAD, y + (SEC_LBL_H - CH) / 2, label, theme::TEXT_SEC, theme::BG);
+        s.draw_string(self.cx() + PAD, y + (SEC_LBL_H - CH) / 2, label, theme::TEXT_SEC, theme::BG);
+    }
+
+    // Draw a filled card background with a subtle border.
+    fn draw_card(&self, s: &SharedSurface, y: u32, h: u32) {
+        let cx = self.cx(); let cw = self.cw();
+        let x = cx + PAD; let w = cw.saturating_sub(PAD * 2);
+        s.fill_rect_rounded_aa(x, y, w, h, 8, theme::CARD_BG);
+        s.draw_rect_rounded_aa(x, y, w, h, 8, theme::BORDER);
     }
 
     // ── Desktop Background page ───────────────────────────────────────────────
 
     fn draw_wp_toggle(&self, s: &SharedSurface) {
-        let cx  = self.cx();
-        let y   = self.wp_toggle_y();
-        let x0  = cx + PAD;
-        let tw  = MTOG_W * 2 + MTOG_G + 4;
-        // Outer track
+        let y  = self.wp_toggle_y();
+        let x0 = self.cx() + PAD;
+        let tw = MTOG_W * 2 + MTOG_G + 4;
         s.fill_rect_rounded_aa(x0, y, tw, MTOG_H, MTOG_H / 2, theme::SURFACE);
         s.draw_rect_rounded_aa(x0, y, tw, MTOG_H, MTOG_H / 2, theme::BORDER);
-        // Active pill
         let pill_x = if self.wp.mode == WpMode::Color { x0 + 2 }
                      else { x0 + 2 + MTOG_W + MTOG_G };
         s.fill_rect_rounded_aa(pill_x, y + 2, MTOG_W, MTOG_H - 4, (MTOG_H - 4) / 2, theme::ACCENT);
-        // Labels
         let labels = ["Solid Color", "Wallpaper Image"];
         for (i, lbl) in labels.iter().enumerate() {
             let lx = x0 + 2 + i as u32 * (MTOG_W + MTOG_G);
@@ -707,24 +760,19 @@ impl App {
     fn draw_desktop_bg(&self, s: &SharedSurface) {
         self.draw_page_title(s, "Desktop Background");
         self.draw_wp_toggle(s);
-
         match self.wp.mode {
             WpMode::Color => self.draw_wp_color_section(s),
             WpMode::Image => self.draw_wp_image_section(s),
         }
-
-        // Apply button (bottom-right)
         let (ax, ay) = self.apply_btn();
         s.fill_rect_rounded_aa(ax, ay, BTN_W, BTN_H, 7, theme::BTN_PRIMARY);
         let lbl = "Apply";
-        let lx = ax + (BTN_W.saturating_sub(lbl.len() as u32 * CW)) / 2;
-        s.draw_string(lx, ay + (BTN_H - CH) / 2, lbl, theme::BTN_TEXT, theme::BTN_PRIMARY);
+        s.draw_string(ax + (BTN_W.saturating_sub(lbl.len() as u32 * CW)) / 2,
+                      ay + (BTN_H - CH) / 2, lbl, theme::BTN_TEXT, theme::BTN_PRIMARY);
     }
 
     fn draw_wp_color_section(&self, s: &SharedSurface) {
-        let cx = self.cx();
         self.draw_sec_label(s, self.wp_body_y(), "Background Color");
-        // 4×4 swatch grid (16 colours: 4 dark, 4 mid-dark, 4 medium/warm, 4 light)
         for i in 0..16 {
             let (sx, sy) = self.swatch_rect(i);
             let c = self.wp.swatches[i];
@@ -735,41 +783,34 @@ impl App {
                 s.draw_rect_rounded_aa(sx.saturating_sub(2), sy.saturating_sub(2), CSZ+4, CSZ+4, 8, theme::ACCENT);
                 s.draw_rect_rounded_aa(sx.saturating_sub(3), sy.saturating_sub(3), CSZ+6, CSZ+6, 9, theme::ACCENT_DIM);
             } else {
-                // Subtle border — brighter for light swatches so they don't vanish on light bg
                 let border = if c.r > 0xB0 { theme::TEXT_MUTED } else { theme::BORDER };
                 s.draw_rect_rounded_aa(sx, sy, CSZ, CSZ, 7, border);
             }
         }
-        // Row labels on the left
         let row_labels = ["Dark", "Deep", "Mid", "Light"];
         for (r, lbl) in row_labels.iter().enumerate() {
             let ry = self.wp_swatch_row_y(r as u32) + (CSZ - CH) / 2;
-            let lx = cx + PAD + 4 * (CSZ + CGAP) + 10;
+            let lx = self.cx() + PAD + 4 * (CSZ + CGAP) + 10;
             s.draw_string(lx, ry, lbl, theme::TEXT_MUTED, theme::BG);
         }
     }
 
     fn draw_wp_image_section(&self, s: &SharedSurface) {
         let cx = self.cx();
-
-        // Scaling picker
         self.draw_sec_label(s, self.wp_scale_y(), "Image Scaling");
         let modes = [ScalingMode::Fill, ScalingMode::Fit, ScalingMode::Stretch,
                      ScalingMode::Center, ScalingMode::Tile];
         for (i, mode) in modes.iter().enumerate() {
             let (bx, by) = self.sbtn_rect(i);
             let is_sel = self.wp.scaling == *mode;
-            let bg     = if is_sel { theme::SEL_BG } else { theme::SURFACE };
-            let fg     = theme::TEXT;
+            let bg = if is_sel { theme::SEL_BG } else { theme::SURFACE };
             let border = if is_sel { theme::ACCENT } else { theme::BORDER };
             s.fill_rect_rounded_aa(bx, by, SBTN_W, SBTN_H, 5, bg);
             s.draw_rect_rounded_aa(bx, by, SBTN_W, SBTN_H, 5, border);
             let lbl = mode.to_str();
             let lx = bx + (SBTN_W.saturating_sub(lbl.len() as u32 * CW)) / 2;
-            s.draw_string(lx, by + (SBTN_H - CH) / 2, lbl, fg, bg);
+            s.draw_string(lx, by + (SBTN_H - CH) / 2, lbl, theme::TEXT, bg);
         }
-
-        // Wallpaper image tiles
         self.draw_sec_label(s, self.wp_tiles_label_y(), "Wallpaper Images");
         let start = self.wpscr;
         let vis   = 2 * TCOLS;
@@ -790,21 +831,20 @@ impl App {
             s.fill_rect_rounded_aa(px, py, pw, ph, 4, Color::new(28, 34, 50));
             match img.thumb {
                 ThumbSt::Loaded { w, h } => {
-                    let (dw, dh) = fit_in(w as u32, h as u32, pw - 4, ph - 4);
-                    let dx = px + (pw - dw) / 2; let dy = py + (ph - dh) / 2;
-                    s.fill_rect_rounded_aa(dx, dy, dw, dh, 3, theme::ACCENT_DIM);
+                    let (dw, dh) = fit_in(w as u32, h as u32, pw-4, ph-4);
+                    s.fill_rect_rounded_aa(px+(pw-dw)/2, py+(ph-dh)/2, dw, dh, 3, theme::ACCENT_DIM);
                 }
                 ThumbSt::Fail => {
-                    s.draw_rect_rounded_aa(px + 6, py + 4, pw - 12, ph - 8, 3, theme::WARNING);
+                    s.draw_rect_rounded_aa(px+6, py+4, pw-12, ph-8, 3, theme::WARNING);
                 }
                 ThumbSt::Pending => {
-                    let dw = pw / 3; let dh = ph / 3;
-                    s.fill_rect_rounded_aa(px + dw, py + dh, dw, dh, 3, theme::SB_THUMB);
+                    let dw=pw/3; let dh=ph/3;
+                    s.fill_rect_rounded_aa(px+dw, py+dh, dw, dh, 3, theme::SB_THUMB);
                 }
             }
             let max_c = (TW / CW) as usize;
             let lbl = if img.name.len() > max_c { &img.name[..max_c] } else { &img.name };
-            s.draw_string(tx + 4, ty + TH - CH - 2, lbl, theme::TEXT_SEC, bg);
+            s.draw_string(tx+4, ty+TH-CH-2, lbl, theme::TEXT_SEC, bg);
         }
         if self.wp.loading {
             s.draw_string(cx + PAD, self.wp_tiles_label_y() + SEC_LBL_H + 4,
@@ -815,19 +855,97 @@ impl App {
         }
     }
 
+    // ── Network page ──────────────────────────────────────────────────────────
+    //
+    // Layout:
+    //   Page title
+    //   Status bar (dot + text: Connected / No connection)
+    //   Card: IP / Netmask / Gateway / MAC
+    //   DNS card: current DNS + three preset buttons [Auto] [8.8.8.8] [1.1.1.1]
+    //   [Refresh] button (bottom-right)
+
+    fn draw_network(&self, s: &SharedSurface) {
+        let cx = self.cx();
+
+        self.draw_page_title(s, "Network");
+
+        // ── Status indicator ─────────────────────────────────────────────────
+        let st_y = PTITLE_H + 10;
+        let dot_x = cx + PAD; let dot_y = st_y + (CH - 8) / 2;
+        let dot_col = if self.net.connected { theme::NET_OK } else { theme::NET_FAIL };
+        s.fill_rect_rounded_aa(dot_x, dot_y, 8, 8, 4, dot_col);
+        let st_lbl = if self.net.connected { "Connected" } else { "No connection" };
+        s.draw_string(dot_x + 12, st_y, st_lbl, theme::TEXT, theme::BG);
+
+        if !self.deferred_done {
+            s.draw_string(cx + PAD, st_y + CH + 8, "Loading...", theme::TEXT_MUTED, theme::BG);
+            return;
+        }
+
+        // ── Network info card ─────────────────────────────────────────────────
+        let card1_y = st_y + CH + 16;
+        let row     = CH + 10;
+        let card1_h = 4 + row * 4 + 4;
+        self.draw_card(s, card1_y, card1_h);
+
+        let kx = cx + PAD + 10;
+        let kw = 80u32;
+        let vx = kx + kw + 4;
+        let mut ry = card1_y + 6;
+        let kv = |s: &SharedSurface, ry: u32, k: &str, v: &str| {
+            s.draw_string(kx,  ry + (CH/2).saturating_sub(0), k, theme::INFO_KEY, theme::CARD_BG);
+            s.draw_string(vx,  ry + (CH/2).saturating_sub(0), v, theme::INFO_VAL, theme::CARD_BG);
+        };
+        kv(s, ry, "IP Address",  self.net.ip_str());  ry += row;
+        kv(s, ry, "Subnet Mask", self.net.nm_str());  ry += row;
+        kv(s, ry, "Gateway",     self.net.gw_str());  ry += row;
+        kv(s, ry, "MAC",         self.net.mac_str());
+
+        // ── DNS card ─────────────────────────────────────────────────────────
+        let card2_y = card1_y + card1_h + 12;
+        let dns_btn_h: u32 = 24;
+        let card2_h   = 4 + row + 8 + dns_btn_h + 4;
+        self.draw_card(s, card2_y, card2_h);
+
+        let dns_kv_y = card2_y + 6;
+        s.draw_string(kx, dns_kv_y, "DNS Server", theme::INFO_KEY, theme::CARD_BG);
+        s.draw_string(vx, dns_kv_y, self.net.dns_str(), theme::INFO_VAL, theme::CARD_BG);
+
+        // DNS preset buttons
+        let dns_btn_y  = dns_kv_y + row + 8;
+        let dns_btn_w  = 90u32;
+        let dns_btn_g  = 8u32;
+        let presets    = ["Auto", "8.8.8.8", "1.1.1.1"];
+        let preset_dns = [self.net.auto_dns, 0x0808_0808u32, 0x0101_0101u32];
+        for (i, lbl) in presets.iter().enumerate() {
+            let bx = kx + i as u32 * (dns_btn_w + dns_btn_g);
+            let active = preset_dns[i] == self.net.dns_raw && self.net.dns_raw != 0;
+            let bg     = if active { theme::SEL_BG   } else { theme::BTN_GHOST };
+            let border = if active { theme::ACCENT    } else { theme::BORDER };
+            s.fill_rect_rounded_aa(bx, dns_btn_y, dns_btn_w, dns_btn_h, 5, bg);
+            s.draw_rect_rounded_aa(bx, dns_btn_y, dns_btn_w, dns_btn_h, 5, border);
+            let tx = bx + (dns_btn_w.saturating_sub(lbl.len() as u32 * CW)) / 2;
+            s.draw_string(tx, dns_btn_y + (dns_btn_h - CH) / 2, lbl, theme::TEXT, bg);
+        }
+
+        // ── Refresh button ────────────────────────────────────────────────────
+        let (ax, ay) = self.apply_btn();
+        let rlbl = "Refresh";
+        s.fill_rect_rounded_aa(ax, ay, BTN_W, BTN_H, 7, theme::BTN_GHOST);
+        s.draw_rect_rounded_aa(ax, ay, BTN_W, BTN_H, 7, theme::BORDER);
+        s.draw_string(ax + (BTN_W.saturating_sub(rlbl.len() as u32 * CW)) / 2,
+                      ay + (BTN_H - CH) / 2, rlbl, theme::TEXT, theme::BTN_GHOST);
+    }
+
     // ── Display Resolution page ───────────────────────────────────────────────
 
     fn draw_display_res(&self, s: &SharedSurface) {
         let cx = self.cx();
-
         self.draw_page_title(s, "Display Resolution");
-
-        // Subtitle
         let sub_y = PTITLE_H + (SEC_LBL_H - CH) / 2;
         s.draw_string(cx + PAD, sub_y, "Available Resolutions", theme::TEXT_MUTED, theme::BG);
 
         let (ltop, lh, lw, sbx) = self.res_geom();
-
         for i in 0..VIS_ROWS {
             let idx = self.scroll + i;
             if idx >= self.mcnt { break; }
@@ -840,35 +958,26 @@ impl App {
                 (theme::BG, theme::TEXT_SEC, theme::TEXT_MUTED)
             };
             s.fill_rect(cx + PAD, ry, lw, ROW_H - 1, rbg);
-            if active {
-                s.fill_rect(cx + PAD, ry, 3, ROW_H-1, theme::ACCENT);
-            }
+            if active { s.fill_rect(cx + PAD, ry, 3, ROW_H-1, theme::ACCENT); }
             let mut lb = [0u8; 24];
             let label = fmt_res(&mut lb, m.w, m.h);
             s.draw_string(cx + PAD + 8, ry+(ROW_H-CH)/2, label, fg, rbg);
             let bpp = "32bpp";
             let bx = cx + PAD + lw - bpp.len() as u32 * CW - 6;
             s.draw_string(bx, ry+(ROW_H-CH)/2, bpp, dim, rbg);
-            if !active {
-                s.fill_rect(cx + PAD + 8, ry+ROW_H-1, lw-16, 1, theme::DIVIDER);
-            }
+            if !active { s.fill_rect(cx + PAD + 8, ry+ROW_H-1, lw-16, 1, theme::DIVIDER); }
         }
-
-        // Scrollbar track + thumb
         s.fill_rect(sbx, ltop, SBW, lh, theme::SB_TRACK);
         let (ty, th, _) = self.sb_geom();
         let tc = if self.sbdrag { theme::SB_THUMB_ACT } else { theme::SB_THUMB };
         s.fill_rect_rounded_aa(sbx+1, ty, SBW-2, th, 3, tc);
 
-        // Info line below list
         if self.mcnt > 0 {
             let m = self.modes[self.sel];
             let mut ib = [0u8; 44];
             let info = fmt_info(&mut ib, m.w, m.h);
             s.draw_string(cx + PAD, ltop+lh+6, info, theme::TEXT_MUTED, theme::BG);
         }
-
-        // Buttons
         let (ax, ay) = self.apply_btn();
         let (rx, ry) = self.restore_btn();
         s.fill_rect_rounded_aa(ax, ay, BTN_W, BTN_H, 7, theme::BTN_PRIMARY);
@@ -881,69 +990,108 @@ impl App {
     }
 
     // ── About System page ─────────────────────────────────────────────────────
+    //
+    // Visual structure (inspired by macOS "About This Mac"):
+    //
+    //   [  icon – concentric ring logo  ]
+    //   Atom OS                          (prominent)
+    //   Version 0.2.0  ·  Beryllium      (subtitle)
+    //   ─────────────────────────────────
+    //   Card 1 – System
+    //     OS / Kernel / Architecture
+    //   Card 2 – Hardware
+    //     Processor / Cores / Memory
+    //   Card 3 – Runtime
+    //     Uptime / IP Address
 
     fn draw_about(&self, s: &SharedSurface) {
-        const OS_NAME: &str = "Atom OS";
-        const OS_VER:  &str = "0.2.0";
-        const OS_CODE: &str = "Beryllium";
-        const KERN:    &str = "0.2.0-smp-microkernel";
-
-        let cx = self.cx();
-        let cw = self.cw();
-        let kw = 100u32;       // key column width
-        let vx = cx + PAD + kw + 8;  // value column x
+        let cx  = self.cx();
+        let cw  = self.cw();
 
         self.draw_page_title(s, "About System");
 
-        let row  = 22u32;
-        let mut y = PTITLE_H + 10;
+        // ── Logo icon (concentric rings) ──────────────────────────────────────
+        let icon_cx = cx + cw / 2;
+        let icon_y  = PTITLE_H + 10;
+        let ic      = icon_cx; let iy = icon_y + ICON_R;
 
-        macro_rules! kv {
-            ($k:expr, $v:expr) => {{
-                s.draw_string(cx + PAD, y, $k, theme::INFO_KEY, theme::BG);
-                s.draw_string(vx, y, $v, theme::INFO_VAL, theme::BG);
-                y += row;
-            }};
-        }
-        macro_rules! sep {
-            () => {{
-                y += 4;
-                s.fill_rect(cx + PAD, y, cw.saturating_sub(PAD*2), 1, theme::DIVIDER);
-                y += 8;
-            }};
-        }
+        // Outer ring
+        s.draw_rect_rounded_aa(ic.saturating_sub(ICON_R), iy.saturating_sub(ICON_R),
+                               ICON_R*2, ICON_R*2, ICON_R, theme::ACCENT_DIM);
+        // Middle ring
+        let mr = ICON_R * 2 / 3;
+        s.draw_rect_rounded_aa(ic.saturating_sub(mr), iy.saturating_sub(mr),
+                               mr*2, mr*2, mr, theme::ACCENT_DIM);
+        // Nucleus
+        let nr = ICON_R / 4;
+        s.fill_rect_rounded_aa(ic.saturating_sub(nr), iy.saturating_sub(nr),
+                               nr*2, nr*2, nr, theme::ACCENT);
 
-        kv!("OS Name",      OS_NAME);
-        let mut vb = [0u8; 32];
-        let vl = {
-            let mut p=0usize;
-            for b in OS_VER.bytes() { vb[p]=b; p+=1; }
-            vb[p]=b' '; p+=1; vb[p]=b'('; p+=1;
-            for b in OS_CODE.bytes() { if p<31 { vb[p]=b; p+=1; } }
-            if p<31 { vb[p]=b')'; p+=1; }
-            p
+        // ── OS name ───────────────────────────────────────────────────────────
+        let name_y = icon_y + ICON_R * 2 + 12;
+        let name   = "Atom OS";
+        // Draw twice with 1 px horizontal offset for pseudo-bold
+        let nx = cx + (cw.saturating_sub(name.len() as u32 * CW)) / 2;
+        s.draw_string(nx + 1, name_y, name, theme::TEXT, theme::BG);
+        s.draw_string(nx,     name_y, name, theme::TEXT, theme::BG);
+
+        // Version + codename
+        let sub = "v0.2.0  Beryllium";
+        let sx  = cx + (cw.saturating_sub(sub.len() as u32 * CW)) / 2;
+        s.draw_string(sx, name_y + CH + 6, sub, theme::TEXT_SEC, theme::BG);
+
+        // Thin divider
+        let div_y = name_y + CH * 2 + 18;
+        s.fill_rect(cx + PAD, div_y, cw.saturating_sub(PAD*2), 1, theme::DIVIDER);
+
+        // ── Info cards ────────────────────────────────────────────────────────
+        let row  = CH + 8;
+        let kw   = 90u32;
+        let voff = kw + 8;
+
+        let mut y = div_y + 10;
+
+        // Helper closures use shared references – capture as parameters instead.
+        let draw_kv = |s: &SharedSurface, y: u32, bg: Color, kx: u32, vx: u32, k: &str, v: &str| {
+            s.draw_string(kx, y, k, theme::INFO_KEY, bg);
+            s.draw_string(vx, y, v, theme::INFO_VAL, bg);
         };
-        kv!("Version",       core::str::from_utf8(&vb[..vl]).unwrap_or(OS_VER));
-        kv!("Kernel",        KERN);
-        kv!("Architecture",  "x86_64");
-        sep!();
 
-        // Processor – may be long, truncate to fit
+        // Card 1 – System
+        let c1h = 4 + row * 3 + 2;
+        self.draw_card(s, y, c1h);
+        let kx = cx + PAD + 10; let vx = kx + voff;
+        let mut ry = y + 6;
+        draw_kv(s, ry, theme::CARD_BG, kx, vx, "OS",           "Atom OS 0.2.0");  ry += row;
+        draw_kv(s, ry, theme::CARD_BG, kx, vx, "Kernel",       "0.2.0-smp");      ry += row;
+        draw_kv(s, ry, theme::CARD_BG, kx, vx, "Architecture", "x86_64");
+        y += c1h + 8;
+
+        // Card 2 – Hardware
         let cpu_raw = self.sinfo.cpu();
-        let max_chars = ((cx + cw).saturating_sub(vx + PAD) / CW) as usize;
-        let cpu = if cpu_raw.len() > max_chars { &cpu_raw[..max_chars] } else { cpu_raw };
-        kv!("Processor",    cpu);
-        let mut cb=[0u8;8]; let cl=fmt_u64(&mut cb, self.sinfo.cores);
-        kv!("CPU Cores",    core::str::from_utf8(&cb[..cl]).unwrap_or("?"));
-        sep!();
+        let max_c   = (self.cw().saturating_sub(PAD * 2 + 10 + voff + PAD) / CW) as usize;
+        let cpu     = if cpu_raw.len() > max_c { &cpu_raw[..max_c] } else { cpu_raw };
+        let mut cb = [0u8; 8]; let cl = fmt_u64(&mut cb, self.sinfo.cores);
+        let cores_str = core::str::from_utf8(&cb[..cl]).unwrap_or("?");
+        let mut mb = [0u8; 48];
+        let ml = fmt_mem(&mut mb, self.sinfo.mem_used, self.sinfo.mem_total);
+        let mem_str = core::str::from_utf8(&mb[..ml]).unwrap_or("?");
 
-        let mut mb=[0u8;48];
-        let ml=fmt_mem(&mut mb, self.sinfo.mem_used, self.sinfo.mem_total);
-        kv!("Memory",       core::str::from_utf8(&mb[..ml]).unwrap_or("?"));
-        kv!("Uptime",       self.sinfo.uptime());
-        sep!();
+        let c2h = 4 + row * 3 + 2;
+        self.draw_card(s, y, c2h);
+        ry = y + 6;
+        draw_kv(s, ry, theme::CARD_BG, kx, vx, "Processor", cpu);          ry += row;
+        draw_kv(s, ry, theme::CARD_BG, kx, vx, "CPU Cores", cores_str);    ry += row;
+        draw_kv(s, ry, theme::CARD_BG, kx, vx, "Memory",    mem_str);
+        y += c2h + 8;
 
-        kv!("IP Address",   self.sinfo.ip());
+        // Card 3 – Runtime
+        let c3h = 4 + row * 2 + 2;
+        self.draw_card(s, y, c3h);
+        ry = y + 6;
+        let ip = if self.net.connected { self.net.ip_str() } else { "unavailable" };
+        draw_kv(s, ry, theme::CARD_BG, kx, vx, "Uptime",     self.sinfo.uptime()); ry += row;
+        draw_kv(s, ry, theme::CARD_BG, kx, vx, "IP Address", ip);
     }
 
     // ── Status bar ────────────────────────────────────────────────────────────
@@ -953,16 +1101,18 @@ impl App {
         s.fill_rect(0, sy, self.sw, STAT_H, theme::HDR_BG);
         s.fill_rect(0, sy, self.sw, 1, theme::BORDER);
         let ty = sy + (STAT_H - CH) / 2;
+        let base_x = SIDEBAR_W + 1 + PAD;
         if self.status.kind != StatusKind::None {
             let col = if self.status.kind == StatusKind::Ok { theme::SUCCESS } else { theme::WARNING };
-            s.draw_string(SIDEBAR_W + 1 + PAD, ty, self.status.as_str(), col, theme::HDR_BG);
+            s.draw_string(base_x, ty, self.status.as_str(), col, theme::HDR_BG);
         } else {
             let hint = match self.page {
                 Page::DesktopBg  => "Select color or image, then Apply",
+                Page::Network    => "Network configuration  |  Click a DNS preset to switch",
                 Page::DisplayRes => "Select resolution, then Apply  |  R to restore default",
                 Page::AboutSys   => "Atom OS System Information",
             };
-            s.draw_string(SIDEBAR_W + 1 + PAD, ty, hint, theme::TEXT_MUTED, theme::HDR_BG);
+            s.draw_string(base_x, ty, hint, theme::TEXT_MUTED, theme::HDR_BG);
         }
     }
 
@@ -985,7 +1135,7 @@ impl App {
             b'\n'|b'\r' => match self.page {
                 Page::DesktopBg  => self.apply_wallpaper(),
                 Page::DisplayRes => self.apply_resolution(),
-                Page::AboutSys   => {}
+                _ => {}
             },
             b'r'|b'R' if self.page == Page::DisplayRes => self.restore_default(),
             _ => {}
@@ -993,24 +1143,21 @@ impl App {
     }
 
     fn on_mouse_down(&mut self, mx: i32, my: i32) {
-        // Sidebar navigation
         if let Some(pg) = self.nav_hit(mx, my) {
             self.page = pg; self.dirty = true; return;
         }
-        // Content area
         match self.page {
             Page::DesktopBg  => self.on_wp_click(mx, my),
+            Page::Network    => self.on_net_click(mx, my),
             Page::DisplayRes => self.on_res_click(mx, my),
             Page::AboutSys   => {}
         }
     }
 
     fn on_wp_click(&mut self, mx: i32, my: i32) {
-        // Apply button
         let (ax, ay) = self.apply_btn();
         if in_rect(mx, my, ax, ay, BTN_W, BTN_H) { self.apply_wallpaper(); return; }
 
-        // Mode toggle
         let ty = self.wp_toggle_y();
         let x0 = self.cx() + PAD;
         if in_rect(mx, my, x0 + 2, ty, MTOG_W, MTOG_H) {
@@ -1030,7 +1177,6 @@ impl App {
                 }
             }
             WpMode::Image => {
-                // Scaling buttons
                 let smodes = [ScalingMode::Fill, ScalingMode::Fit, ScalingMode::Stretch,
                               ScalingMode::Center, ScalingMode::Tile];
                 for (i, mode) in smodes.iter().enumerate() {
@@ -1039,7 +1185,6 @@ impl App {
                         self.wp.scaling = *mode; self.dirty = true; return;
                     }
                 }
-                // Image tiles
                 let start = self.wpscr;
                 let end = (start + 2 * TCOLS).min(self.wp.images.len());
                 for idx in start..end {
@@ -1052,18 +1197,57 @@ impl App {
         }
     }
 
+    fn on_net_click(&mut self, mx: i32, my: i32) {
+        // Refresh button
+        let (ax, ay) = self.apply_btn();
+        if in_rect(mx, my, ax, ay, BTN_W, BTN_H) {
+            self.net.refresh();
+            self.last_refresh = get_ticks();
+            self.status.set(StatusKind::Ok, b"Network info refreshed.");
+            self.dirty = true;
+            return;
+        }
+
+        if !self.deferred_done { return; }
+
+        // DNS preset buttons (same geometry as in draw_network)
+        let cx   = self.cx();
+        let st_y = PTITLE_H + 10;
+        let row  = (CH + 10) as u32;
+        let card1_y = st_y + CH + 16;
+        let card1_h = 4 + row * 4 + 4;
+        let card2_y = card1_y + card1_h + 12;
+        let dns_kv_y = card2_y + 6;
+        let dns_btn_y = dns_kv_y + row + 8;
+        let dns_btn_w = 90u32; let dns_btn_h = 24u32; let dns_btn_g = 8u32;
+        let kx = cx + PAD + 10;
+
+        let presets    = [self.net.auto_dns, 0x0808_0808u32, 0x0101_0101u32];
+        for (i, &dns) in presets.iter().enumerate() {
+            let bx = kx + i as u32 * (dns_btn_w + dns_btn_g);
+            if in_rect(mx, my, bx, dns_btn_y, dns_btn_w, dns_btn_h) {
+                if dns == 0 { return; } // Auto DNS not yet known
+                self.net.set_dns(dns);
+                // Small delay then refresh to confirm
+                self.net.refresh();
+                self.last_refresh = get_ticks();
+                self.status.set(StatusKind::Ok, b"DNS updated.");
+                self.dirty = true;
+                return;
+            }
+        }
+    }
+
     fn on_res_click(&mut self, mx: i32, my: i32) {
         let (ltop, lh, lw, sbx) = self.res_geom();
         let (ty, th, _) = self.sb_geom();
         let cx = self.cx();
 
-        // Apply / Restore buttons
         let (ax, ay) = self.apply_btn();
         let (rx, ry) = self.restore_btn();
         if in_rect(mx, my, ax, ay, BTN_W, BTN_H) { self.apply_resolution(); return; }
         if in_rect(mx, my, rx, ry, RBTN_W, BTN_H) { self.restore_default(); return; }
 
-        // Scrollbar
         if in_rect(mx, my, sbx, ltop, SBW, lh) {
             if in_rect(mx, my, sbx, ty, SBW, th) {
                 self.sbdrag = true; self.sboff = my - ty as i32;
@@ -1074,8 +1258,6 @@ impl App {
             }
             self.dirty = true; return;
         }
-
-        // Mode rows
         if in_rect(mx, my, cx + PAD, ltop, lw, lh) {
             let row = ((my - ltop as i32) / ROW_H as i32) as usize;
             let idx = self.scroll + row;
@@ -1088,7 +1270,6 @@ impl App {
             self.set_scroll_from_drag(my - self.sboff);
         }
     }
-
     fn on_mouse_up(&mut self) {
         if self.sbdrag { self.sbdrag = false; self.dirty = true; }
     }
@@ -1104,7 +1285,7 @@ impl App {
                 if dz > 0 { self.scroll = self.scroll.saturating_sub(steps); }
                 else { let max=self.mcnt.saturating_sub(VIS_ROWS); self.scroll=(self.scroll+steps).min(max); }
             }
-            Page::AboutSys => {}
+            _ => {}
         }
         self.dirty = true;
     }
@@ -1147,6 +1328,7 @@ impl App {
                 if let Some(m) = OpenInTabMsg::from_bytes(pay) {
                     self.page = match m.tab_name.as_str() {
                         "Desktop Background"|"Wallpaper"     => Page::DesktopBg,
+                        "Network"                            => Page::Network,
                         "Display Resolution"|"Resolution"    => Page::DisplayRes,
                         "About System"                       => Page::AboutSys,
                         _ => return,
@@ -1173,14 +1355,22 @@ impl App {
     }
 
     fn run(&mut self) {
+        // Render the first empty frame immediately so the window appears fast.
         self.render();
+
+        // Now do the expensive init (network IPC, filesystem scan) with short
+        // timeouts. The window is already visible, so any delay here is hidden.
+        self.deferred_init();
+        self.render();
+
         let mut buf = [0u8; 128];
         let ports = [self.lport];
         while self.alive {
             while let Ok(Some(len)) = try_recv(self.lport, &mut buf) { self.on_msg(&buf, len); }
-            self.status.tick();
+            if self.status.tick() { self.dirty = true; }
+            self.maybe_refresh();
             if self.dirty { self.render(); }
-            let _ = wait_any(&ports, 16);
+            let _ = wait_any(&ports, 32); // 32 ms ≈ 30 fps ceiling; settings panel not a game
         }
     }
 
@@ -1227,6 +1417,39 @@ fn fmt_u64(buf: &mut [u8], mut n: u64) -> usize {
     cnt
 }
 
+fn fmt_uptime(buf: &mut [u8; 32]) -> usize {
+    let s = get_ticks() / 100;
+    let h = s / 3600; let m = (s % 3600) / 60; let ss = s % 60;
+    let mut p = 0usize;
+    p += fmt_u64(&mut buf[p..], h); buf[p]=b'h'; p+=1; buf[p]=b' '; p+=1;
+    if m<10 { buf[p]=b'0'; p+=1; }
+    p += fmt_u64(&mut buf[p..], m); buf[p]=b'm'; p+=1; buf[p]=b' '; p+=1;
+    if ss<10 { buf[p]=b'0'; p+=1; }
+    p += fmt_u64(&mut buf[p..], ss); buf[p]=b's'; p+=1;
+    p
+}
+
+fn fmt_ipv4(buf: &mut [u8; 20], ip: u32) -> usize {
+    let b = ip.to_be_bytes();
+    let mut p = 0usize;
+    p += fmt_u64(&mut buf[p..], b[0] as u64); buf[p]=b'.'; p+=1;
+    p += fmt_u64(&mut buf[p..], b[1] as u64); buf[p]=b'.'; p+=1;
+    p += fmt_u64(&mut buf[p..], b[2] as u64); buf[p]=b'.'; p+=1;
+    p += fmt_u64(&mut buf[p..], b[3] as u64);
+    p
+}
+
+fn fmt_mac(buf: &mut [u8; 20], mac: &[u8; 6]) -> usize {
+    const HEX: &[u8] = b"0123456789ABCDEF";
+    let mut p = 0usize;
+    for (i, &b) in mac.iter().enumerate() {
+        buf[p] = HEX[(b >> 4) as usize]; p+=1;
+        buf[p] = HEX[(b & 0xF) as usize]; p+=1;
+        if i < 5 { buf[p] = b':'; p+=1; }
+    }
+    p
+}
+
 fn fmt_res<'a>(buf: &'a mut [u8; 24], w: u16, h: u16) -> &'a str {
     let mut p = 0usize;
     p += fmt_u64(&mut buf[p..], w as u64);
@@ -1245,11 +1468,11 @@ fn fmt_info<'a>(buf: &'a mut [u8; 44], w: u16, h: u16) -> &'a str {
 }
 
 fn fmt_mem(buf: &mut [u8; 48], used: u64, total: u64) -> usize {
-    let mut p=0;
-    p+=fmt_u64(&mut buf[p..], used/1024);
-    let mid=b" MB used / "; for b in mid { buf[p]=*b; p+=1; }
-    p+=fmt_u64(&mut buf[p..], total/1024);
-    let suf=b" MB total"; for b in suf { buf[p]=*b; p+=1; }
+    let mut p = 0;
+    p += fmt_u64(&mut buf[p..], used/1024);
+    let mid=b" MB / "; for b in mid { buf[p]=*b; p+=1; }
+    p += fmt_u64(&mut buf[p..], total/1024);
+    let suf=b" MB"; for b in suf { buf[p]=*b; p+=1; }
     p
 }
 
@@ -1257,6 +1480,44 @@ fn fit_in(sw: u32, sh: u32, mw: u32, mh: u32) -> (u32, u32) {
     if sw==0||sh==0||mw==0||mh==0 { return (1,1); }
     let s = ((mw as u64*1024)/sw as u64).min((mh as u64*1024)/sh as u64).max(1);
     (((sw as u64*s)/1024).max(1) as u32, ((sh as u64*s)/1024).max(1) as u32)
+}
+
+// Network config query with a short 500 ms timeout so startup is not blocked.
+fn query_net_fast() -> Option<libnet::config::NetworkConfig> {
+    let netd_port = libipc::protocol::lookup_service("netd").ok()?;
+    let reply_port = atom_syscall::ipc::create_port().ok()?;
+
+    let msg = NetGetConfigMsg { reply_port: reply_port as u64 };
+    if send_message(netd_port, MessageType::NetGetConfig, &msg.to_bytes()).is_err() {
+        let _ = atom_syscall::ipc::close_port(reply_port);
+        return None;
+    }
+    match atom_syscall::ipc::wait_any(&[reply_port], 500) {
+        Ok(_) => {
+            let mut buf = [0u8; 64];
+            if let Ok(len) = atom_syscall::ipc::recv(reply_port, &mut buf) {
+                if let Some(hdr) = MessageHeader::from_bytes(&buf) {
+                    if hdr.msg_type == MessageType::NetGetConfigReply {
+                        let payload = get_payload(&buf, len);
+                        if let Some(reply) = NetGetConfigReplyMsg::from_bytes(payload) {
+                            let _ = atom_syscall::ipc::close_port(reply_port);
+                            use libnet::IpAddr;
+                            return Some(libnet::config::NetworkConfig {
+                                ip:      IpAddr::from_u32(reply.own_ip),
+                                netmask: IpAddr::from_u32(reply.netmask),
+                                gateway: IpAddr::from_u32(reply.gateway),
+                                dns:     IpAddr::from_u32(reply.dns_server),
+                                mac:     reply.mac,
+                            });
+                        }
+                    }
+                }
+            }
+            let _ = atom_syscall::ipc::close_port(reply_port);
+            None
+        }
+        _ => { let _ = atom_syscall::ipc::close_port(reply_port); None }
+    }
 }
 
 fn query_modes() -> ([Mode; VIDEO_MAX_MODES], usize) {

--- a/userspace/system_apps/system_settings/src/main.rs
+++ b/userspace/system_apps/system_settings/src/main.rs
@@ -164,6 +164,9 @@ const BTN_H:  u32 = 28;
 const BTN_W:  u32 = 90;
 const RBTN_W: u32 = 128;
 
+// Info card key column — wide enough for "Architecture" (12 × 8 px = 96 px) + gap
+const INFO_KW: u32 = 112;
+
 // About page icon size
 const ICON_R: u32 = 28;  // outer icon radius
 
@@ -369,12 +372,15 @@ struct SysInfo {
     cpu_buf: [u8; 64], cpu_len: usize,
     cores:   u64,
     mem_total: u64, mem_used: u64,
+    storage_total: u64, storage_used: u64,
     up_buf:  [u8; 32], up_len: usize,
 }
 impl SysInfo {
     fn empty() -> Self {
         Self { cpu_buf: [0;64], cpu_len: 0, cores: 0,
-               mem_total: 0, mem_used: 0, up_buf: [0;32], up_len: 0 }
+               mem_total: 0, mem_used: 0,
+               storage_total: 0, storage_used: 0,
+               up_buf: [0;32], up_len: 0 }
     }
     fn collect_static(&mut self) {
         self.cpu_len = get_cpu_brand(&mut self.cpu_buf);
@@ -382,6 +388,11 @@ impl SysInfo {
         let (total, free) = get_memory_info();
         self.mem_total = total;
         self.mem_used  = total.saturating_sub(free);
+        if let Ok(sv) = atom_syscall::fs::statvfs("/") {
+            let bs = sv.frsize.max(sv.bsize).max(512);
+            self.storage_total = sv.blocks.saturating_mul(bs);
+            self.storage_used  = sv.blocks.saturating_sub(sv.bfree).saturating_mul(bs);
+        }
     }
     fn refresh_uptime(&mut self) {
         self.up_len = fmt_uptime(&mut self.up_buf);
@@ -859,10 +870,25 @@ impl App {
     //
     // Layout:
     //   Page title
-    //   Status bar (dot + text: Connected / No connection)
-    //   Card: IP / Netmask / Gateway / MAC
-    //   DNS card: current DNS + three preset buttons [Auto] [8.8.8.8] [1.1.1.1]
+    //   Status indicator (dot + "Connected" / "No connection")
+    //   Card 1 – Connection: IP / Subnet Mask / Gateway
+    //   Card 2 – DNS: current server + preset buttons [Auto] [8.8.8.8] [1.1.1.1]
+    //   Card 3 – Hardware: Interface / Type / MAC / Link
     //   [Refresh] button (bottom-right)
+    //
+    // net_dns_btn_geom() centralises the DNS button positions so draw and click
+    // share exactly the same geometry.
+
+    fn net_dns_btn_geom(&self) -> (u32, u32, u32, u32, u32) {
+        let st_y    = PTITLE_H + 10;
+        let row     = CH + 10;
+        let card1_h = 4 + row * 3 + 4;   // 3 rows: IP, Mask, GW
+        let card2_y = st_y + CH + 16 + card1_h + 12;
+        let dns_kv_y = card2_y + 6;
+        let btn_y    = dns_kv_y + row + 8;
+        let kx       = self.cx() + PAD + 10;
+        (kx, btn_y, 90, 24, 8) // (kx, btn_y, btn_w, btn_h, btn_gap)
+    }
 
     fn draw_network(&self, s: &SharedSurface) {
         let cx = self.cx();
@@ -870,10 +896,10 @@ impl App {
         self.draw_page_title(s, "Network");
 
         // ── Status indicator ─────────────────────────────────────────────────
-        let st_y = PTITLE_H + 10;
-        let dot_x = cx + PAD; let dot_y = st_y + (CH - 8) / 2;
+        let st_y  = PTITLE_H + 10;
+        let dot_x = cx + PAD;
         let dot_col = if self.net.connected { theme::NET_OK } else { theme::NET_FAIL };
-        s.fill_rect_rounded_aa(dot_x, dot_y, 8, 8, 4, dot_col);
+        s.fill_rect_rounded_aa(dot_x, st_y, 8, 8, 4, dot_col);
         let st_lbl = if self.net.connected { "Connected" } else { "No connection" };
         s.draw_string(dot_x + 12, st_y, st_lbl, theme::TEXT, theme::BG);
 
@@ -882,51 +908,55 @@ impl App {
             return;
         }
 
-        // ── Network info card ─────────────────────────────────────────────────
-        let card1_y = st_y + CH + 16;
-        let row     = CH + 10;
-        let card1_h = 4 + row * 4 + 4;
-        self.draw_card(s, card1_y, card1_h);
+        let row = CH + 10;
+        let kx  = cx + PAD + 10;
+        let vx  = kx + INFO_KW + 8;
 
-        let kx = cx + PAD + 10;
-        let kw = 80u32;
-        let vx = kx + kw + 4;
-        let mut ry = card1_y + 6;
-        let kv = |s: &SharedSurface, ry: u32, k: &str, v: &str| {
-            s.draw_string(kx,  ry + (CH/2).saturating_sub(0), k, theme::INFO_KEY, theme::CARD_BG);
-            s.draw_string(vx,  ry + (CH/2).saturating_sub(0), v, theme::INFO_VAL, theme::CARD_BG);
+        let kv = |s: &SharedSurface, y: u32, k: &str, v: &str| {
+            s.draw_string(kx, y, k, theme::INFO_KEY,  theme::CARD_BG);
+            s.draw_string(vx, y, v, theme::INFO_VAL, theme::CARD_BG);
         };
+
+        // ── Card 1 – Connection ──────────────────────────────────────────────
+        let card1_y = st_y + CH + 16;
+        let card1_h = 4 + row * 3 + 4;
+        self.draw_card(s, card1_y, card1_h);
+        let mut ry = card1_y + 6;
         kv(s, ry, "IP Address",  self.net.ip_str());  ry += row;
         kv(s, ry, "Subnet Mask", self.net.nm_str());  ry += row;
-        kv(s, ry, "Gateway",     self.net.gw_str());  ry += row;
-        kv(s, ry, "MAC",         self.net.mac_str());
+        kv(s, ry, "Gateway",     self.net.gw_str());
 
-        // ── DNS card ─────────────────────────────────────────────────────────
+        // ── Card 2 – DNS ─────────────────────────────────────────────────────
         let card2_y = card1_y + card1_h + 12;
-        let dns_btn_h: u32 = 24;
-        let card2_h   = 4 + row + 8 + dns_btn_h + 4;
+        let (_, dns_btn_y, dns_btn_w, dns_btn_h, dns_btn_g) = self.net_dns_btn_geom();
+        let card2_h = 4 + row + 8 + dns_btn_h + 4;
         self.draw_card(s, card2_y, card2_h);
 
         let dns_kv_y = card2_y + 6;
-        s.draw_string(kx, dns_kv_y, "DNS Server", theme::INFO_KEY, theme::CARD_BG);
-        s.draw_string(vx, dns_kv_y, self.net.dns_str(), theme::INFO_VAL, theme::CARD_BG);
+        kv(s, dns_kv_y, "DNS Server", self.net.dns_str());
 
-        // DNS preset buttons
-        let dns_btn_y  = dns_kv_y + row + 8;
-        let dns_btn_w  = 90u32;
-        let dns_btn_g  = 8u32;
         let presets    = ["Auto", "8.8.8.8", "1.1.1.1"];
         let preset_dns = [self.net.auto_dns, 0x0808_0808u32, 0x0101_0101u32];
         for (i, lbl) in presets.iter().enumerate() {
             let bx = kx + i as u32 * (dns_btn_w + dns_btn_g);
             let active = preset_dns[i] == self.net.dns_raw && self.net.dns_raw != 0;
-            let bg     = if active { theme::SEL_BG   } else { theme::BTN_GHOST };
-            let border = if active { theme::ACCENT    } else { theme::BORDER };
+            let bg     = if active { theme::SEL_BG  } else { theme::BTN_GHOST };
+            let border = if active { theme::ACCENT   } else { theme::BORDER };
             s.fill_rect_rounded_aa(bx, dns_btn_y, dns_btn_w, dns_btn_h, 5, bg);
             s.draw_rect_rounded_aa(bx, dns_btn_y, dns_btn_w, dns_btn_h, 5, border);
             let tx = bx + (dns_btn_w.saturating_sub(lbl.len() as u32 * CW)) / 2;
             s.draw_string(tx, dns_btn_y + (dns_btn_h - CH) / 2, lbl, theme::TEXT, bg);
         }
+
+        // ── Card 3 – Hardware ────────────────────────────────────────────────
+        let card3_y = card2_y + card2_h + 12;
+        let card3_h = 4 + row * 4 + 4;
+        self.draw_card(s, card3_y, card3_h);
+        ry = card3_y + 6;
+        kv(s, ry, "Interface", "eth0");                                                 ry += row;
+        kv(s, ry, "Type",      "Ethernet");                                             ry += row;
+        kv(s, ry, "MAC",       self.net.mac_str());                                     ry += row;
+        kv(s, ry, "Link",      if self.net.connected { "Up" } else { "Down" });
 
         // ── Refresh button ────────────────────────────────────────────────────
         let (ax, ay) = self.apply_btn();
@@ -1005,93 +1035,79 @@ impl App {
     //     Uptime / IP Address
 
     fn draw_about(&self, s: &SharedSurface) {
-        let cx  = self.cx();
-        let cw  = self.cw();
+        let cx = self.cx();
+        let cw = self.cw();
 
         self.draw_page_title(s, "About System");
 
         // ── Logo icon (concentric rings) ──────────────────────────────────────
         let icon_cx = cx + cw / 2;
         let icon_y  = PTITLE_H + 10;
-        let ic      = icon_cx; let iy = icon_y + ICON_R;
-
-        // Outer ring
+        let ic = icon_cx; let iy = icon_y + ICON_R;
         s.draw_rect_rounded_aa(ic.saturating_sub(ICON_R), iy.saturating_sub(ICON_R),
                                ICON_R*2, ICON_R*2, ICON_R, theme::ACCENT_DIM);
-        // Middle ring
         let mr = ICON_R * 2 / 3;
         s.draw_rect_rounded_aa(ic.saturating_sub(mr), iy.saturating_sub(mr),
                                mr*2, mr*2, mr, theme::ACCENT_DIM);
-        // Nucleus
         let nr = ICON_R / 4;
         s.fill_rect_rounded_aa(ic.saturating_sub(nr), iy.saturating_sub(nr),
                                nr*2, nr*2, nr, theme::ACCENT);
 
         // ── OS name ───────────────────────────────────────────────────────────
         let name_y = icon_y + ICON_R * 2 + 12;
-        let name   = "Atom OS";
-        // Draw twice with 1 px horizontal offset for pseudo-bold
+        let name = "Atom OS";
         let nx = cx + (cw.saturating_sub(name.len() as u32 * CW)) / 2;
         s.draw_string(nx + 1, name_y, name, theme::TEXT, theme::BG);
         s.draw_string(nx,     name_y, name, theme::TEXT, theme::BG);
-
-        // Version + codename
         let sub = "v0.2.0  Beryllium";
-        let sx  = cx + (cw.saturating_sub(sub.len() as u32 * CW)) / 2;
+        let sx = cx + (cw.saturating_sub(sub.len() as u32 * CW)) / 2;
         s.draw_string(sx, name_y + CH + 6, sub, theme::TEXT_SEC, theme::BG);
 
-        // Thin divider
         let div_y = name_y + CH * 2 + 18;
         s.fill_rect(cx + PAD, div_y, cw.saturating_sub(PAD*2), 1, theme::DIVIDER);
 
         // ── Info cards ────────────────────────────────────────────────────────
+        // INFO_KW ensures the key column is wide enough for "Architecture"
+        // (12 chars × 8 px = 96 px) with a comfortable gap before the value.
         let row  = CH + 8;
-        let kw   = 90u32;
-        let voff = kw + 8;
-
+        let kx   = cx + PAD + 10;
+        let vx   = kx + INFO_KW + 8;
+        let max_c = (cw.saturating_sub(PAD * 2 + 10 + INFO_KW + 8 + PAD) / CW) as usize;
         let mut y = div_y + 10;
 
-        // Helper closures use shared references – capture as parameters instead.
-        let draw_kv = |s: &SharedSurface, y: u32, bg: Color, kx: u32, vx: u32, k: &str, v: &str| {
-            s.draw_string(kx, y, k, theme::INFO_KEY, bg);
-            s.draw_string(vx, y, v, theme::INFO_VAL, bg);
+        let kv = |s: &SharedSurface, y: u32, k: &str, v: &str| {
+            s.draw_string(kx, y, k, theme::INFO_KEY,  theme::CARD_BG);
+            s.draw_string(vx, y, v, theme::INFO_VAL, theme::CARD_BG);
         };
 
         // Card 1 – System
-        let c1h = 4 + row * 3 + 2;
-        self.draw_card(s, y, c1h);
-        let kx = cx + PAD + 10; let vx = kx + voff;
+        self.draw_card(s, y, 4 + row * 3 + 2);
         let mut ry = y + 6;
-        draw_kv(s, ry, theme::CARD_BG, kx, vx, "OS",           "Atom OS 0.2.0");  ry += row;
-        draw_kv(s, ry, theme::CARD_BG, kx, vx, "Kernel",       "0.2.0-smp");      ry += row;
-        draw_kv(s, ry, theme::CARD_BG, kx, vx, "Architecture", "x86_64");
-        y += c1h + 8;
+        kv(s, ry, "OS",           "Atom OS 0.2.0"); ry += row;
+        kv(s, ry, "Kernel",       "0.2.0-smp");     ry += row;
+        kv(s, ry, "Architecture", "x86_64");
+        y += 4 + row * 3 + 2 + 8;
 
         // Card 2 – Hardware
         let cpu_raw = self.sinfo.cpu();
-        let max_c   = (self.cw().saturating_sub(PAD * 2 + 10 + voff + PAD) / CW) as usize;
-        let cpu     = if cpu_raw.len() > max_c { &cpu_raw[..max_c] } else { cpu_raw };
-        let mut cb = [0u8; 8]; let cl = fmt_u64(&mut cb, self.sinfo.cores);
-        let cores_str = core::str::from_utf8(&cb[..cl]).unwrap_or("?");
-        let mut mb = [0u8; 48];
-        let ml = fmt_mem(&mut mb, self.sinfo.mem_used, self.sinfo.mem_total);
-        let mem_str = core::str::from_utf8(&mb[..ml]).unwrap_or("?");
-
-        let c2h = 4 + row * 3 + 2;
-        self.draw_card(s, y, c2h);
+        let cpu = if cpu_raw.len() > max_c { &cpu_raw[..max_c] } else { cpu_raw };
+        let mut cb = [0u8;  8]; let cl = fmt_u64(&mut cb, self.sinfo.cores);
+        let mut mb = [0u8; 48]; let ml = fmt_mem(&mut mb, self.sinfo.mem_used, self.sinfo.mem_total);
+        let mut sb = [0u8; 48]; let sl = fmt_storage(&mut sb, self.sinfo.storage_used, self.sinfo.storage_total);
+        self.draw_card(s, y, 4 + row * 4 + 2);
         ry = y + 6;
-        draw_kv(s, ry, theme::CARD_BG, kx, vx, "Processor", cpu);          ry += row;
-        draw_kv(s, ry, theme::CARD_BG, kx, vx, "CPU Cores", cores_str);    ry += row;
-        draw_kv(s, ry, theme::CARD_BG, kx, vx, "Memory",    mem_str);
-        y += c2h + 8;
+        kv(s, ry, "Processor", cpu);                                                         ry += row;
+        kv(s, ry, "CPU Cores", core::str::from_utf8(&cb[..cl]).unwrap_or("?"));              ry += row;
+        kv(s, ry, "Memory",    core::str::from_utf8(&mb[..ml]).unwrap_or("?"));              ry += row;
+        kv(s, ry, "Storage",   core::str::from_utf8(&sb[..sl]).unwrap_or("?"));
+        y += 4 + row * 4 + 2 + 8;
 
         // Card 3 – Runtime
-        let c3h = 4 + row * 2 + 2;
-        self.draw_card(s, y, c3h);
-        ry = y + 6;
         let ip = if self.net.connected { self.net.ip_str() } else { "unavailable" };
-        draw_kv(s, ry, theme::CARD_BG, kx, vx, "Uptime",     self.sinfo.uptime()); ry += row;
-        draw_kv(s, ry, theme::CARD_BG, kx, vx, "IP Address", ip);
+        self.draw_card(s, y, 4 + row * 2 + 2);
+        ry = y + 6;
+        kv(s, ry, "Uptime",     self.sinfo.uptime()); ry += row;
+        kv(s, ry, "IP Address", ip);
     }
 
     // ── Status bar ────────────────────────────────────────────────────────────
@@ -1210,17 +1226,8 @@ impl App {
 
         if !self.deferred_done { return; }
 
-        // DNS preset buttons (same geometry as in draw_network)
-        let cx   = self.cx();
-        let st_y = PTITLE_H + 10;
-        let row  = (CH + 10) as u32;
-        let card1_y = st_y + CH + 16;
-        let card1_h = 4 + row * 4 + 4;
-        let card2_y = card1_y + card1_h + 12;
-        let dns_kv_y = card2_y + 6;
-        let dns_btn_y = dns_kv_y + row + 8;
-        let dns_btn_w = 90u32; let dns_btn_h = 24u32; let dns_btn_g = 8u32;
-        let kx = cx + PAD + 10;
+        // DNS preset buttons — delegate geometry to the same helper draw_network uses.
+        let (kx, dns_btn_y, dns_btn_w, dns_btn_h, dns_btn_g) = self.net_dns_btn_geom();
 
         let presets    = [self.net.auto_dns, 0x0808_0808u32, 0x0101_0101u32];
         for (i, &dns) in presets.iter().enumerate() {
@@ -1473,6 +1480,20 @@ fn fmt_mem(buf: &mut [u8; 48], used: u64, total: u64) -> usize {
     let mid=b" MB / "; for b in mid { buf[p]=*b; p+=1; }
     p += fmt_u64(&mut buf[p..], total/1024);
     let suf=b" MB"; for b in suf { buf[p]=*b; p+=1; }
+    p
+}
+
+fn fmt_storage(buf: &mut [u8; 48], used: u64, total: u64) -> usize {
+    if total == 0 {
+        let m = b"N/A"; buf[..m.len()].copy_from_slice(m); return m.len();
+    }
+    let used_mb  = used  / (1024 * 1024);
+    let total_mb = total / (1024 * 1024);
+    let mut p = 0;
+    p += fmt_u64(&mut buf[p..], used_mb);
+    let mid = b" MB / "; for b in mid { buf[p]=*b; p+=1; }
+    p += fmt_u64(&mut buf[p..], total_mb);
+    let suf = b" MB"; for b in suf { buf[p]=*b; p+=1; }
     p
 }
 

--- a/userspace/system_apps/system_settings/src/main.rs
+++ b/userspace/system_apps/system_settings/src/main.rs
@@ -1,0 +1,1392 @@
+// Atom OS – System Settings
+//
+// Unified settings panel.  Sidebar on the right, content on the left.
+// Three pages under two categories:
+//
+//   PERSONALIZATION
+//     Desktop Background  – solid colours + wallpaper browser + scaling
+//
+//   SYSTEM SETTINGS
+//     Display Resolution  – scrollable video-mode list
+//     About System        – OS / hardware / network summary
+//
+// Lifecycle: identical to the old display_settings app.
+// IPC service name: "system_settings"
+
+#![no_std]
+#![no_main]
+#![feature(alloc_error_handler)]
+
+extern crate alloc;
+
+use core::alloc::{GlobalAlloc, Layout};
+use core::cell::UnsafeCell;
+use core::sync::atomic::{AtomicUsize, Ordering};
+use core::panic::PanicInfo;
+
+use atom_syscall::graphics::{
+    SharedSurface, VideoModeEntry, get_video_modes, video_mode_count, VIDEO_MAX_MODES, Color,
+};
+use atom_syscall::ipc::{create_port, send, try_recv, wait_any, PortId};
+use atom_syscall::thread::{exit, yield_now, get_ticks, get_cpu_count};
+use atom_syscall::debug::{log, get_cpu_brand, get_memory_info};
+use atom_syscall::graphics::set_video_mode;
+
+use libipc::messages::{
+    MessageType, MessageHeader,
+    SurfaceAssignMsg, SurfacePresentMsg,
+    KeyEvent as IpcKeyEvent,
+    MouseButtonEvent, MouseButton,
+    MouseMoveEvent, MouseScrollEvent,
+    OpenInTabMsg,
+    WallpaperAppliedMsg, WallpaperFailedMsg,
+    ScalingMode, ApplyWallpaperMsg, WallpaperSourceType,
+};
+
+use libnet::net_get_config;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+// ── Heap ─────────────────────────────────────────────────────────────────────
+
+const HEAP_SIZE: usize = 512 * 1024;
+
+struct BumpAllocator {
+    heap: UnsafeCell<[u8; HEAP_SIZE]>,
+    next: AtomicUsize,
+}
+unsafe impl Sync for BumpAllocator {}
+impl BumpAllocator {
+    const fn new() -> Self {
+        Self { heap: UnsafeCell::new([0; HEAP_SIZE]), next: AtomicUsize::new(0) }
+    }
+}
+unsafe impl GlobalAlloc for BumpAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let align = layout.align().max(16);
+        loop {
+            let cur = self.next.load(Ordering::Relaxed);
+            let aligned = (cur + align - 1) & !(align - 1);
+            let new_next = aligned + layout.size();
+            if new_next > HEAP_SIZE { return core::ptr::null_mut(); }
+            if self.next.compare_exchange_weak(cur, new_next,
+                    Ordering::SeqCst, Ordering::Relaxed).is_ok() {
+                return (self.heap.get() as *mut u8).add(aligned);
+            }
+        }
+    }
+    unsafe fn dealloc(&self, _: *mut u8, _: Layout) {}
+}
+#[global_allocator]
+static ALLOCATOR: BumpAllocator = BumpAllocator::new();
+#[alloc_error_handler]
+fn alloc_error(_: Layout) -> ! { loop {} }
+
+// ── Theme ────────────────────────────────────────────────────────────────────
+
+mod theme {
+    use atom_syscall::graphics::Color;
+    pub const BG:           Color = Color::new(0x0B, 0x0E, 0x13);
+    pub const SURFACE:      Color = Color::new(0x14, 0x19, 0x22);
+    pub const SURFACE_ALT:  Color = Color::new(0x1B, 0x21, 0x30);
+    pub const BORDER:       Color = Color::new(0x2A, 0x31, 0x42);
+    pub const TEXT:         Color = Color::new(0xE8, 0xEC, 0xF4);
+    pub const TEXT_SEC:     Color = Color::new(0xAA, 0xB2, 0xC5);
+    pub const TEXT_MUTED:   Color = Color::new(0x6C, 0x74, 0x86);
+    pub const ACCENT:       Color = Color::new(0x4C, 0x8D, 0xFF);
+    pub const ACCENT_DIM:   Color = Color::new(0x2A, 0x55, 0xAA);
+    pub const SEL_BG:       Color = Color::new(0x1E, 0x2E, 0x50);
+    pub const HDR_BG:       Color = Color::new(0x1E, 0x26, 0x36);
+    pub const SIDEBAR_BG:   Color = Color::new(0x10, 0x14, 0x1E);
+    pub const SUCCESS:      Color = Color::new(0x22, 0xC5, 0x5E);
+    pub const WARNING:      Color = Color::new(0xF5, 0x9E, 0x0B);
+    pub const SCROLLBAR:    Color = Color::new(0x1A, 0x20, 0x30);
+    pub const THUMB:        Color = Color::new(0x40, 0x4E, 0x70);
+    pub const BTN_PRIMARY:  Color = Color::new(0x4C, 0x8D, 0xFF);
+    pub const BTN_RESTORE:  Color = Color::new(0x28, 0x30, 0x48);
+    pub const BTN_TEXT:     Color = Color::new(0xFF, 0xFF, 0xFF);
+    pub const ITEM_HOVER:   Color = Color::new(0x22, 0x2C, 0x44);
+    pub const CAT_LABEL:    Color = Color::new(0x55, 0x60, 0x80);
+    pub const DIVIDER:      Color = Color::new(0x22, 0x29, 0x3A);
+    pub const INFO_LABEL:   Color = Color::new(0x80, 0x90, 0xB0);
+    pub const INFO_VALUE:   Color = Color::new(0xD0, 0xD8, 0xEC);
+}
+
+// ── Layout constants ─────────────────────────────────────────────────────────
+
+const CHAR_W:       u32 = 8;
+const CHAR_H:       u32 = 8;
+const HDR_H:        u32 = 36;
+const STATUS_H:     u32 = 22;
+const SIDEBAR_W:    u32 = 208;
+const PAD:          u32 = 14;
+const ITEM_H:       u32 = 28;   // sidebar item row height
+
+// Resolution list
+const ROW_H:        u32 = 22;
+const VISIBLE_ROWS: usize = 11;
+const SB_W:         u32 = 8;
+
+// Wallpaper page
+const COLOR_SZ:     u32 = 48;
+const COLOR_GAP:    u32 = 10;
+const SCALE_BTN_W:  u32 = 62;
+const SCALE_BTN_H:  u32 = 24;
+const SCALE_BTN_GAP:u32 = 8;
+const IMG_W:        u32 = 88;
+const IMG_H:        u32 = 76;
+const IMG_GAP:      u32 = 10;
+const IMG_COLS:     usize = 4;
+
+// Sidebar geometry helpers – computed at runtime based on surface_w
+// Sidebar occupies [surface_w - SIDEBAR_W .. surface_w]
+
+// ── Data types ───────────────────────────────────────────────────────────────
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Page { DesktopBackground, DisplayResolution, AboutSystem }
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum StatusKind { None, Ok, Warn }
+
+struct Status {
+    kind: StatusKind, text: [u8; 56], len: usize, ticks: u32,
+}
+impl Status {
+    const fn new() -> Self { Self { kind: StatusKind::None, text: [0; 56], len: 0, ticks: 0 } }
+    fn set(&mut self, kind: StatusKind, msg: &[u8]) {
+        self.kind = kind;
+        self.len = msg.len().min(55);
+        self.text[..self.len].copy_from_slice(&msg[..self.len]);
+        self.ticks = 180;
+    }
+    fn tick(&mut self) {
+        if self.ticks > 0 { self.ticks -= 1; }
+        if self.ticks == 0 { self.kind = StatusKind::None; }
+    }
+    fn as_str(&self) -> &str { core::str::from_utf8(&self.text[..self.len]).unwrap_or("") }
+}
+
+#[derive(Clone, Copy)]
+struct Mode { width: u16, height: u16 }
+
+const DEFAULT_W: u16 = 1024;
+const DEFAULT_H: u16 = 768;
+
+#[derive(Clone, PartialEq, Eq)]
+enum WallpaperSource { SolidColor { rgb: u32 }, Image { path: String } }
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ThumbState { Unloaded, Loaded { width: u16, height: u16 }, Failed }
+
+struct WpInfo { name: String, path: String, thumb: ThumbState }
+
+struct WallpaperState {
+    colors: [Color; 8],
+    images: Vec<WpInfo>,
+    selected: Option<WallpaperSource>,
+    scaling: ScalingMode,
+    discovering: bool,
+}
+
+impl WallpaperState {
+    fn new() -> Self {
+        Self {
+            colors: [
+                Color::new(18, 20, 28), Color::new(12, 14, 22),
+                Color::new(24, 28, 42), Color::new(16, 24, 40),
+                Color::new(22, 36, 52), Color::new(28, 18, 36),
+                Color::new(20, 30, 24), Color::new(34, 20, 20),
+            ],
+            images: Vec::new(),
+            selected: None,
+            scaling: ScalingMode::Fill,
+            discovering: false,
+        }
+    }
+    fn is_image_selected(&self) -> bool {
+        matches!(self.selected, Some(WallpaperSource::Image { .. }))
+    }
+    fn select_color(&mut self, i: usize) {
+        if i >= self.colors.len() { return; }
+        let c = self.colors[i];
+        let rgb = ((c.r as u32) << 16) | ((c.g as u32) << 8) | c.b as u32;
+        self.selected = Some(WallpaperSource::SolidColor { rgb });
+    }
+    fn select_image(&mut self, i: usize) {
+        if let Some(info) = self.images.get(i) {
+            self.selected = Some(WallpaperSource::Image { path: info.path.clone() });
+        }
+    }
+    fn discover(&mut self) {
+        use atom_syscall::fs::{open, readdir, close, OpenFlags, FileType};
+        self.discovering = true;
+        self.images.clear();
+        let fd = match open("/system/wallpapers/", OpenFlags::DIRECTORY, 0) {
+            Ok(fd) => fd,
+            Err(_) => { self.discovering = false; return; }
+        };
+        let entries = match readdir(fd) {
+            Ok(e) => e,
+            Err(_) => { let _ = close(fd); self.discovering = false; return; }
+        };
+        let _ = close(fd);
+        for e in entries {
+            if e.file_type == FileType::Directory { continue; }
+            let low = e.name.to_lowercase();
+            if !low.ends_with(".jpg") && !low.ends_with(".jpeg") { continue; }
+            let mut path = String::from("/system/wallpapers/");
+            path.push_str(&e.name);
+            self.images.push(WpInfo { name: e.name, path, thumb: ThumbState::Unloaded });
+            if self.images.len() >= 80 { break; }
+        }
+        self.images.sort_by(|a, b| a.name.cmp(&b.name));
+        self.discovering = false;
+    }
+}
+
+// ── About System cached info ──────────────────────────────────────────────────
+
+struct AboutInfo {
+    cpu_brand: [u8; 64], cpu_brand_len: usize,
+    cpu_cores: u64,
+    mem_total_kb: u64, mem_used_kb: u64,
+    uptime_buf: [u8; 32], uptime_len: usize,
+    ip_buf: [u8; 48], ip_len: usize,
+}
+
+impl AboutInfo {
+    fn gather() -> Self {
+        let mut cpu_brand = [0u8; 64];
+        let cpu_brand_len = get_cpu_brand(&mut cpu_brand);
+        let cpu_cores = get_cpu_count();
+
+        let (total_kb, free_kb) = get_memory_info();
+        let mem_total_kb = total_kb;
+        let mem_used_kb = total_kb.saturating_sub(free_kb);
+
+        // Uptime
+        let mut uptime_buf = [0u8; 32];
+        let uptime_len = {
+            let ticks = get_ticks();
+            let secs = ticks / 100;
+            let h = secs / 3600;
+            let m = (secs % 3600) / 60;
+            let s = secs % 60;
+            let mut p = 0usize;
+            p += write_u64(&mut uptime_buf[p..], h);
+            uptime_buf[p] = b'h'; p += 1;
+            uptime_buf[p] = b' '; p += 1;
+            if m < 10 { uptime_buf[p] = b'0'; p += 1; }
+            p += write_u64(&mut uptime_buf[p..], m);
+            uptime_buf[p] = b'm'; p += 1;
+            uptime_buf[p] = b' '; p += 1;
+            if s < 10 { uptime_buf[p] = b'0'; p += 1; }
+            p += write_u64(&mut uptime_buf[p..], s);
+            uptime_buf[p] = b's'; p += 1;
+            p
+        };
+
+        // IP address
+        let mut ip_buf = [0u8; 48];
+        let ip_len = gather_ip(&mut ip_buf);
+
+        AboutInfo { cpu_brand, cpu_brand_len, cpu_cores, mem_total_kb, mem_used_kb,
+                    uptime_buf, uptime_len, ip_buf, ip_len }
+    }
+    fn cpu_brand_str(&self) -> &str {
+        core::str::from_utf8(&self.cpu_brand[..self.cpu_brand_len]).unwrap_or("x86_64")
+    }
+    fn uptime_str(&self) -> &str {
+        core::str::from_utf8(&self.uptime_buf[..self.uptime_len]).unwrap_or("-")
+    }
+    fn ip_str(&self) -> &str {
+        core::str::from_utf8(&self.ip_buf[..self.ip_len]).unwrap_or("unavailable")
+    }
+}
+
+fn gather_ip(buf: &mut [u8; 48]) -> usize {
+    let port = match libipc::protocol::lookup_service("netd") {
+        Ok(p) => p,
+        Err(_) => {
+            let msg = b"unavailable";
+            buf[..msg.len()].copy_from_slice(msg);
+            return msg.len();
+        }
+    };
+    match net_get_config(port) {
+        Ok(cfg) => {
+            use libnet::IpAddr;
+            match cfg.ip {
+                IpAddr::V4(b) => {
+                    let mut p = 0usize;
+                    p += write_u64(&mut buf[p..], b[0] as u64);
+                    buf[p] = b'.'; p += 1;
+                    p += write_u64(&mut buf[p..], b[1] as u64);
+                    buf[p] = b'.'; p += 1;
+                    p += write_u64(&mut buf[p..], b[2] as u64);
+                    buf[p] = b'.'; p += 1;
+                    p += write_u64(&mut buf[p..], b[3] as u64);
+                    p
+                }
+                IpAddr::V6(_) => { let m = b"(IPv6)"; buf[..6].copy_from_slice(m); 6 }
+            }
+        }
+        Err(_) => { let m = b"unavailable"; buf[..m.len()].copy_from_slice(m); m.len() }
+    }
+}
+
+// ── Main app state ────────────────────────────────────────────────────────────
+
+struct SystemSettings {
+    window_id:   u32,
+    comp_port:   PortId,
+    local_port:  PortId,
+    surface:     Option<SharedSurface>,
+    sw:          u32,   // surface width
+    sh:          u32,   // surface height
+    dirty:       bool,
+    running:     bool,
+
+    // Navigation
+    active_page: Page,
+
+    // Status bar
+    status: Status,
+
+    // Resolution page
+    modes:      [Mode; VIDEO_MAX_MODES],
+    mode_count: usize,
+    selected:   usize,
+    scroll:     usize,
+    sb_drag:    bool,
+    sb_drag_off:i32,
+
+    // Wallpaper page
+    wp: WallpaperState,
+    wp_scroll: usize,
+
+    // About page
+    about: AboutInfo,
+}
+
+impl SystemSettings {
+    fn new(window_id: u32, comp_port: PortId, local_port: PortId,
+           surface: SharedSurface,
+           modes: [Mode; VIDEO_MAX_MODES], mode_count: usize) -> Self {
+        let sw = surface.width();
+        let sh = surface.height();
+        let sel = default_idx(&modes, mode_count);
+        let mut s = Self {
+            window_id, comp_port, local_port,
+            surface: Some(surface), sw, sh,
+            dirty: true, running: true,
+            active_page: Page::DesktopBackground,
+            status: Status::new(),
+            modes, mode_count, selected: sel,
+            scroll: 0, sb_drag: false, sb_drag_off: 0,
+            wp: WallpaperState::new(), wp_scroll: 0,
+            about: AboutInfo::gather(),
+        };
+        s.clamp_scroll();
+        s.wp.discover();
+        s
+    }
+
+    // ── Layout helpers ────────────────────────────────────────────────────────
+
+    /// X coordinate where the sidebar begins.
+    fn sidebar_x(&self) -> u32 { self.sw.saturating_sub(SIDEBAR_W) }
+
+    /// Width of the content area.
+    fn content_w(&self) -> u32 { self.sw.saturating_sub(SIDEBAR_W + 1) }
+
+    /// Y where content / sidebar body starts (below header).
+    fn body_y(&self) -> u32 { HDR_H + 1 }
+
+    /// Height of content / sidebar body.
+    fn body_h(&self) -> u32 { self.sh.saturating_sub(HDR_H + 1 + STATUS_H) }
+
+    // ── Sidebar hit testing ───────────────────────────────────────────────────
+
+    /// Given a click inside the sidebar, return the clicked Page (if any).
+    fn sidebar_page_at(&self, cx: i32, cy: i32) -> Option<Page> {
+        let sx = self.sidebar_x() as i32;
+        if cx < sx { return None; }
+        for (page, iy) in self.sidebar_item_positions() {
+            if cy >= iy as i32 && cy < (iy + ITEM_H) as i32 {
+                return Some(page);
+            }
+        }
+        None
+    }
+
+    /// Returns (Page, absolute_y) for every sidebar item, in order.
+    fn sidebar_item_positions(&self) -> [(Page, u32); 3] {
+        let top = self.body_y() + PAD;
+        let cat_h = CHAR_H + 12;   // category row height
+        let gap   = ITEM_H + 6;    // inter-item gap
+
+        let y0 = top + cat_h + 4;                               // Desktop Background
+        let y1 = y0 + gap + cat_h + 4 + 14;                     // Display Resolution (new cat)
+        let y2 = y1 + gap;                                       // About System
+        [
+            (Page::DesktopBackground,  y0),
+            (Page::DisplayResolution,  y1),
+            (Page::AboutSystem,        y2),
+        ]
+    }
+
+    // ── Page switching ────────────────────────────────────────────────────────
+
+    fn switch_page(&mut self, page: Page) {
+        self.active_page = page;
+        self.dirty = true;
+    }
+
+    fn handle_open_in_tab(&mut self, name: &str) {
+        match name {
+            "Desktop Background" | "Wallpaper" => self.switch_page(Page::DesktopBackground),
+            "Display Resolution" | "Resolution" => self.switch_page(Page::DisplayResolution),
+            "About System"                      => self.switch_page(Page::AboutSystem),
+            _ => return,
+        }
+    }
+
+    // ── IPC presentation ─────────────────────────────────────────────────────
+
+    fn present(&self) {
+        let msg = SurfacePresentMsg { window_id: self.window_id };
+        let hdr = MessageHeader::new(MessageType::SurfacePresent, SurfacePresentMsg::SIZE as u32);
+        let mut buf = [0u8; MessageHeader::SIZE + SurfacePresentMsg::SIZE];
+        buf[..MessageHeader::SIZE].copy_from_slice(&hdr.to_bytes());
+        buf[MessageHeader::SIZE..].copy_from_slice(&msg.to_bytes());
+        let _ = send(self.comp_port, &buf);
+    }
+
+    fn notify_mode_changed(&self) {
+        let hdr = MessageHeader::new(MessageType::VideoModeChanged, 0);
+        let mut buf = [0u8; MessageHeader::SIZE];
+        buf[..MessageHeader::SIZE].copy_from_slice(&hdr.to_bytes());
+        let _ = send(self.comp_port, &buf);
+    }
+
+    // ── Resolution helpers ────────────────────────────────────────────────────
+
+    fn clamp_scroll(&mut self) {
+        let max = self.mode_count.saturating_sub(VISIBLE_ROWS);
+        if self.scroll > max { self.scroll = max; }
+        if self.selected < self.scroll { self.scroll = self.selected; }
+        if self.selected >= self.scroll + VISIBLE_ROWS {
+            self.scroll = self.selected + 1 - VISIBLE_ROWS;
+        }
+    }
+
+    fn res_list_geom(&self) -> (u32, u32, u32, u32) {
+        let sec_h = CHAR_H + 14;
+        let top = self.body_y() + PAD + sec_h;
+        let h   = VISIBLE_ROWS as u32 * ROW_H;
+        let cw  = self.content_w();
+        let w   = cw.saturating_sub(PAD * 2 + SB_W + 4);
+        let sbx = cw.saturating_sub(PAD + SB_W);
+        (top, h, w, sbx)
+    }
+
+    fn scrollbar_geom(&self) -> (u32, u32, u32) {
+        let (top, list_h, _, _) = self.res_list_geom();
+        let total = self.mode_count as u32;
+        let vis   = VISIBLE_ROWS as u32;
+        let thumb_h = if total > 0 {
+            ((list_h * vis) / total).max(14).min(list_h)
+        } else { list_h };
+        let travel = list_h.saturating_sub(thumb_h);
+        let max_s  = self.mode_count.saturating_sub(VISIBLE_ROWS) as u32;
+        let thumb_y = if max_s > 0 {
+            top + travel * self.scroll as u32 / max_s
+        } else { top };
+        (thumb_y, thumb_h, travel)
+    }
+
+    fn set_scroll_from_y(&mut self, thumb_y: i32) {
+        let (top, _, _, _) = self.res_list_geom();
+        let (_, _, travel) = self.scrollbar_geom();
+        let max_s = self.mode_count.saturating_sub(VISIBLE_ROWS);
+        if travel == 0 || max_s == 0 { self.scroll = 0; return; }
+        let rel = (thumb_y - top as i32).clamp(0, travel as i32) as u32;
+        self.scroll = ((rel as u64 * max_s as u64 + travel as u64 / 2) / travel as u64) as usize;
+        self.dirty = true;
+    }
+
+    fn apply_resolution(&mut self) {
+        if self.mode_count == 0 { return; }
+        let m = self.modes[self.selected];
+        match set_video_mode(m.width, m.height, 32) {
+            Ok(()) => { self.notify_mode_changed(); self.status.set(StatusKind::Ok, b"Resolution applied."); }
+            Err(_) => self.status.set(StatusKind::Warn, b"BGA unavailable or mode rejected."),
+        }
+        self.dirty = true;
+    }
+
+    fn restore_default(&mut self) {
+        if self.mode_count == 0 { return; }
+        self.selected = default_idx(&self.modes, self.mode_count);
+        self.clamp_scroll();
+        let m = self.modes[self.selected];
+        match set_video_mode(m.width, m.height, 32) {
+            Ok(()) => { self.notify_mode_changed(); self.status.set(StatusKind::Ok, b"Restored 1024x768."); }
+            Err(_) => self.status.set(StatusKind::Warn, b"BGA unavailable."),
+        }
+        self.dirty = true;
+    }
+
+    // ── Wallpaper helpers ─────────────────────────────────────────────────────
+
+    fn color_tile_rect(&self, i: usize) -> (u32, u32) {
+        let row = (i / 4) as u32;
+        let col = (i % 4) as u32;
+        let x = PAD + col * (COLOR_SZ + COLOR_GAP);
+        let y = self.body_y() + PAD + CHAR_H + 10 + row * (COLOR_SZ + COLOR_GAP);
+        (x, y)
+    }
+
+    fn scaling_btn_rect(&self, i: usize) -> (u32, u32) {
+        let row = (i / 3) as u32;
+        let col = (i % 3) as u32;
+        let base_y = self.body_y() + PAD + CHAR_H + 10
+            + 2 * (COLOR_SZ + COLOR_GAP) + 10 + CHAR_H + 6;
+        let x = PAD + col * (SCALE_BTN_W + SCALE_BTN_GAP);
+        let y = base_y + row * (SCALE_BTN_H + SCALE_BTN_GAP);
+        (x, y)
+    }
+
+    fn img_tile_rect(&self, visible_idx: usize) -> (u32, u32) {
+        let col = (visible_idx % IMG_COLS) as u32;
+        let row = (visible_idx / IMG_COLS) as u32;
+        let base_y = self.body_y() + PAD + CHAR_H + 10
+            + 2 * (COLOR_SZ + COLOR_GAP) + 10 + CHAR_H + 6
+            + 2 * (SCALE_BTN_H + SCALE_BTN_GAP) + 14 + CHAR_H + 6;
+        let x = PAD + col * (IMG_W + IMG_GAP);
+        let y = base_y + row * (IMG_H + IMG_GAP);
+        (x, y)
+    }
+
+    fn apply_wallpaper(&mut self) {
+        let source = match &self.wp.selected {
+            Some(s) => s.clone(),
+            None => { self.status.set(StatusKind::Warn, b"No background selected."); self.dirty = true; return; }
+        };
+        let msg = match &source {
+            WallpaperSource::SolidColor { rgb } => ApplyWallpaperMsg {
+                source_type: WallpaperSourceType::SolidColor,
+                image_path: None, color_rgb: Some(*rgb),
+                scaling_mode: self.wp.scaling,
+            },
+            WallpaperSource::Image { path } => ApplyWallpaperMsg {
+                source_type: WallpaperSourceType::Image,
+                image_path: Some(path.clone()), color_rgb: None,
+                scaling_mode: self.wp.scaling,
+            },
+        };
+        let payload = msg.to_bytes();
+        let hdr = MessageHeader::new(MessageType::ApplyWallpaper, payload.len() as u32);
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&hdr.to_bytes());
+        buf.extend_from_slice(&payload);
+        match send(self.comp_port, &buf) {
+            Ok(()) => { self.status.set(StatusKind::Ok, b"Applying background..."); }
+            Err(_) => { self.status.set(StatusKind::Warn, b"Failed to apply."); }
+        }
+        self.dirty = true;
+    }
+
+    // ── Rendering ─────────────────────────────────────────────────────────────
+
+    fn render(&mut self) {
+        if !self.dirty { return; }
+        self.dirty = false;
+        let surface = match self.surface { Some(ref s) => s as *const SharedSurface, None => return };
+        let surface = unsafe { &*surface };
+        self.draw_header(surface);
+        self.draw_sidebar(surface);
+        self.draw_divider(surface);
+        self.draw_content(surface);
+        self.draw_status_bar(surface);
+        self.present();
+    }
+
+    fn draw_header(&self, s: &SharedSurface) {
+        s.fill_rect(0, 0, self.sw, HDR_H, theme::HDR_BG);
+        s.fill_rect(0, HDR_H - 1, self.sw, 1, theme::BORDER);
+        // Gear icon (simplified pixel art)
+        let ix = PAD;
+        let iy = (HDR_H - 14) / 2;
+        s.fill_rect(ix + 5, iy, 4, 14, theme::ACCENT);
+        s.fill_rect(ix, iy + 5, 14, 4, theme::ACCENT);
+        s.fill_rect(ix + 3, iy + 3, 8, 8, theme::ACCENT);
+        s.fill_rect(ix + 5, iy + 5, 4, 4, theme::HDR_BG);
+        // Title
+        let title = "System Settings";
+        let tx = ix + 20;
+        let ty = (HDR_H - CHAR_H) / 2;
+        s.draw_string(tx, ty, title, theme::TEXT, theme::HDR_BG);
+    }
+
+    fn draw_sidebar(&self, s: &SharedSurface) {
+        let sx = self.sidebar_x();
+        let by = self.body_y();
+        let bh = self.body_h();
+        // Background
+        s.fill_rect(sx, by, SIDEBAR_W, bh, theme::SIDEBAR_BG);
+
+        let positions = self.sidebar_item_positions();
+        let top = by + PAD;
+        let cat_y0 = top;
+        let cat_y1 = positions[1].1 - CHAR_H - 4 - 14;
+
+        // Category 1: PERSONALIZATION
+        self.draw_sidebar_category(s, sx, cat_y0, "PERSONALIZATION");
+        // Item: Desktop Background
+        self.draw_sidebar_item(s, sx, positions[0].1,
+            "Desktop Background", positions[0].0 == self.active_page);
+
+        // Category 2: SYSTEM SETTINGS
+        self.draw_sidebar_category(s, sx, cat_y1, "SYSTEM SETTINGS");
+        // Item: Display Resolution
+        self.draw_sidebar_item(s, sx, positions[1].1,
+            "Display Resolution", positions[1].0 == self.active_page);
+        // Item: About System
+        self.draw_sidebar_item(s, sx, positions[2].1,
+            "About System", positions[2].0 == self.active_page);
+    }
+
+    fn draw_sidebar_category(&self, s: &SharedSurface, sx: u32, y: u32, label: &str) {
+        s.draw_string(sx + PAD, y + 2, label, theme::CAT_LABEL, theme::SIDEBAR_BG);
+    }
+
+    fn draw_sidebar_item(&self, s: &SharedSurface, sx: u32, y: u32, label: &str, active: bool) {
+        let bg = if active { theme::SEL_BG } else { theme::SIDEBAR_BG };
+        s.fill_rect(sx, y, SIDEBAR_W, ITEM_H, bg);
+        if active {
+            s.fill_rect(sx, y, 3, ITEM_H, theme::ACCENT);
+        }
+        let fg = if active { theme::TEXT } else { theme::TEXT_SEC };
+        let lx = sx + PAD + (if active { 6 } else { 4 });
+        s.draw_string(lx, y + (ITEM_H - CHAR_H) / 2, label, fg, bg);
+    }
+
+    fn draw_divider(&self, s: &SharedSurface) {
+        let sx = self.sidebar_x();
+        s.fill_rect(sx.saturating_sub(1), self.body_y(), 1, self.body_h(), theme::BORDER);
+    }
+
+    fn draw_content(&self, s: &SharedSurface) {
+        let by = self.body_y();
+        let bh = self.body_h();
+        let cw = self.content_w();
+        s.fill_rect(0, by, cw, bh, theme::BG);
+        match self.active_page {
+            Page::DesktopBackground => self.render_desktop_bg(s),
+            Page::DisplayResolution => self.render_display_res(s),
+            Page::AboutSystem       => self.render_about(s),
+        }
+    }
+
+    fn draw_status_bar(&self, s: &SharedSurface) {
+        let sy = self.sh - STATUS_H;
+        s.fill_rect(0, sy, self.sw, STATUS_H, theme::HDR_BG);
+        s.fill_rect(0, sy, self.sw, 1, theme::BORDER);
+        let ty = sy + (STATUS_H - CHAR_H) / 2;
+        if self.status.kind != StatusKind::None {
+            let col = if self.status.kind == StatusKind::Ok { theme::SUCCESS } else { theme::WARNING };
+            s.draw_string(PAD, ty, self.status.as_str(), col, theme::HDR_BG);
+        } else {
+            let hint = match self.active_page {
+                Page::DesktopBackground => "Select color or wallpaper, then Apply",
+                Page::DisplayResolution => "Select resolution, then Apply",
+                Page::AboutSystem       => "Atom OS System Information",
+            };
+            s.draw_string(PAD, ty, hint, theme::TEXT_MUTED, theme::HDR_BG);
+        }
+    }
+
+    // ── Desktop Background page ───────────────────────────────────────────────
+
+    fn render_desktop_bg(&self, s: &SharedSurface) {
+        let by = self.body_y();
+        let cw = self.content_w();
+        let sh = self.sh;
+
+        // Page title
+        let title_y = by + PAD;
+        s.draw_string(PAD, title_y, "Desktop Background", theme::TEXT, theme::BG);
+        s.fill_rect(0, title_y + CHAR_H + 4, cw, 1, theme::DIVIDER);
+
+        // Section: Background Color
+        let sec1_y = title_y + CHAR_H + 10;
+        s.draw_string(PAD, sec1_y, "Background Color", theme::TEXT_SEC, theme::BG);
+
+        // 4×2 color tile grid
+        for i in 0..8 {
+            let (tx, ty) = self.color_tile_rect(i);
+            if ty + COLOR_SZ > sh { continue; }
+            let color = self.wp.colors[i];
+            let is_sel = match &self.wp.selected {
+                Some(WallpaperSource::SolidColor { rgb }) => {
+                    let tile_rgb = ((color.r as u32) << 16) | ((color.g as u32) << 8) | color.b as u32;
+                    tile_rgb == *rgb
+                }
+                _ => false,
+            };
+            s.fill_rect_rounded_aa(tx, ty, COLOR_SZ, COLOR_SZ, 6, color);
+            if is_sel {
+                s.draw_rect_rounded_aa(tx, ty, COLOR_SZ, COLOR_SZ, 6, theme::ACCENT);
+                s.draw_rect_rounded_aa(tx + 1, ty + 1, COLOR_SZ - 2, COLOR_SZ - 2, 6, theme::ACCENT);
+            } else {
+                s.draw_rect_rounded_aa(tx, ty, COLOR_SZ, COLOR_SZ, 6, theme::BORDER);
+            }
+        }
+
+        // Scaling section label
+        let scale_sec_y = self.body_y() + PAD + CHAR_H + 10
+            + 2 * (COLOR_SZ + COLOR_GAP) + 10;
+        if scale_sec_y + CHAR_H < sh {
+            s.draw_string(PAD, scale_sec_y, "Image Scaling", theme::TEXT_SEC, theme::BG);
+        }
+
+        // Scaling buttons
+        let modes = [ScalingMode::Fill, ScalingMode::Fit, ScalingMode::Stretch,
+                     ScalingMode::Center, ScalingMode::Tile];
+        for (i, mode) in modes.iter().enumerate() {
+            let (bx, btn_y) = self.scaling_btn_rect(i);
+            if btn_y + SCALE_BTN_H > sh { continue; }
+            let enabled = self.wp.is_image_selected();
+            let active  = self.wp.scaling == *mode;
+            let bg = if !enabled { theme::SURFACE_ALT } else if active { theme::SEL_BG } else { theme::SURFACE };
+            let fg = if !enabled { theme::TEXT_MUTED } else { theme::TEXT };
+            s.fill_rect_rounded_aa(bx, btn_y, SCALE_BTN_W, SCALE_BTN_H, 4, bg);
+            s.draw_rect_rounded_aa(bx, btn_y, SCALE_BTN_W, SCALE_BTN_H, 4,
+                if active { theme::ACCENT } else { theme::BORDER });
+            let lbl = mode.to_str();
+            let lx = bx + (SCALE_BTN_W.saturating_sub(lbl.len() as u32 * CHAR_W)) / 2;
+            s.draw_string(lx, btn_y + (SCALE_BTN_H - CHAR_H) / 2, lbl, fg, bg);
+        }
+
+        // Wallpaper images section
+        let img_sec_base_y = self.body_y() + PAD + CHAR_H + 10
+            + 2 * (COLOR_SZ + COLOR_GAP) + 10 + CHAR_H + 6
+            + 2 * (SCALE_BTN_H + SCALE_BTN_GAP) + 14;
+        if img_sec_base_y + CHAR_H < sh {
+            s.draw_string(PAD, img_sec_base_y, "Wallpaper Images", theme::TEXT_SEC, theme::BG);
+        }
+
+        let vis_rows = 2usize;
+        let vis_count = vis_rows * IMG_COLS;
+        let start = self.wp_scroll;
+        let end = (start + vis_count).min(self.wp.images.len());
+        for idx in start..end {
+            let vis_i = idx - start;
+            let (ix, iy) = self.img_tile_rect(vis_i);
+            if iy + IMG_H > sh { continue; }
+            let info = &self.wp.images[idx];
+            let sel = matches!(&self.wp.selected, Some(WallpaperSource::Image { path }) if path == &info.path);
+            let bg = if sel { theme::SEL_BG } else { theme::SURFACE };
+            s.fill_rect_rounded_aa(ix, iy, IMG_W, IMG_H, 6, bg);
+            s.draw_rect_rounded_aa(ix, iy, IMG_W, IMG_H, 6,
+                if sel { theme::ACCENT } else { theme::BORDER });
+            // Thumbnail preview area
+            let pw = IMG_W.saturating_sub(16);
+            let ph = IMG_H.saturating_sub(22);
+            let px = ix + 8; let py = iy + 6;
+            s.fill_rect_rounded_aa(px, py, pw, ph, 4, Color::new(35, 42, 60));
+            match info.thumb {
+                ThumbState::Loaded { width, height } => {
+                    let (dw, dh) = fit_within(width as u32, height as u32, pw - 4, ph - 4);
+                    let dx = px + (pw - dw) / 2; let dy = py + (ph - dh) / 2;
+                    s.fill_rect_rounded_aa(dx, dy, dw, dh, 3, theme::ACCENT_DIM);
+                    s.draw_rect_rounded_aa(dx, dy, dw, dh, 3, theme::ACCENT);
+                }
+                ThumbState::Failed => {
+                    s.draw_rect_rounded_aa(px + 8, py + 6, pw - 16, ph - 12, 3, theme::WARNING);
+                }
+                ThumbState::Unloaded => {
+                    let dw = pw / 2; let dh = ph / 2;
+                    s.fill_rect_rounded_aa(px + dw / 2, py + dh / 2, dw, dh, 3, theme::THUMB);
+                }
+            }
+            // Filename label (truncated)
+            let max_chars = (IMG_W / CHAR_W) as usize;
+            let label = if info.name.len() > max_chars { &info.name[..max_chars] } else { &info.name };
+            s.draw_string(ix + 4, iy + IMG_H - CHAR_H - 3, label, theme::TEXT_SEC, bg);
+        }
+
+        if self.wp.discovering {
+            let load_y = img_sec_base_y + CHAR_H + 10;
+            if load_y + CHAR_H < sh {
+                s.draw_string(PAD, load_y, "Discovering wallpapers...", theme::TEXT_MUTED, theme::BG);
+            }
+        } else if self.wp.images.is_empty() {
+            let msg_y = img_sec_base_y + CHAR_H + 10;
+            if msg_y + CHAR_H < sh {
+                s.draw_string(PAD, msg_y, "No images in /system/wallpapers/", theme::TEXT_MUTED, theme::BG);
+            }
+        }
+
+        // Apply button – bottom of content area
+        let btn_h = 28u32;
+        let btn_w = 88u32;
+        let btn_y = self.sh - STATUS_H - btn_h - 10;
+        let btn_x = self.content_w().saturating_sub(PAD + btn_w);
+        s.fill_rect_rounded_aa(btn_x, btn_y, btn_w, btn_h, 6, theme::BTN_PRIMARY);
+        let lbl = "Apply";
+        let lx = btn_x + (btn_w - lbl.len() as u32 * CHAR_W) / 2;
+        s.draw_string(lx, btn_y + (btn_h - CHAR_H) / 2, lbl, theme::BTN_TEXT, theme::BTN_PRIMARY);
+    }
+
+    // ── Display Resolution page ───────────────────────────────────────────────
+
+    fn render_display_res(&self, s: &SharedSurface) {
+        let by = self.body_y();
+        let cw = self.content_w();
+
+        // Page title
+        s.draw_string(PAD, by + PAD, "Display Resolution", theme::TEXT, theme::BG);
+        s.fill_rect(0, by + PAD + CHAR_H + 4, cw, 1, theme::DIVIDER);
+
+        let (list_top, list_h, list_w, sbx) = self.res_list_geom();
+
+        // Subtitle
+        s.draw_string(PAD, by + PAD + CHAR_H + 8, "Available Resolutions", theme::TEXT_MUTED, theme::BG);
+
+        // Mode rows
+        for i in 0..VISIBLE_ROWS {
+            let idx = self.scroll + i;
+            if idx >= self.mode_count { break; }
+            let m = self.modes[idx];
+            let ry = list_top + i as u32 * ROW_H;
+            let sel = idx == self.selected;
+            let (row_bg, fg, dim) = if sel {
+                (theme::SEL_BG, theme::TEXT, theme::ACCENT)
+            } else {
+                (theme::BG, theme::TEXT, theme::TEXT_MUTED)
+            };
+            s.fill_rect(PAD, ry, list_w, ROW_H - 1, row_bg);
+            if sel { s.fill_rect(PAD, ry, 3, ROW_H - 1, theme::ACCENT); }
+            let mut lbuf = [0u8; 24];
+            let label = fmt_resolution(&mut lbuf, m.width, m.height);
+            s.draw_string(PAD + 8, ry + (ROW_H - CHAR_H) / 2, label, fg, row_bg);
+            let bpp = "32bpp";
+            let bx = PAD + list_w - bpp.len() as u32 * CHAR_W - 6;
+            s.draw_string(bx, ry + (ROW_H - CHAR_H) / 2, bpp, dim, row_bg);
+            if !sel {
+                s.fill_rect(PAD + 8, ry + ROW_H - 1, list_w - 16, 1, theme::DIVIDER);
+            }
+        }
+
+        // Scrollbar
+        s.fill_rect(sbx, list_top, SB_W, list_h, theme::SCROLLBAR);
+        let (thy, thh, _) = self.scrollbar_geom();
+        let thumb_c = if self.sb_drag { theme::ACCENT } else { theme::THUMB };
+        s.fill_rect_rounded_aa(sbx + 1, thy, SB_W - 2, thh, 3, thumb_c);
+
+        // Info line
+        if self.mode_count > 0 {
+            let m = self.modes[self.selected];
+            let mut ibuf = [0u8; 44];
+            let info = fmt_info(&mut ibuf, m.width, m.height);
+            s.draw_string(PAD, list_top + list_h + 6, info, theme::TEXT_MUTED, theme::BG);
+        }
+
+        // Buttons
+        let btn_h = 28u32;
+        let btn_y = self.sh - STATUS_H - btn_h - 10;
+        let aw = 88u32;
+        let ax = self.content_w().saturating_sub(PAD + aw);
+        s.fill_rect_rounded_aa(ax, btn_y, aw, btn_h, 6, theme::BTN_PRIMARY);
+        let al = "Apply";
+        s.draw_string(ax + (aw - al.len() as u32 * CHAR_W) / 2,
+            btn_y + (btn_h - CHAR_H) / 2, al, theme::BTN_TEXT, theme::BTN_PRIMARY);
+        let rw = 128u32;
+        let rx = ax.saturating_sub(PAD + rw);
+        s.fill_rect_rounded_aa(rx, btn_y, rw, btn_h, 6, theme::BTN_RESTORE);
+        s.draw_rect_rounded_aa(rx, btn_y, rw, btn_h, 6, theme::BORDER);
+        let rl = "Restore Default";
+        s.draw_string(rx + (rw - rl.len() as u32 * CHAR_W) / 2,
+            btn_y + (btn_h - CHAR_H) / 2, rl, theme::BTN_TEXT, theme::BTN_RESTORE);
+    }
+
+    // ── About System page ─────────────────────────────────────────────────────
+
+    fn render_about(&self, s: &SharedSurface) {
+        const OS_NAME:    &str = "Atom OS";
+        const OS_VER:     &str = "0.2.0";
+        const OS_CODE:    &str = "Beryllium";
+        const KERNEL_VER: &str = "0.2.0-smp-microkernel";
+
+        let by = self.body_y();
+        let cw = self.content_w();
+
+        // Page title
+        s.draw_string(PAD, by + PAD, "About System", theme::TEXT, theme::BG);
+        s.fill_rect(0, by + PAD + CHAR_H + 4, cw, 1, theme::DIVIDER);
+
+        let label_x = PAD;
+        let value_x = PAD + 112;
+        let row_h = 20u32;
+
+        let mut y = by + PAD + CHAR_H + 16;
+
+        // Helper: draw a row
+        macro_rules! row {
+            ($label:expr, $value:expr) => {
+                s.draw_string(label_x, y, $label, theme::INFO_LABEL, theme::BG);
+                s.draw_string(value_x, y, $value, theme::INFO_VALUE, theme::BG);
+                y += row_h;
+            };
+        }
+        macro_rules! divider {
+            () => {
+                y += 6;
+                s.fill_rect(0, y, cw, 1, theme::DIVIDER);
+                y += 10;
+            };
+        }
+
+        // OS section
+        row!("OS Name", OS_NAME);
+        let mut ver_buf = [0u8; 32];
+        let ver_len = build_ver_str(&mut ver_buf, OS_VER, OS_CODE);
+        let ver_str = core::str::from_utf8(&ver_buf[..ver_len]).unwrap_or(OS_VER);
+        row!("Version", ver_str);
+        row!("Kernel", KERNEL_VER);
+        row!("Architecture", "x86_64");
+
+        divider!();
+
+        // CPU section
+        let brand = if self.about.cpu_brand_len > 0 {
+            self.about.cpu_brand_str()
+        } else {
+            "x86_64 (Atom Core)"
+        };
+        // Truncate long brand string
+        let brand_disp = if brand.len() * CHAR_W as usize > (cw as usize).saturating_sub(value_x as usize + PAD as usize) {
+            let max = ((cw as usize).saturating_sub(value_x as usize + PAD as usize)) / CHAR_W as usize;
+            if max < brand.len() { &brand[..max] } else { brand }
+        } else { brand };
+        row!("Processor", brand_disp);
+        let mut cores_buf = [0u8; 16];
+        let cores_len = write_u64(&mut cores_buf, self.about.cpu_cores);
+        let cores_str = core::str::from_utf8(&cores_buf[..cores_len]).unwrap_or("?");
+        row!("CPU Cores", cores_str);
+
+        divider!();
+
+        // Memory section
+        let mut mem_buf = [0u8; 48];
+        let mem_len = build_mem_str(&mut mem_buf, self.about.mem_used_kb, self.about.mem_total_kb);
+        let mem_str = core::str::from_utf8(&mem_buf[..mem_len]).unwrap_or("?");
+        row!("Memory", mem_str);
+        row!("Uptime", self.about.uptime_str());
+
+        divider!();
+
+        // Network section
+        row!("IP Address", self.about.ip_str());
+    }
+
+    // ── Input handling ────────────────────────────────────────────────────────
+
+    fn handle_key(&mut self, ev: &IpcKeyEvent) {
+        if ev.character == 0 {
+            match ev.scancode & 0x7F {
+                0x48 => { // Up
+                    if self.active_page == Page::DisplayResolution && self.selected > 0 {
+                        self.selected -= 1; self.clamp_scroll(); self.dirty = true;
+                    }
+                }
+                0x50 => { // Down
+                    if self.active_page == Page::DisplayResolution
+                        && self.selected + 1 < self.mode_count {
+                        self.selected += 1; self.clamp_scroll(); self.dirty = true;
+                    }
+                }
+                0x49 => { // Page Up
+                    if self.active_page == Page::DisplayResolution {
+                        self.selected = self.selected.saturating_sub(VISIBLE_ROWS);
+                        self.clamp_scroll(); self.dirty = true;
+                    }
+                }
+                0x51 => { // Page Down
+                    if self.active_page == Page::DisplayResolution {
+                        let last = self.mode_count.saturating_sub(1);
+                        self.selected = (self.selected + VISIBLE_ROWS).min(last);
+                        self.clamp_scroll(); self.dirty = true;
+                    }
+                }
+                _ => {}
+            }
+            return;
+        }
+        match ev.character {
+            b'\n' | b'\r' => match self.active_page {
+                Page::DesktopBackground => self.apply_wallpaper(),
+                Page::DisplayResolution => self.apply_resolution(),
+                Page::AboutSystem       => {}
+            },
+            b'r' | b'R' if self.active_page == Page::DisplayResolution => self.restore_default(),
+            _ => {}
+        }
+    }
+
+    fn handle_mouse_down(&mut self, x: i32, y: i32) {
+        // Sidebar click?
+        if let Some(page) = self.sidebar_page_at(x, y) {
+            self.switch_page(page);
+            return;
+        }
+
+        // Content area
+        match self.active_page {
+            Page::DesktopBackground => self.handle_wp_click(x, y),
+            Page::DisplayResolution => self.handle_res_click(x, y),
+            Page::AboutSystem       => {}
+        }
+    }
+
+    fn handle_wp_click(&mut self, x: i32, y: i32) {
+        // Color tiles
+        for i in 0..8 {
+            let (tx, ty) = self.color_tile_rect(i);
+            if x >= tx as i32 && x < (tx + COLOR_SZ) as i32
+               && y >= ty as i32 && y < (ty + COLOR_SZ) as i32 {
+                self.wp.select_color(i);
+                self.dirty = true;
+                return;
+            }
+        }
+        // Scaling buttons
+        let modes = [ScalingMode::Fill, ScalingMode::Fit, ScalingMode::Stretch,
+                     ScalingMode::Center, ScalingMode::Tile];
+        for (i, mode) in modes.iter().enumerate() {
+            let (bx, by) = self.scaling_btn_rect(i);
+            if x >= bx as i32 && x < (bx + SCALE_BTN_W) as i32
+               && y >= by as i32 && y < (by + SCALE_BTN_H) as i32 {
+                if self.wp.is_image_selected() {
+                    self.wp.scaling = *mode;
+                    self.dirty = true;
+                }
+                return;
+            }
+        }
+        // Image tiles
+        let vis_count = 2 * IMG_COLS;
+        let start = self.wp_scroll;
+        let end = (start + vis_count).min(self.wp.images.len());
+        for idx in start..end {
+            let vis_i = idx - start;
+            let (ix, iy) = self.img_tile_rect(vis_i);
+            if x >= ix as i32 && x < (ix + IMG_W) as i32
+               && y >= iy as i32 && y < (iy + IMG_H) as i32 {
+                self.wp.select_image(idx);
+                self.dirty = true;
+                return;
+            }
+        }
+        // Apply button
+        let btn_h = 28u32; let btn_w = 88u32;
+        let btn_y = (self.sh - STATUS_H - btn_h - 10) as i32;
+        let btn_x = (self.content_w().saturating_sub(PAD + btn_w)) as i32;
+        if x >= btn_x && x < btn_x + btn_w as i32 && y >= btn_y && y < btn_y + btn_h as i32 {
+            self.apply_wallpaper();
+        }
+    }
+
+    fn handle_res_click(&mut self, x: i32, y: i32) {
+        let (list_top, list_h, list_w, sbx) = self.res_list_geom();
+        let (thy, thh, _) = self.scrollbar_geom();
+        let btn_h = 28u32;
+        let btn_y = (self.sh - STATUS_H - btn_h - 10) as i32;
+        let aw = 88u32;
+        let ax = self.content_w().saturating_sub(PAD + aw) as i32;
+        let rw = 128u32;
+        let rx = (ax as u32).saturating_sub(PAD + rw) as i32;
+
+        // Apply button
+        if y >= btn_y && y < btn_y + btn_h as i32 {
+            if x >= ax && x < ax + aw as i32 { self.apply_resolution(); return; }
+            if x >= rx && x < rx + rw as i32 { self.restore_default(); return; }
+        }
+        // Scrollbar
+        if x >= sbx as i32 && x < (sbx + SB_W) as i32
+           && y >= list_top as i32 && y < (list_top + list_h) as i32 {
+            if y >= thy as i32 && y < (thy + thh) as i32 {
+                self.sb_drag = true;
+                self.sb_drag_off = y - thy as i32;
+            } else if (y as u32) < thy {
+                self.scroll = self.scroll.saturating_sub(VISIBLE_ROWS);
+            } else {
+                let max_s = self.mode_count.saturating_sub(VISIBLE_ROWS);
+                self.scroll = (self.scroll + VISIBLE_ROWS).min(max_s);
+            }
+            self.dirty = true;
+            return;
+        }
+        // Mode rows
+        if x >= PAD as i32 && x < (PAD + list_w) as i32
+           && y >= list_top as i32 && y < (list_top + list_h) as i32 {
+            let row = ((y - list_top as i32) / ROW_H as i32) as usize;
+            let idx = self.scroll + row;
+            if idx < self.mode_count {
+                self.selected = idx;
+                self.clamp_scroll();
+                self.dirty = true;
+            }
+        }
+    }
+
+    fn handle_mouse_move(&mut self, y: i32) {
+        if self.sb_drag && self.active_page == Page::DisplayResolution {
+            self.set_scroll_from_y(y - self.sb_drag_off);
+        }
+    }
+
+    fn handle_mouse_up(&mut self) {
+        if self.sb_drag { self.sb_drag = false; self.dirty = true; }
+    }
+
+    fn handle_scroll(&mut self, dz: i32) {
+        let steps = dz.unsigned_abs().max(1) as usize;
+        match self.active_page {
+            Page::DesktopBackground => {
+                if dz > 0 {
+                    self.wp_scroll = self.wp_scroll.saturating_sub(steps * IMG_COLS);
+                } else if dz < 0 {
+                    let max = self.wp.images.len().saturating_sub(2 * IMG_COLS);
+                    self.wp_scroll = (self.wp_scroll + steps * IMG_COLS).min(max);
+                }
+            }
+            Page::DisplayResolution => {
+                if dz > 0 {
+                    self.scroll = self.scroll.saturating_sub(steps);
+                } else if dz < 0 {
+                    let max = self.mode_count.saturating_sub(VISIBLE_ROWS);
+                    self.scroll = (self.scroll + steps).min(max);
+                }
+            }
+            Page::AboutSystem => {}
+        }
+        self.dirty = true;
+    }
+
+    // ── Event loop ────────────────────────────────────────────────────────────
+
+    fn process_msg(&mut self, buf: &[u8], len: usize) {
+        if len < MessageHeader::SIZE { return; }
+        let hdr = match MessageHeader::from_bytes(buf) { Some(h) => h, None => return };
+        let payload = &buf[MessageHeader::SIZE..len.min(buf.len())];
+        match hdr.msg_type {
+            MessageType::TerminateRequest => { self.running = false; }
+            MessageType::SurfaceAssign => {
+                if let Some(msg) = SurfaceAssignMsg::from_bytes(payload) {
+                    if let Ok(s) = SharedSurface::from_region(msg.region_id, msg.width, msg.height) {
+                        self.sw = msg.width; self.sh = msg.height;
+                        self.surface = Some(s); self.dirty = true;
+                    }
+                }
+            }
+            MessageType::KeyPress => {
+                if let Some(ev) = IpcKeyEvent::from_bytes(payload) { self.handle_key(&ev); }
+            }
+            MessageType::MouseButtonDown => {
+                if let Some(ev) = MouseButtonEvent::from_bytes(payload) {
+                    if ev.button == MouseButton::Left { self.handle_mouse_down(ev.x, ev.y); }
+                }
+            }
+            MessageType::MouseMove => {
+                if let Some(ev) = MouseMoveEvent::from_bytes(payload) { self.handle_mouse_move(ev.y); }
+            }
+            MessageType::MouseButtonUp => {
+                if let Some(ev) = MouseButtonEvent::from_bytes(payload) {
+                    if ev.button == MouseButton::Left { self.handle_mouse_up(); }
+                }
+            }
+            MessageType::MouseScroll => {
+                if let Some(ev) = MouseScrollEvent::from_bytes(payload) { self.handle_scroll(ev.dz); }
+            }
+            MessageType::OpenInTab => {
+                if let Some(msg) = OpenInTabMsg::from_bytes(payload) { self.handle_open_in_tab(&msg.tab_name); }
+            }
+            MessageType::WallpaperApplied => {
+                if WallpaperAppliedMsg::from_bytes(payload).is_some() {
+                    self.status.set(StatusKind::Ok, b"Background applied successfully.");
+                    self.dirty = true;
+                }
+            }
+            MessageType::WallpaperFailed => {
+                if let Some(msg) = WallpaperFailedMsg::from_bytes(payload) {
+                    let mut e = String::from("Failed: ");
+                    e.push_str(&msg.error_message);
+                    self.status.set(StatusKind::Warn, e.as_bytes());
+                    self.dirty = true;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn run(&mut self) {
+        self.render();
+        let mut buf = [0u8; 128];
+        let ports = [self.local_port];
+        while self.running {
+            while let Ok(Some(len)) = try_recv(self.local_port, &mut buf) {
+                self.process_msg(&buf, len);
+            }
+            self.status.tick();
+            if self.dirty { self.render(); }
+            let _ = wait_any(&ports, 16);
+        }
+    }
+
+    fn wait_for_surface(port: PortId) -> Option<SurfaceAssignMsg> {
+        let mut buf = [0u8; 128];
+        let ports = [port];
+        for _ in 0..200 {
+            if wait_any(&ports, 50).is_ok() {
+                if let Ok(Some(len)) = try_recv(port, &mut buf) {
+                    if len >= MessageHeader::SIZE {
+                        if let Some(hdr) = MessageHeader::from_bytes(&buf) {
+                            if hdr.msg_type == MessageType::SurfaceAssign {
+                                if let Some(msg) = SurfaceAssignMsg::from_bytes(
+                                    &buf[MessageHeader::SIZE..]) { return Some(msg); }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn query_modes() -> ([Mode; VIDEO_MAX_MODES], usize) {
+    let count = video_mode_count().min(VIDEO_MAX_MODES);
+    if count == 0 { return ([Mode { width: 0, height: 0 }; VIDEO_MAX_MODES], 0); }
+    let mut raw = [VideoModeEntry::default(); VIDEO_MAX_MODES];
+    let written = get_video_modes(&mut raw[..count]);
+    let mut modes = [Mode { width: 0, height: 0 }; VIDEO_MAX_MODES];
+    for i in 0..written { modes[i] = Mode { width: raw[i].width as u16, height: raw[i].height as u16 }; }
+    (modes, written)
+}
+
+fn default_idx(modes: &[Mode], count: usize) -> usize {
+    for i in 0..count {
+        if modes[i].width == DEFAULT_W && modes[i].height == DEFAULT_H { return i; }
+    }
+    0
+}
+
+fn write_u64(buf: &mut [u8], mut n: u64) -> usize {
+    if n == 0 { if !buf.is_empty() { buf[0] = b'0'; } return 1; }
+    let mut tmp = [0u8; 20]; let mut i = 0usize;
+    while n > 0 { tmp[i] = b'0' + (n % 10) as u8; i += 1; n /= 10; }
+    if i > buf.len() { return 0; }
+    for j in 0..i { buf[j] = tmp[i - 1 - j]; }
+    i
+}
+
+fn fmt_resolution<'a>(buf: &'a mut [u8; 24], w: u16, h: u16) -> &'a str {
+    let mut p = 0usize;
+    p += write_u64(&mut buf[p..], w as u64);
+    buf[p..p+3].copy_from_slice(b" x "); p += 3;
+    p += write_u64(&mut buf[p..], h as u64);
+    core::str::from_utf8(&buf[..p]).unwrap_or("?")
+}
+
+fn fmt_info<'a>(buf: &'a mut [u8; 44], w: u16, h: u16) -> &'a str {
+    let pre = b"Selected: "; buf[..pre.len()].copy_from_slice(pre); let mut p = pre.len();
+    p += write_u64(&mut buf[p..], w as u64);
+    buf[p..p+3].copy_from_slice(b" x "); p += 3;
+    p += write_u64(&mut buf[p..], h as u64);
+    let suf = b" @ 32bpp  60Hz"; buf[p..p+suf.len()].copy_from_slice(suf); p += suf.len();
+    core::str::from_utf8(&buf[..p]).unwrap_or("?")
+}
+
+fn build_ver_str(buf: &mut [u8; 32], ver: &str, code: &str) -> usize {
+    let mut p = 0usize;
+    for b in ver.bytes() { if p < 31 { buf[p] = b; p += 1; } }
+    let sep = b" (";
+    for b in sep { if p < 31 { buf[p] = *b; p += 1; } }
+    for b in code.bytes() { if p < 31 { buf[p] = b; p += 1; } }
+    if p < 31 { buf[p] = b')'; p += 1; }
+    p
+}
+
+fn build_mem_str(buf: &mut [u8; 48], used_kb: u64, total_kb: u64) -> usize {
+    let mut p = 0usize;
+    p += write_u64(&mut buf[p..], used_kb / 1024);
+    let mid = b" MB / "; for b in mid { buf[p] = *b; p += 1; }
+    p += write_u64(&mut buf[p..], total_kb / 1024);
+    let suf = b" MB"; for b in suf { buf[p] = *b; p += 1; }
+    p
+}
+
+fn fit_within(sw: u32, sh: u32, mw: u32, mh: u32) -> (u32, u32) {
+    if sw == 0 || sh == 0 || mw == 0 || mh == 0 { return (0, 0); }
+    let scale_w = (mw as u64 * 1024) / sw as u64;
+    let scale_h = (mh as u64 * 1024) / sh as u64;
+    let scale = scale_w.min(scale_h).max(1);
+    (((sw as u64 * scale) / 1024).max(1) as u32, ((sh as u64 * scale) / 1024).max(1) as u32)
+}
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! { main() }
+
+fn main() -> ! {
+    log("SystemSettings: starting");
+
+    let port = match create_port() {
+        Ok(p) => p,
+        Err(_) => { log("SystemSettings: create_port failed"); exit(1); }
+    };
+    let _ = libipc::protocol::register_service("system_settings", port);
+
+    log("SystemSettings: looking up compositor.register");
+    let reg_port = loop {
+        match libipc::protocol::lookup_service("compositor.register") {
+            Ok(p) => break p,
+            Err(_) => yield_now(),
+        }
+    };
+
+    let mut rmsg = [0u8; MessageHeader::SIZE + 16];
+    let hdr = MessageHeader::new(MessageType::AppRegister, 16);
+    rmsg[..MessageHeader::SIZE].copy_from_slice(&hdr.to_bytes());
+    rmsg[MessageHeader::SIZE..MessageHeader::SIZE + 8].copy_from_slice(&port.to_le_bytes());
+    rmsg[MessageHeader::SIZE + 8..MessageHeader::SIZE + 16].copy_from_slice(&0u64.to_le_bytes());
+    let _ = send(reg_port, &rmsg[..MessageHeader::SIZE + 16]);
+
+    let sa = match SystemSettings::wait_for_surface(port) {
+        Some(sa) => sa,
+        None => { log("SystemSettings: surface timeout"); exit(1); }
+    };
+
+    let surface = match SharedSurface::from_region(sa.region_id, sa.width, sa.height) {
+        Ok(s) => s,
+        Err(_) => { log("SystemSettings: surface map failed"); exit(1); }
+    };
+
+    let (modes, mode_count) = query_modes();
+    let mut app = SystemSettings::new(sa.window_id, sa.compositor_port, port,
+                                      surface, modes, mode_count);
+    app.run();
+    exit(0);
+}
+
+#[panic_handler]
+fn panic(_: &PanicInfo) -> ! { log("SystemSettings: PANIC"); exit(0xFF); }

--- a/userspace/system_apps/system_settings/src/main.rs
+++ b/userspace/system_apps/system_settings/src/main.rs
@@ -1,16 +1,15 @@
 // Atom OS – System Settings
 //
-// Unified settings panel.  Sidebar on the right, content on the left.
-// Three pages under two categories:
+// Unified settings panel.  Sidebar on the LEFT, content on the RIGHT.
+// No inner header – the window chrome already shows the app name.
 //
 //   PERSONALIZATION
-//     Desktop Background  – solid colours + wallpaper browser + scaling
+//     Desktop Background  – solid-colour swatches + wallpaper browser + scaling
 //
 //   SYSTEM SETTINGS
 //     Display Resolution  – scrollable video-mode list
 //     About System        – OS / hardware / network summary
 //
-// Lifecycle: identical to the old display_settings app.
 // IPC service name: "system_settings"
 
 #![no_std]
@@ -42,7 +41,6 @@ use libipc::messages::{
     WallpaperAppliedMsg, WallpaperFailedMsg,
     ScalingMode, ApplyWallpaperMsg, WallpaperSourceType,
 };
-
 use libnet::net_get_config;
 
 use alloc::string::String;
@@ -68,10 +66,9 @@ unsafe impl GlobalAlloc for BumpAllocator {
         loop {
             let cur = self.next.load(Ordering::Relaxed);
             let aligned = (cur + align - 1) & !(align - 1);
-            let new_next = aligned + layout.size();
-            if new_next > HEAP_SIZE { return core::ptr::null_mut(); }
-            if self.next.compare_exchange_weak(cur, new_next,
-                    Ordering::SeqCst, Ordering::Relaxed).is_ok() {
+            let end = aligned + layout.size();
+            if end > HEAP_SIZE { return core::ptr::null_mut(); }
+            if self.next.compare_exchange_weak(cur, end, Ordering::SeqCst, Ordering::Relaxed).is_ok() {
                 return (self.heap.get() as *mut u8).add(aligned);
             }
         }
@@ -83,237 +80,236 @@ static ALLOCATOR: BumpAllocator = BumpAllocator::new();
 #[alloc_error_handler]
 fn alloc_error(_: Layout) -> ! { loop {} }
 
-// ── Theme ────────────────────────────────────────────────────────────────────
+// ── Theme ─────────────────────────────────────────────────────────────────────
 
 mod theme {
     use atom_syscall::graphics::Color;
-    pub const BG:           Color = Color::new(0x0B, 0x0E, 0x13);
-    pub const SURFACE:      Color = Color::new(0x14, 0x19, 0x22);
-    pub const SURFACE_ALT:  Color = Color::new(0x1B, 0x21, 0x30);
-    pub const BORDER:       Color = Color::new(0x2A, 0x31, 0x42);
-    pub const TEXT:         Color = Color::new(0xE8, 0xEC, 0xF4);
-    pub const TEXT_SEC:     Color = Color::new(0xAA, 0xB2, 0xC5);
-    pub const TEXT_MUTED:   Color = Color::new(0x6C, 0x74, 0x86);
-    pub const ACCENT:       Color = Color::new(0x4C, 0x8D, 0xFF);
-    pub const ACCENT_DIM:   Color = Color::new(0x2A, 0x55, 0xAA);
-    pub const SEL_BG:       Color = Color::new(0x1E, 0x2E, 0x50);
-    pub const HDR_BG:       Color = Color::new(0x1E, 0x26, 0x36);
-    pub const SIDEBAR_BG:   Color = Color::new(0x10, 0x14, 0x1E);
-    pub const SUCCESS:      Color = Color::new(0x22, 0xC5, 0x5E);
-    pub const WARNING:      Color = Color::new(0xF5, 0x9E, 0x0B);
-    pub const SCROLLBAR:    Color = Color::new(0x1A, 0x20, 0x30);
-    pub const THUMB:        Color = Color::new(0x40, 0x4E, 0x70);
-    pub const BTN_PRIMARY:  Color = Color::new(0x4C, 0x8D, 0xFF);
-    pub const BTN_RESTORE:  Color = Color::new(0x28, 0x30, 0x48);
-    pub const BTN_TEXT:     Color = Color::new(0xFF, 0xFF, 0xFF);
-    pub const ITEM_HOVER:   Color = Color::new(0x22, 0x2C, 0x44);
-    pub const CAT_LABEL:    Color = Color::new(0x55, 0x60, 0x80);
-    pub const DIVIDER:      Color = Color::new(0x22, 0x29, 0x3A);
-    pub const INFO_LABEL:   Color = Color::new(0x80, 0x90, 0xB0);
-    pub const INFO_VALUE:   Color = Color::new(0xD0, 0xD8, 0xEC);
+    // Backgrounds
+    pub const BG:          Color = Color::new(0x0B, 0x0E, 0x13);   // main content bg
+    pub const SURFACE:     Color = Color::new(0x14, 0x19, 0x22);   // card / tile bg
+    pub const SURFACE_ALT: Color = Color::new(0x1C, 0x22, 0x32);   // elevated surface
+    pub const SIDEBAR_BG:  Color = Color::new(0x0D, 0x11, 0x1A);   // sidebar bg (darker)
+    pub const HDR_BG:      Color = Color::new(0x0D, 0x11, 0x1A);   // status bar bg
+    // Borders / dividers
+    pub const BORDER:      Color = Color::new(0x28, 0x30, 0x42);
+    pub const DIVIDER:     Color = Color::new(0x1A, 0x20, 0x30);
+    // Text
+    pub const TEXT:        Color = Color::new(0xE8, 0xEC, 0xF4);
+    pub const TEXT_SEC:    Color = Color::new(0xA0, 0xAA, 0xC0);
+    pub const TEXT_MUTED:  Color = Color::new(0x55, 0x60, 0x7A);
+    // Accent
+    pub const ACCENT:      Color = Color::new(0x4C, 0x8D, 0xFF);
+    pub const ACCENT_DIM:  Color = Color::new(0x25, 0x4A, 0x88);
+    pub const SEL_BG:      Color = Color::new(0x1A, 0x2A, 0x4E);
+    // Sidebar active item
+    pub const ITEM_ACTIVE_BG: Color = Color::new(0x1C, 0x2C, 0x50);
+    // Status
+    pub const SUCCESS:     Color = Color::new(0x22, 0xC5, 0x5E);
+    pub const WARNING:     Color = Color::new(0xF5, 0x9E, 0x0B);
+    // Scrollbar
+    pub const SB_TRACK:    Color = Color::new(0x16, 0x1C, 0x2A);
+    pub const SB_THUMB:    Color = Color::new(0x38, 0x46, 0x64);
+    pub const SB_THUMB_ACT:Color = Color::new(0x4C, 0x8D, 0xFF);
+    // Buttons
+    pub const BTN_PRIMARY: Color = Color::new(0x4C, 0x8D, 0xFF);
+    pub const BTN_GHOST:   Color = Color::new(0x1E, 0x26, 0x3C);
+    pub const BTN_TEXT:    Color = Color::new(0xFF, 0xFF, 0xFF);
+    // About page info
+    pub const INFO_KEY:    Color = Color::new(0x70, 0x80, 0xA8);
+    pub const INFO_VAL:    Color = Color::new(0xD4, 0xDC, 0xF0);
 }
 
-// ── Layout constants ─────────────────────────────────────────────────────────
+// ── Layout constants ──────────────────────────────────────────────────────────
 
-const CHAR_W:       u32 = 8;
-const CHAR_H:       u32 = 8;
-const HDR_H:        u32 = 36;
-const STATUS_H:     u32 = 22;
-const SIDEBAR_W:    u32 = 208;
-const PAD:          u32 = 14;
-const ITEM_H:       u32 = 28;   // sidebar item row height
+const CW:     u32 = 8;   // character width
+const CH:     u32 = 8;   // character height
 
-// Resolution list
-const ROW_H:        u32 = 22;
-const VISIBLE_ROWS: usize = 11;
-const SB_W:         u32 = 8;
+// Sidebar (LEFT side, no header)
+const SIDEBAR_W:  u32 = 200;  // sidebar width
+const SB_PAD:     u32 = 12;   // sidebar inner padding
+const ITEM_H:     u32 = 30;   // nav item height
 
-// Wallpaper page
-const COLOR_SZ:     u32 = 48;
-const COLOR_GAP:    u32 = 10;
-const SCALE_BTN_W:  u32 = 62;
-const SCALE_BTN_H:  u32 = 24;
-const SCALE_BTN_GAP:u32 = 8;
-const IMG_W:        u32 = 88;
-const IMG_H:        u32 = 76;
-const IMG_GAP:      u32 = 10;
-const IMG_COLS:     usize = 4;
+// Status bar (full-width, bottom)
+const STAT_H:     u32 = 22;
 
-// Sidebar geometry helpers – computed at runtime based on surface_w
-// Sidebar occupies [surface_w - SIDEBAR_W .. surface_w]
+// Content area inner padding
+const PAD:        u32 = 16;
 
-// ── Data types ───────────────────────────────────────────────────────────────
+// Resolution page
+const ROW_H:      u32 = 22;
+const VIS_ROWS:   usize = 12;
+const SBW:        u32 = 8;    // scrollbar width
+
+// Wallpaper page — fixed absolute y-positions from content top (y=0)
+// Page title + divider take  CH+6+4+2 = 20px baseline → section starts at 32
+const PTITLE_H:  u32 = CH + 14;  // 22 — page title block height
+
+const SEC_LBL_H: u32 = CH + 8;  // 16 — section label row height
+
+// Color swatches
+const CSZ:   u32 = 44;   // swatch size
+const CGAP:  u32 = 8;    // gap between swatches (4 per row × 2 rows)
+
+// Scaling buttons
+const SBTN_W:  u32 = 56;
+const SBTN_H:  u32 = 22;
+const SBTN_G:  u32 = 8;
+
+// Wallpaper image tiles
+const TW:     u32 = 84;
+const TH:     u32 = 72;
+const TG:     u32 = 8;
+const TCOLS:  usize = 4;
+
+// Apply / Restore buttons
+const BTN_H:   u32 = 28;
+const BTN_W:   u32 = 90;
+const RBTN_W:  u32 = 128;
+
+// Default resolution
+const DEF_W: u16 = 1024;
+const DEF_H: u16 = 768;
+
+// ── Data types ────────────────────────────────────────────────────────────────
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-enum Page { DesktopBackground, DisplayResolution, AboutSystem }
+enum Page { DesktopBg, DisplayRes, AboutSys }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum StatusKind { None, Ok, Warn }
 
 struct Status {
-    kind: StatusKind, text: [u8; 56], len: usize, ticks: u32,
+    kind: StatusKind, buf: [u8; 64], len: usize, ticks: u32,
 }
 impl Status {
-    const fn new() -> Self { Self { kind: StatusKind::None, text: [0; 56], len: 0, ticks: 0 } }
+    const fn new() -> Self { Self { kind: StatusKind::None, buf: [0; 64], len: 0, ticks: 0 } }
     fn set(&mut self, kind: StatusKind, msg: &[u8]) {
         self.kind = kind;
-        self.len = msg.len().min(55);
-        self.text[..self.len].copy_from_slice(&msg[..self.len]);
-        self.ticks = 180;
+        self.len = msg.len().min(63);
+        self.buf[..self.len].copy_from_slice(&msg[..self.len]);
+        self.ticks = 200;
     }
     fn tick(&mut self) {
         if self.ticks > 0 { self.ticks -= 1; }
         if self.ticks == 0 { self.kind = StatusKind::None; }
     }
-    fn as_str(&self) -> &str { core::str::from_utf8(&self.text[..self.len]).unwrap_or("") }
+    fn as_str(&self) -> &str { core::str::from_utf8(&self.buf[..self.len]).unwrap_or("") }
 }
 
 #[derive(Clone, Copy)]
-struct Mode { width: u16, height: u16 }
-
-const DEFAULT_W: u16 = 1024;
-const DEFAULT_H: u16 = 768;
+struct Mode { w: u16, h: u16 }
 
 #[derive(Clone, PartialEq, Eq)]
-enum WallpaperSource { SolidColor { rgb: u32 }, Image { path: String } }
+enum WpSrc { Color { rgb: u32 }, Image { path: String } }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-enum ThumbState { Unloaded, Loaded { width: u16, height: u16 }, Failed }
+enum ThumbSt { Pending, Loaded { w: u16, h: u16 }, Fail }
 
-struct WpInfo { name: String, path: String, thumb: ThumbState }
+struct WpImage { name: String, path: String, thumb: ThumbSt }
 
-struct WallpaperState {
-    colors: [Color; 8],
-    images: Vec<WpInfo>,
-    selected: Option<WallpaperSource>,
-    scaling: ScalingMode,
-    discovering: bool,
+struct WpState {
+    swatches: [Color; 8],
+    images:   Vec<WpImage>,
+    selected: Option<WpSrc>,
+    scaling:  ScalingMode,
+    loading:  bool,
 }
-
-impl WallpaperState {
+impl WpState {
     fn new() -> Self {
         Self {
-            colors: [
-                Color::new(18, 20, 28), Color::new(12, 14, 22),
-                Color::new(24, 28, 42), Color::new(16, 24, 40),
-                Color::new(22, 36, 52), Color::new(28, 18, 36),
-                Color::new(20, 30, 24), Color::new(34, 20, 20),
+            swatches: [
+                Color::new(18,20,28), Color::new(12,14,22),
+                Color::new(24,28,42), Color::new(16,24,40),
+                Color::new(22,36,52), Color::new(28,18,36),
+                Color::new(20,30,24), Color::new(34,20,20),
             ],
             images: Vec::new(),
             selected: None,
             scaling: ScalingMode::Fill,
-            discovering: false,
+            loading: false,
         }
     }
-    fn is_image_selected(&self) -> bool {
-        matches!(self.selected, Some(WallpaperSource::Image { .. }))
-    }
-    fn select_color(&mut self, i: usize) {
-        if i >= self.colors.len() { return; }
-        let c = self.colors[i];
+    fn is_image_sel(&self) -> bool { matches!(self.selected, Some(WpSrc::Image { .. })) }
+    fn pick_color(&mut self, i: usize) {
+        if i >= 8 { return; }
+        let c = self.swatches[i];
         let rgb = ((c.r as u32) << 16) | ((c.g as u32) << 8) | c.b as u32;
-        self.selected = Some(WallpaperSource::SolidColor { rgb });
+        self.selected = Some(WpSrc::Color { rgb });
     }
-    fn select_image(&mut self, i: usize) {
-        if let Some(info) = self.images.get(i) {
-            self.selected = Some(WallpaperSource::Image { path: info.path.clone() });
+    fn pick_image(&mut self, i: usize) {
+        if let Some(img) = self.images.get(i) {
+            self.selected = Some(WpSrc::Image { path: img.path.clone() });
         }
     }
     fn discover(&mut self) {
         use atom_syscall::fs::{open, readdir, close, OpenFlags, FileType};
-        self.discovering = true;
+        self.loading = true;
         self.images.clear();
         let fd = match open("/system/wallpapers/", OpenFlags::DIRECTORY, 0) {
             Ok(fd) => fd,
-            Err(_) => { self.discovering = false; return; }
+            Err(_) => { self.loading = false; return; }
         };
         let entries = match readdir(fd) {
             Ok(e) => e,
-            Err(_) => { let _ = close(fd); self.discovering = false; return; }
+            Err(_) => { let _ = close(fd); self.loading = false; return; }
         };
         let _ = close(fd);
         for e in entries {
             if e.file_type == FileType::Directory { continue; }
-            let low = e.name.to_lowercase();
-            if !low.ends_with(".jpg") && !low.ends_with(".jpeg") { continue; }
-            let mut path = String::from("/system/wallpapers/");
-            path.push_str(&e.name);
-            self.images.push(WpInfo { name: e.name, path, thumb: ThumbState::Unloaded });
+            let lc = e.name.to_lowercase();
+            if !lc.ends_with(".jpg") && !lc.ends_with(".jpeg") { continue; }
+            let mut p = String::from("/system/wallpapers/");
+            p.push_str(&e.name);
+            self.images.push(WpImage { name: e.name, path: p, thumb: ThumbSt::Pending });
             if self.images.len() >= 80 { break; }
         }
         self.images.sort_by(|a, b| a.name.cmp(&b.name));
-        self.discovering = false;
+        self.loading = false;
     }
 }
 
-// ── About System cached info ──────────────────────────────────────────────────
-
-struct AboutInfo {
-    cpu_brand: [u8; 64], cpu_brand_len: usize,
-    cpu_cores: u64,
-    mem_total_kb: u64, mem_used_kb: u64,
-    uptime_buf: [u8; 32], uptime_len: usize,
+// Cached system info for the About page
+struct SysInfo {
+    cpu_buf: [u8; 64], cpu_len: usize,
+    cores: u64,
+    mem_total: u64, mem_used: u64,
+    up_buf: [u8; 32], up_len: usize,
     ip_buf: [u8; 48], ip_len: usize,
 }
-
-impl AboutInfo {
-    fn gather() -> Self {
-        let mut cpu_brand = [0u8; 64];
-        let cpu_brand_len = get_cpu_brand(&mut cpu_brand);
-        let cpu_cores = get_cpu_count();
-
-        let (total_kb, free_kb) = get_memory_info();
-        let mem_total_kb = total_kb;
-        let mem_used_kb = total_kb.saturating_sub(free_kb);
-
-        // Uptime
-        let mut uptime_buf = [0u8; 32];
-        let uptime_len = {
-            let ticks = get_ticks();
-            let secs = ticks / 100;
-            let h = secs / 3600;
-            let m = (secs % 3600) / 60;
-            let s = secs % 60;
-            let mut p = 0usize;
-            p += write_u64(&mut uptime_buf[p..], h);
-            uptime_buf[p] = b'h'; p += 1;
-            uptime_buf[p] = b' '; p += 1;
-            if m < 10 { uptime_buf[p] = b'0'; p += 1; }
-            p += write_u64(&mut uptime_buf[p..], m);
-            uptime_buf[p] = b'm'; p += 1;
-            uptime_buf[p] = b' '; p += 1;
-            if s < 10 { uptime_buf[p] = b'0'; p += 1; }
-            p += write_u64(&mut uptime_buf[p..], s);
-            uptime_buf[p] = b's'; p += 1;
-            p
-        };
-
-        // IP address
+impl SysInfo {
+    fn collect() -> Self {
+        let mut cpu_buf = [0u8; 64];
+        let cpu_len = get_cpu_brand(&mut cpu_buf);
+        let cores   = get_cpu_count();
+        let (total, free) = get_memory_info();
+        let mut up_buf = [0u8; 32];
+        let up_len = fmt_uptime(&mut up_buf);
         let mut ip_buf = [0u8; 48];
-        let ip_len = gather_ip(&mut ip_buf);
-
-        AboutInfo { cpu_brand, cpu_brand_len, cpu_cores, mem_total_kb, mem_used_kb,
-                    uptime_buf, uptime_len, ip_buf, ip_len }
+        let ip_len = collect_ip(&mut ip_buf);
+        SysInfo { cpu_buf, cpu_len, cores, mem_total: total, mem_used: total.saturating_sub(free),
+                  up_buf, up_len, ip_buf, ip_len }
     }
-    fn cpu_brand_str(&self) -> &str {
-        core::str::from_utf8(&self.cpu_brand[..self.cpu_brand_len]).unwrap_or("x86_64")
-    }
-    fn uptime_str(&self) -> &str {
-        core::str::from_utf8(&self.uptime_buf[..self.uptime_len]).unwrap_or("-")
-    }
-    fn ip_str(&self) -> &str {
-        core::str::from_utf8(&self.ip_buf[..self.ip_len]).unwrap_or("unavailable")
-    }
+    fn cpu(&self) -> &str { core::str::from_utf8(&self.cpu_buf[..self.cpu_len]).unwrap_or("x86_64") }
+    fn uptime(&self) -> &str { core::str::from_utf8(&self.up_buf[..self.up_len]).unwrap_or("-") }
+    fn ip(&self) -> &str { core::str::from_utf8(&self.ip_buf[..self.ip_len]).unwrap_or("unavailable") }
 }
 
-fn gather_ip(buf: &mut [u8; 48]) -> usize {
+fn fmt_uptime(buf: &mut [u8; 32]) -> usize {
+    let s = get_ticks() / 100;
+    let h = s / 3600; let m = (s % 3600) / 60; let ss = s % 60;
+    let mut p = 0usize;
+    p += fmt_u64(&mut buf[p..], h); buf[p]=b'h'; p+=1; buf[p]=b' '; p+=1;
+    if m<10 { buf[p]=b'0'; p+=1; }
+    p += fmt_u64(&mut buf[p..], m); buf[p]=b'm'; p+=1; buf[p]=b' '; p+=1;
+    if ss<10 { buf[p]=b'0'; p+=1; }
+    p += fmt_u64(&mut buf[p..], ss); buf[p]=b's'; p+=1;
+    p
+}
+
+fn collect_ip(buf: &mut [u8; 48]) -> usize {
     let port = match libipc::protocol::lookup_service("netd") {
         Ok(p) => p,
-        Err(_) => {
-            let msg = b"unavailable";
-            buf[..msg.len()].copy_from_slice(msg);
-            return msg.len();
-        }
+        Err(_) => { let m = b"unavailable"; buf[..m.len()].copy_from_slice(m); return m.len(); }
     };
     match net_get_config(port) {
         Ok(cfg) => {
@@ -321,268 +317,238 @@ fn gather_ip(buf: &mut [u8; 48]) -> usize {
             match cfg.ip {
                 IpAddr::V4(b) => {
                     let mut p = 0usize;
-                    p += write_u64(&mut buf[p..], b[0] as u64);
-                    buf[p] = b'.'; p += 1;
-                    p += write_u64(&mut buf[p..], b[1] as u64);
-                    buf[p] = b'.'; p += 1;
-                    p += write_u64(&mut buf[p..], b[2] as u64);
-                    buf[p] = b'.'; p += 1;
-                    p += write_u64(&mut buf[p..], b[3] as u64);
-                    p
+                    p+=fmt_u64(&mut buf[p..],b[0]as u64); buf[p]=b'.'; p+=1;
+                    p+=fmt_u64(&mut buf[p..],b[1]as u64); buf[p]=b'.'; p+=1;
+                    p+=fmt_u64(&mut buf[p..],b[2]as u64); buf[p]=b'.'; p+=1;
+                    p+=fmt_u64(&mut buf[p..],b[3]as u64); p
                 }
-                IpAddr::V6(_) => { let m = b"(IPv6)"; buf[..6].copy_from_slice(m); 6 }
+                IpAddr::V6(_) => { let m=b"(IPv6)"; buf[..6].copy_from_slice(m); 6 }
             }
         }
-        Err(_) => { let m = b"unavailable"; buf[..m.len()].copy_from_slice(m); m.len() }
+        Err(_) => { let m=b"unavailable"; buf[..m.len()].copy_from_slice(m); m.len() }
     }
 }
 
-// ── Main app state ────────────────────────────────────────────────────────────
+// ── App state ─────────────────────────────────────────────────────────────────
 
-struct SystemSettings {
-    window_id:   u32,
-    comp_port:   PortId,
-    local_port:  PortId,
-    surface:     Option<SharedSurface>,
-    sw:          u32,   // surface width
-    sh:          u32,   // surface height
-    dirty:       bool,
-    running:     bool,
+struct App {
+    wid:    u32,
+    cport:  PortId,
+    lport:  PortId,
+    surf:   Option<SharedSurface>,
+    sw:     u32,
+    sh:     u32,
+    dirty:  bool,
+    alive:  bool,
 
-    // Navigation
-    active_page: Page,
-
-    // Status bar
+    page:   Page,
     status: Status,
 
     // Resolution page
-    modes:      [Mode; VIDEO_MAX_MODES],
-    mode_count: usize,
-    selected:   usize,
-    scroll:     usize,
-    sb_drag:    bool,
-    sb_drag_off:i32,
+    modes:  [Mode; VIDEO_MAX_MODES],
+    mcnt:   usize,
+    sel:    usize,
+    scroll: usize,
+    sbdrag: bool,
+    sboff:  i32,
 
     // Wallpaper page
-    wp: WallpaperState,
-    wp_scroll: usize,
+    wp:      WpState,
+    wpscr:   usize,
 
     // About page
-    about: AboutInfo,
+    sinfo:  SysInfo,
 }
 
-impl SystemSettings {
-    fn new(window_id: u32, comp_port: PortId, local_port: PortId,
-           surface: SharedSurface,
-           modes: [Mode; VIDEO_MAX_MODES], mode_count: usize) -> Self {
-        let sw = surface.width();
-        let sh = surface.height();
-        let sel = default_idx(&modes, mode_count);
-        let mut s = Self {
-            window_id, comp_port, local_port,
-            surface: Some(surface), sw, sh,
-            dirty: true, running: true,
-            active_page: Page::DesktopBackground,
-            status: Status::new(),
-            modes, mode_count, selected: sel,
-            scroll: 0, sb_drag: false, sb_drag_off: 0,
-            wp: WallpaperState::new(), wp_scroll: 0,
-            about: AboutInfo::gather(),
+impl App {
+    fn new(wid: u32, cport: PortId, lport: PortId, surf: SharedSurface,
+           modes: [Mode; VIDEO_MAX_MODES], mcnt: usize) -> Self {
+        let sw = surf.width(); let sh = surf.height();
+        let sel = default_mode(&modes, mcnt);
+        let mut a = Self {
+            wid, cport, lport, surf: Some(surf), sw, sh,
+            dirty: true, alive: true,
+            page: Page::DesktopBg, status: Status::new(),
+            modes, mcnt, sel, scroll: 0, sbdrag: false, sboff: 0,
+            wp: WpState::new(), wpscr: 0,
+            sinfo: SysInfo::collect(),
         };
-        s.clamp_scroll();
-        s.wp.discover();
-        s
+        a.clamp_scroll();
+        a.wp.discover();
+        a
     }
 
-    // ── Layout helpers ────────────────────────────────────────────────────────
+    // ── Geometry ──────────────────────────────────────────────────────────────
 
-    /// X coordinate where the sidebar begins.
-    fn sidebar_x(&self) -> u32 { self.sw.saturating_sub(SIDEBAR_W) }
+    // Sidebar occupies x ∈ [0, SIDEBAR_W)
+    // Content occupies x ∈ [SIDEBAR_W+1, sw)
+    fn cx(&self) -> u32 { SIDEBAR_W + 1 }          // content left edge (absolute)
+    fn cw(&self) -> u32 { self.sw.saturating_sub(SIDEBAR_W + 1) }  // content width
+    fn content_h(&self) -> u32 { self.sh.saturating_sub(STAT_H) }  // usable height
 
-    /// Width of the content area.
-    fn content_w(&self) -> u32 { self.sw.saturating_sub(SIDEBAR_W + 1) }
+    // ── Sidebar item hit-test ─────────────────────────────────────────────────
 
-    /// Y where content / sidebar body starts (below header).
-    fn body_y(&self) -> u32 { HDR_H + 1 }
+    // Returns (page, absolute_y, item_height) for each nav item
+    fn nav_items(&self) -> [(Page, u32); 3] {
+        let top = SB_PAD;
+        let cat  = CH + 10;   // category label row + gap below
+        let igap = 4;         // gap between items
 
-    /// Height of content / sidebar body.
-    fn body_h(&self) -> u32 { self.sh.saturating_sub(HDR_H + 1 + STATUS_H) }
+        let y0 = top + cat;                           // Desktop Bg
+        let y1 = y0 + ITEM_H + igap + 14 + cat;      // Display Res  (+gap + next category)
+        let y2 = y1 + ITEM_H + igap;                  // About Sys
+        [(Page::DesktopBg, y0), (Page::DisplayRes, y1), (Page::AboutSys, y2)]
+    }
 
-    // ── Sidebar hit testing ───────────────────────────────────────────────────
-
-    /// Given a click inside the sidebar, return the clicked Page (if any).
-    fn sidebar_page_at(&self, cx: i32, cy: i32) -> Option<Page> {
-        let sx = self.sidebar_x() as i32;
-        if cx < sx { return None; }
-        for (page, iy) in self.sidebar_item_positions() {
-            if cy >= iy as i32 && cy < (iy + ITEM_H) as i32 {
-                return Some(page);
-            }
+    fn nav_hit(&self, mx: i32, my: i32) -> Option<Page> {
+        if mx < 0 || mx >= SIDEBAR_W as i32 { return None; }
+        for (pg, iy) in self.nav_items() {
+            if my >= iy as i32 && my < (iy + ITEM_H) as i32 { return Some(pg); }
         }
         None
     }
 
-    /// Returns (Page, absolute_y) for every sidebar item, in order.
-    fn sidebar_item_positions(&self) -> [(Page, u32); 3] {
-        let top = self.body_y() + PAD;
-        let cat_h = CHAR_H + 12;   // category row height
-        let gap   = ITEM_H + 6;    // inter-item gap
+    // ── Wallpaper page element positions (absolute) ───────────────────────────
 
-        let y0 = top + cat_h + 4;                               // Desktop Background
-        let y1 = y0 + gap + cat_h + 4 + 14;                     // Display Resolution (new cat)
-        let y2 = y1 + gap;                                       // About System
-        [
-            (Page::DesktopBackground,  y0),
-            (Page::DisplayResolution,  y1),
-            (Page::AboutSystem,        y2),
-        ]
+    // Content y layout (from y=0 at the top of the surface):
+    //   0  .. PTITLE_H        : page title block
+    //   PTITLE_H .. PTITLE_H+2: thin divider
+    //   — section "Background Color"
+    //   — 4×2 color swatches
+    //   — section "Image Scaling"
+    //   — scaling buttons
+    //   — section "Wallpaper Images"
+    //   — image tiles
+    //   sh-STAT_H-BTN_H-12   : Apply button
+
+    fn wp_section1_y(&self) -> u32 { PTITLE_H + 4 }
+    fn wp_swatch_row_y(&self, row: u32) -> u32 {
+        self.wp_section1_y() + SEC_LBL_H + row * (CSZ + CGAP)
+    }
+    fn wp_section2_y(&self) -> u32 { self.wp_swatch_row_y(2) + 4 }
+    fn wp_sbtn_row_y(&self, row: u32) -> u32 {
+        self.wp_section2_y() + SEC_LBL_H + row * (SBTN_H + SBTN_G)
+    }
+    fn wp_section3_y(&self) -> u32 { self.wp_sbtn_row_y(2) + 6 }
+    fn wp_tile_row_y(&self, row: u32) -> u32 {
+        self.wp_section3_y() + SEC_LBL_H + row * (TH + TG)
     }
 
-    // ── Page switching ────────────────────────────────────────────────────────
-
-    fn switch_page(&mut self, page: Page) {
-        self.active_page = page;
-        self.dirty = true;
+    fn swatch_rect(&self, i: usize) -> (u32, u32) {
+        let cx = self.cx();
+        let col = (i % 4) as u32;
+        let row = (i / 4) as u32;
+        (cx + PAD + col * (CSZ + CGAP), self.wp_swatch_row_y(row))
+    }
+    fn sbtn_rect(&self, i: usize) -> (u32, u32) {
+        let cx = self.cx();
+        let col = (i % 3) as u32;
+        let row = (i / 3) as u32;
+        (cx + PAD + col * (SBTN_W + SBTN_G), self.wp_sbtn_row_y(row))
+    }
+    fn tile_rect(&self, vis: usize) -> (u32, u32) {
+        let cx = self.cx();
+        let col = (vis % TCOLS) as u32;
+        let row = (vis / TCOLS) as u32;
+        (cx + PAD + col * (TW + TG), self.wp_tile_row_y(row))
     }
 
-    fn handle_open_in_tab(&mut self, name: &str) {
-        match name {
-            "Desktop Background" | "Wallpaper" => self.switch_page(Page::DesktopBackground),
-            "Display Resolution" | "Resolution" => self.switch_page(Page::DisplayResolution),
-            "About System"                      => self.switch_page(Page::AboutSystem),
-            _ => return,
-        }
+    fn apply_btn(&self) -> (u32, u32) {
+        let y = self.sh.saturating_sub(STAT_H + BTN_H + 10);
+        let x = (self.cx() + self.cw()).saturating_sub(PAD + BTN_W);
+        (x, y)
     }
-
-    // ── IPC presentation ─────────────────────────────────────────────────────
-
-    fn present(&self) {
-        let msg = SurfacePresentMsg { window_id: self.window_id };
-        let hdr = MessageHeader::new(MessageType::SurfacePresent, SurfacePresentMsg::SIZE as u32);
-        let mut buf = [0u8; MessageHeader::SIZE + SurfacePresentMsg::SIZE];
-        buf[..MessageHeader::SIZE].copy_from_slice(&hdr.to_bytes());
-        buf[MessageHeader::SIZE..].copy_from_slice(&msg.to_bytes());
-        let _ = send(self.comp_port, &buf);
-    }
-
-    fn notify_mode_changed(&self) {
-        let hdr = MessageHeader::new(MessageType::VideoModeChanged, 0);
-        let mut buf = [0u8; MessageHeader::SIZE];
-        buf[..MessageHeader::SIZE].copy_from_slice(&hdr.to_bytes());
-        let _ = send(self.comp_port, &buf);
+    fn restore_btn(&self) -> (u32, u32) {
+        let (ax, ay) = self.apply_btn();
+        (ax.saturating_sub(8 + RBTN_W), ay)
     }
 
     // ── Resolution helpers ────────────────────────────────────────────────────
 
-    fn clamp_scroll(&mut self) {
-        let max = self.mode_count.saturating_sub(VISIBLE_ROWS);
-        if self.scroll > max { self.scroll = max; }
-        if self.selected < self.scroll { self.scroll = self.selected; }
-        if self.selected >= self.scroll + VISIBLE_ROWS {
-            self.scroll = self.selected + 1 - VISIBLE_ROWS;
-        }
-    }
+    fn res_list_top(&self) -> u32 { PTITLE_H + SEC_LBL_H + 6 }
 
-    fn res_list_geom(&self) -> (u32, u32, u32, u32) {
-        let sec_h = CHAR_H + 14;
-        let top = self.body_y() + PAD + sec_h;
-        let h   = VISIBLE_ROWS as u32 * ROW_H;
-        let cw  = self.content_w();
-        let w   = cw.saturating_sub(PAD * 2 + SB_W + 4);
-        let sbx = cw.saturating_sub(PAD + SB_W);
+    fn res_geom(&self) -> (u32, u32, u32, u32) {
+        let top = self.res_list_top();
+        let h   = VIS_ROWS as u32 * ROW_H;
+        let w   = self.cw().saturating_sub(PAD * 2 + SBW + 4);
+        let sbx = self.cx() + self.cw().saturating_sub(PAD + SBW);
         (top, h, w, sbx)
     }
 
-    fn scrollbar_geom(&self) -> (u32, u32, u32) {
-        let (top, list_h, _, _) = self.res_list_geom();
-        let total = self.mode_count as u32;
-        let vis   = VISIBLE_ROWS as u32;
-        let thumb_h = if total > 0 {
-            ((list_h * vis) / total).max(14).min(list_h)
-        } else { list_h };
-        let travel = list_h.saturating_sub(thumb_h);
-        let max_s  = self.mode_count.saturating_sub(VISIBLE_ROWS) as u32;
-        let thumb_y = if max_s > 0 {
-            top + travel * self.scroll as u32 / max_s
-        } else { top };
-        (thumb_y, thumb_h, travel)
+    fn sb_geom(&self) -> (u32, u32, u32) {
+        let (top, lh, _, _) = self.res_geom();
+        let total = self.mcnt as u32;
+        let vis   = VIS_ROWS as u32;
+        let th = if total > 0 { ((lh * vis) / total).max(14).min(lh) } else { lh };
+        let tr = lh.saturating_sub(th);
+        let ms = self.mcnt.saturating_sub(VIS_ROWS) as u32;
+        let ty = if ms > 0 { top + tr * self.scroll as u32 / ms } else { top };
+        (ty, th, tr)
     }
 
-    fn set_scroll_from_y(&mut self, thumb_y: i32) {
-        let (top, _, _, _) = self.res_list_geom();
-        let (_, _, travel) = self.scrollbar_geom();
-        let max_s = self.mode_count.saturating_sub(VISIBLE_ROWS);
-        if travel == 0 || max_s == 0 { self.scroll = 0; return; }
-        let rel = (thumb_y - top as i32).clamp(0, travel as i32) as u32;
-        self.scroll = ((rel as u64 * max_s as u64 + travel as u64 / 2) / travel as u64) as usize;
+    fn clamp_scroll(&mut self) {
+        let max = self.mcnt.saturating_sub(VIS_ROWS);
+        if self.scroll > max { self.scroll = max; }
+        if self.sel < self.scroll { self.scroll = self.sel; }
+        if self.sel >= self.scroll + VIS_ROWS { self.scroll = self.sel + 1 - VIS_ROWS; }
+    }
+
+    fn set_scroll_from_drag(&mut self, y: i32) {
+        let (top, _, _, _) = self.res_geom();
+        let (_, _, tr) = self.sb_geom();
+        let max = self.mcnt.saturating_sub(VIS_ROWS);
+        if tr == 0 || max == 0 { self.scroll = 0; return; }
+        let rel = (y - top as i32).clamp(0, tr as i32) as u32;
+        self.scroll = ((rel as u64 * max as u64 + tr as u64 / 2) / tr as u64) as usize;
         self.dirty = true;
     }
 
     fn apply_resolution(&mut self) {
-        if self.mode_count == 0 { return; }
-        let m = self.modes[self.selected];
-        match set_video_mode(m.width, m.height, 32) {
-            Ok(()) => { self.notify_mode_changed(); self.status.set(StatusKind::Ok, b"Resolution applied."); }
+        if self.mcnt == 0 { return; }
+        let m = self.modes[self.sel];
+        match set_video_mode(m.w, m.h, 32) {
+            Ok(()) => {
+                let hdr = MessageHeader::new(MessageType::VideoModeChanged, 0);
+                let mut b = [0u8; MessageHeader::SIZE];
+                b[..MessageHeader::SIZE].copy_from_slice(&hdr.to_bytes());
+                let _ = send(self.cport, &b);
+                self.status.set(StatusKind::Ok, b"Resolution applied.");
+            }
             Err(_) => self.status.set(StatusKind::Warn, b"BGA unavailable or mode rejected."),
         }
         self.dirty = true;
     }
 
     fn restore_default(&mut self) {
-        if self.mode_count == 0 { return; }
-        self.selected = default_idx(&self.modes, self.mode_count);
+        if self.mcnt == 0 { return; }
+        self.sel = default_mode(&self.modes, self.mcnt);
         self.clamp_scroll();
-        let m = self.modes[self.selected];
-        match set_video_mode(m.width, m.height, 32) {
-            Ok(()) => { self.notify_mode_changed(); self.status.set(StatusKind::Ok, b"Restored 1024x768."); }
+        let m = self.modes[self.sel];
+        match set_video_mode(m.w, m.h, 32) {
+            Ok(()) => {
+                let hdr = MessageHeader::new(MessageType::VideoModeChanged, 0);
+                let mut b = [0u8; MessageHeader::SIZE];
+                b[..MessageHeader::SIZE].copy_from_slice(&hdr.to_bytes());
+                let _ = send(self.cport, &b);
+                self.status.set(StatusKind::Ok, b"Restored 1024x768.");
+            }
             Err(_) => self.status.set(StatusKind::Warn, b"BGA unavailable."),
         }
         self.dirty = true;
     }
 
-    // ── Wallpaper helpers ─────────────────────────────────────────────────────
-
-    fn color_tile_rect(&self, i: usize) -> (u32, u32) {
-        let row = (i / 4) as u32;
-        let col = (i % 4) as u32;
-        let x = PAD + col * (COLOR_SZ + COLOR_GAP);
-        let y = self.body_y() + PAD + CHAR_H + 10 + row * (COLOR_SZ + COLOR_GAP);
-        (x, y)
-    }
-
-    fn scaling_btn_rect(&self, i: usize) -> (u32, u32) {
-        let row = (i / 3) as u32;
-        let col = (i % 3) as u32;
-        let base_y = self.body_y() + PAD + CHAR_H + 10
-            + 2 * (COLOR_SZ + COLOR_GAP) + 10 + CHAR_H + 6;
-        let x = PAD + col * (SCALE_BTN_W + SCALE_BTN_GAP);
-        let y = base_y + row * (SCALE_BTN_H + SCALE_BTN_GAP);
-        (x, y)
-    }
-
-    fn img_tile_rect(&self, visible_idx: usize) -> (u32, u32) {
-        let col = (visible_idx % IMG_COLS) as u32;
-        let row = (visible_idx / IMG_COLS) as u32;
-        let base_y = self.body_y() + PAD + CHAR_H + 10
-            + 2 * (COLOR_SZ + COLOR_GAP) + 10 + CHAR_H + 6
-            + 2 * (SCALE_BTN_H + SCALE_BTN_GAP) + 14 + CHAR_H + 6;
-        let x = PAD + col * (IMG_W + IMG_GAP);
-        let y = base_y + row * (IMG_H + IMG_GAP);
-        (x, y)
-    }
-
     fn apply_wallpaper(&mut self) {
-        let source = match &self.wp.selected {
+        let src = match &self.wp.selected {
             Some(s) => s.clone(),
-            None => { self.status.set(StatusKind::Warn, b"No background selected."); self.dirty = true; return; }
+            None => { self.status.set(StatusKind::Warn, b"Select a background first."); self.dirty=true; return; }
         };
-        let msg = match &source {
-            WallpaperSource::SolidColor { rgb } => ApplyWallpaperMsg {
+        let msg = match &src {
+            WpSrc::Color { rgb } => ApplyWallpaperMsg {
                 source_type: WallpaperSourceType::SolidColor,
                 image_path: None, color_rgb: Some(*rgb),
                 scaling_mode: self.wp.scaling,
             },
-            WallpaperSource::Image { path } => ApplyWallpaperMsg {
+            WpSrc::Image { path } => ApplyWallpaperMsg {
                 source_type: WallpaperSourceType::Image,
                 image_path: Some(path.clone()), color_rgb: None,
                 scaling_mode: self.wp.scaling,
@@ -593,9 +559,9 @@ impl SystemSettings {
         let mut buf = Vec::new();
         buf.extend_from_slice(&hdr.to_bytes());
         buf.extend_from_slice(&payload);
-        match send(self.comp_port, &buf) {
-            Ok(()) => { self.status.set(StatusKind::Ok, b"Applying background..."); }
-            Err(_) => { self.status.set(StatusKind::Warn, b"Failed to apply."); }
+        match send(self.cport, &buf) {
+            Ok(()) => self.status.set(StatusKind::Ok, b"Applying background..."),
+            Err(_) => self.status.set(StatusKind::Warn, b"Failed to send request."),
         }
         self.dirty = true;
     }
@@ -605,628 +571,539 @@ impl SystemSettings {
     fn render(&mut self) {
         if !self.dirty { return; }
         self.dirty = false;
-        let surface = match self.surface { Some(ref s) => s as *const SharedSurface, None => return };
-        let surface = unsafe { &*surface };
-        self.draw_header(surface);
-        self.draw_sidebar(surface);
-        self.draw_divider(surface);
-        self.draw_content(surface);
-        self.draw_status_bar(surface);
-        self.present();
+
+        let sp = match self.surf { Some(ref s) => s as *const SharedSurface, None => return };
+        let s = unsafe { &*sp };
+
+        // Full-window background reset
+        s.fill_rect(0, 0, self.sw, self.sh, theme::BG);
+
+        self.draw_sidebar(s);
+        self.draw_divider(s);
+        self.draw_content(s);
+        self.draw_status(s);
+
+        // Present
+        let msg = SurfacePresentMsg { window_id: self.wid };
+        let hdr = MessageHeader::new(MessageType::SurfacePresent, SurfacePresentMsg::SIZE as u32);
+        let mut b = [0u8; MessageHeader::SIZE + SurfacePresentMsg::SIZE];
+        b[..MessageHeader::SIZE].copy_from_slice(&hdr.to_bytes());
+        b[MessageHeader::SIZE..].copy_from_slice(&msg.to_bytes());
+        let _ = send(self.cport, &b);
     }
 
-    fn draw_header(&self, s: &SharedSurface) {
-        s.fill_rect(0, 0, self.sw, HDR_H, theme::HDR_BG);
-        s.fill_rect(0, HDR_H - 1, self.sw, 1, theme::BORDER);
-        // Gear icon (simplified pixel art)
-        let ix = PAD;
-        let iy = (HDR_H - 14) / 2;
-        s.fill_rect(ix + 5, iy, 4, 14, theme::ACCENT);
-        s.fill_rect(ix, iy + 5, 14, 4, theme::ACCENT);
-        s.fill_rect(ix + 3, iy + 3, 8, 8, theme::ACCENT);
-        s.fill_rect(ix + 5, iy + 5, 4, 4, theme::HDR_BG);
-        // Title
-        let title = "System Settings";
-        let tx = ix + 20;
-        let ty = (HDR_H - CHAR_H) / 2;
-        s.draw_string(tx, ty, title, theme::TEXT, theme::HDR_BG);
-    }
+    // ── Sidebar ───────────────────────────────────────────────────────────────
 
     fn draw_sidebar(&self, s: &SharedSurface) {
-        let sx = self.sidebar_x();
-        let by = self.body_y();
-        let bh = self.body_h();
-        // Background
-        s.fill_rect(sx, by, SIDEBAR_W, bh, theme::SIDEBAR_BG);
+        let h = self.content_h();
+        s.fill_rect(0, 0, SIDEBAR_W, h, theme::SIDEBAR_BG);
 
-        let positions = self.sidebar_item_positions();
-        let top = by + PAD;
-        let cat_y0 = top;
-        let cat_y1 = positions[1].1 - CHAR_H - 4 - 14;
+        let items = self.nav_items();
 
-        // Category 1: PERSONALIZATION
-        self.draw_sidebar_category(s, sx, cat_y0, "PERSONALIZATION");
-        // Item: Desktop Background
-        self.draw_sidebar_item(s, sx, positions[0].1,
-            "Desktop Background", positions[0].0 == self.active_page);
+        // Category 1
+        let cat1_y = SB_PAD;
+        self.draw_cat_label(s, cat1_y, "PERSONALIZATION");
+        self.draw_nav_item(s, items[0].1, "Desktop Background", items[0].0 == self.page);
 
-        // Category 2: SYSTEM SETTINGS
-        self.draw_sidebar_category(s, sx, cat_y1, "SYSTEM SETTINGS");
-        // Item: Display Resolution
-        self.draw_sidebar_item(s, sx, positions[1].1,
-            "Display Resolution", positions[1].0 == self.active_page);
-        // Item: About System
-        self.draw_sidebar_item(s, sx, positions[2].1,
-            "About System", positions[2].0 == self.active_page);
+        // Category 2
+        let cat2_y = items[1].1.saturating_sub(CH + 10 + 4);
+        self.draw_cat_label(s, cat2_y, "SYSTEM SETTINGS");
+        self.draw_nav_item(s, items[1].1, "Display Resolution", items[1].0 == self.page);
+        self.draw_nav_item(s, items[2].1, "About System",       items[2].0 == self.page);
     }
 
-    fn draw_sidebar_category(&self, s: &SharedSurface, sx: u32, y: u32, label: &str) {
-        s.draw_string(sx + PAD, y + 2, label, theme::CAT_LABEL, theme::SIDEBAR_BG);
+    fn draw_cat_label(&self, s: &SharedSurface, y: u32, label: &str) {
+        s.draw_string(SB_PAD + 4, y + 2, label, theme::TEXT_MUTED, theme::SIDEBAR_BG);
     }
 
-    fn draw_sidebar_item(&self, s: &SharedSurface, sx: u32, y: u32, label: &str, active: bool) {
-        let bg = if active { theme::SEL_BG } else { theme::SIDEBAR_BG };
-        s.fill_rect(sx, y, SIDEBAR_W, ITEM_H, bg);
+    fn draw_nav_item(&self, s: &SharedSurface, y: u32, label: &str, active: bool) {
         if active {
-            s.fill_rect(sx, y, 3, ITEM_H, theme::ACCENT);
+            // Rounded-rect highlight spanning most of sidebar width
+            s.fill_rect_rounded_aa(6, y, SIDEBAR_W - 12, ITEM_H, 6, theme::ITEM_ACTIVE_BG);
+            // Left accent bar
+            s.fill_rect_rounded_aa(4, y + 4, 3, ITEM_H - 8, 2, theme::ACCENT);
         }
         let fg = if active { theme::TEXT } else { theme::TEXT_SEC };
-        let lx = sx + PAD + (if active { 6 } else { 4 });
-        s.draw_string(lx, y + (ITEM_H - CHAR_H) / 2, label, fg, bg);
+        let bg = if active { theme::ITEM_ACTIVE_BG } else { theme::SIDEBAR_BG };
+        let lx = SB_PAD + 10;
+        s.draw_string(lx, y + (ITEM_H - CH) / 2, label, fg, bg);
     }
 
     fn draw_divider(&self, s: &SharedSurface) {
-        let sx = self.sidebar_x();
-        s.fill_rect(sx.saturating_sub(1), self.body_y(), 1, self.body_h(), theme::BORDER);
+        s.fill_rect(SIDEBAR_W, 0, 1, self.content_h(), theme::BORDER);
     }
+
+    // ── Content dispatch ──────────────────────────────────────────────────────
 
     fn draw_content(&self, s: &SharedSurface) {
-        let by = self.body_y();
-        let bh = self.body_h();
-        let cw = self.content_w();
-        s.fill_rect(0, by, cw, bh, theme::BG);
-        match self.active_page {
-            Page::DesktopBackground => self.render_desktop_bg(s),
-            Page::DisplayResolution => self.render_display_res(s),
-            Page::AboutSystem       => self.render_about(s),
+        // Clear content area
+        let cx = self.cx();
+        let cw = self.cw();
+        let ch = self.content_h();
+        s.fill_rect(cx, 0, cw, ch, theme::BG);
+
+        match self.page {
+            Page::DesktopBg  => self.draw_desktop_bg(s),
+            Page::DisplayRes => self.draw_display_res(s),
+            Page::AboutSys   => self.draw_about(s),
         }
     }
 
-    fn draw_status_bar(&self, s: &SharedSurface) {
-        let sy = self.sh - STATUS_H;
-        s.fill_rect(0, sy, self.sw, STATUS_H, theme::HDR_BG);
-        s.fill_rect(0, sy, self.sw, 1, theme::BORDER);
-        let ty = sy + (STATUS_H - CHAR_H) / 2;
-        if self.status.kind != StatusKind::None {
-            let col = if self.status.kind == StatusKind::Ok { theme::SUCCESS } else { theme::WARNING };
-            s.draw_string(PAD, ty, self.status.as_str(), col, theme::HDR_BG);
-        } else {
-            let hint = match self.active_page {
-                Page::DesktopBackground => "Select color or wallpaper, then Apply",
-                Page::DisplayResolution => "Select resolution, then Apply",
-                Page::AboutSystem       => "Atom OS System Information",
-            };
-            s.draw_string(PAD, ty, hint, theme::TEXT_MUTED, theme::HDR_BG);
-        }
+    // ── Page title helper ─────────────────────────────────────────────────────
+
+    fn draw_page_title(&self, s: &SharedSurface, title: &str) {
+        let cx = self.cx();
+        let cw = self.cw();
+        let ty = (PTITLE_H - CH) / 2;
+        s.draw_string(cx + PAD, ty, title, theme::TEXT, theme::BG);
+        // Thin accent-colored underline, only under the title text
+        let lw = (title.len() as u32 * CW).min(cw.saturating_sub(PAD * 2));
+        s.fill_rect(cx + PAD, PTITLE_H - 2, lw, 2, theme::ACCENT_DIM);
+    }
+
+    // Section label inside a content page
+    fn draw_sec_label(&self, s: &SharedSurface, y: u32, label: &str) {
+        let cx = self.cx();
+        s.draw_string(cx + PAD, y + (SEC_LBL_H - CH) / 2, label, theme::TEXT_SEC, theme::BG);
     }
 
     // ── Desktop Background page ───────────────────────────────────────────────
 
-    fn render_desktop_bg(&self, s: &SharedSurface) {
-        let by = self.body_y();
-        let cw = self.content_w();
-        let sh = self.sh;
+    fn draw_desktop_bg(&self, s: &SharedSurface) {
+        let cx = self.cx();
+        let cw = self.cw();
 
-        // Page title
-        let title_y = by + PAD;
-        s.draw_string(PAD, title_y, "Desktop Background", theme::TEXT, theme::BG);
-        s.fill_rect(0, title_y + CHAR_H + 4, cw, 1, theme::DIVIDER);
+        self.draw_page_title(s, "Desktop Background");
 
         // Section: Background Color
-        let sec1_y = title_y + CHAR_H + 10;
-        s.draw_string(PAD, sec1_y, "Background Color", theme::TEXT_SEC, theme::BG);
+        self.draw_sec_label(s, self.wp_section1_y(), "Background Color");
 
-        // 4×2 color tile grid
+        // 4×2 colour swatches
         for i in 0..8 {
-            let (tx, ty) = self.color_tile_rect(i);
-            if ty + COLOR_SZ > sh { continue; }
-            let color = self.wp.colors[i];
-            let is_sel = match &self.wp.selected {
-                Some(WallpaperSource::SolidColor { rgb }) => {
-                    let tile_rgb = ((color.r as u32) << 16) | ((color.g as u32) << 8) | color.b as u32;
-                    tile_rgb == *rgb
-                }
-                _ => false,
-            };
-            s.fill_rect_rounded_aa(tx, ty, COLOR_SZ, COLOR_SZ, 6, color);
-            if is_sel {
-                s.draw_rect_rounded_aa(tx, ty, COLOR_SZ, COLOR_SZ, 6, theme::ACCENT);
-                s.draw_rect_rounded_aa(tx + 1, ty + 1, COLOR_SZ - 2, COLOR_SZ - 2, 6, theme::ACCENT);
+            let (sx, sy) = self.swatch_rect(i);
+            let c = self.wp.swatches[i];
+            let rgb = ((c.r as u32) << 16) | ((c.g as u32) << 8) | c.b as u32;
+            let active = matches!(&self.wp.selected, Some(WpSrc::Color { rgb: r }) if *r == rgb);
+            s.fill_rect_rounded_aa(sx, sy, CSZ, CSZ, 8, c);
+            if active {
+                // Double ring highlight
+                s.draw_rect_rounded_aa(sx.saturating_sub(2), sy.saturating_sub(2), CSZ+4, CSZ+4, 9, theme::ACCENT);
+                s.draw_rect_rounded_aa(sx.saturating_sub(3), sy.saturating_sub(3), CSZ+6, CSZ+6, 10, theme::ACCENT_DIM);
             } else {
-                s.draw_rect_rounded_aa(tx, ty, COLOR_SZ, COLOR_SZ, 6, theme::BORDER);
+                s.draw_rect_rounded_aa(sx, sy, CSZ, CSZ, 8, theme::BORDER);
             }
         }
 
-        // Scaling section label
-        let scale_sec_y = self.body_y() + PAD + CHAR_H + 10
-            + 2 * (COLOR_SZ + COLOR_GAP) + 10;
-        if scale_sec_y + CHAR_H < sh {
-            s.draw_string(PAD, scale_sec_y, "Image Scaling", theme::TEXT_SEC, theme::BG);
-        }
-
-        // Scaling buttons
+        // Section: Image Scaling
+        self.draw_sec_label(s, self.wp_section2_y(), "Image Scaling");
         let modes = [ScalingMode::Fill, ScalingMode::Fit, ScalingMode::Stretch,
                      ScalingMode::Center, ScalingMode::Tile];
         for (i, mode) in modes.iter().enumerate() {
-            let (bx, btn_y) = self.scaling_btn_rect(i);
-            if btn_y + SCALE_BTN_H > sh { continue; }
-            let enabled = self.wp.is_image_selected();
-            let active  = self.wp.scaling == *mode;
-            let bg = if !enabled { theme::SURFACE_ALT } else if active { theme::SEL_BG } else { theme::SURFACE };
-            let fg = if !enabled { theme::TEXT_MUTED } else { theme::TEXT };
-            s.fill_rect_rounded_aa(bx, btn_y, SCALE_BTN_W, SCALE_BTN_H, 4, bg);
-            s.draw_rect_rounded_aa(bx, btn_y, SCALE_BTN_W, SCALE_BTN_H, 4,
-                if active { theme::ACCENT } else { theme::BORDER });
+            let (bx, by) = self.sbtn_rect(i);
+            let enabled = self.wp.is_image_sel();
+            let is_sel  = self.wp.scaling == *mode;
+            let bg = if is_sel && enabled { theme::SEL_BG }
+                     else if enabled      { theme::SURFACE }
+                     else                 { theme::SURFACE_ALT };
+            let fg = if enabled { theme::TEXT } else { theme::TEXT_MUTED };
+            let border = if is_sel && enabled { theme::ACCENT } else { theme::BORDER };
+            s.fill_rect_rounded_aa(bx, by, SBTN_W, SBTN_H, 5, bg);
+            s.draw_rect_rounded_aa(bx, by, SBTN_W, SBTN_H, 5, border);
             let lbl = mode.to_str();
-            let lx = bx + (SCALE_BTN_W.saturating_sub(lbl.len() as u32 * CHAR_W)) / 2;
-            s.draw_string(lx, btn_y + (SCALE_BTN_H - CHAR_H) / 2, lbl, fg, bg);
+            let lx = bx + (SBTN_W.saturating_sub(lbl.len() as u32 * CW)) / 2;
+            s.draw_string(lx, by + (SBTN_H - CH) / 2, lbl, fg, bg);
         }
 
-        // Wallpaper images section
-        let img_sec_base_y = self.body_y() + PAD + CHAR_H + 10
-            + 2 * (COLOR_SZ + COLOR_GAP) + 10 + CHAR_H + 6
-            + 2 * (SCALE_BTN_H + SCALE_BTN_GAP) + 14;
-        if img_sec_base_y + CHAR_H < sh {
-            s.draw_string(PAD, img_sec_base_y, "Wallpaper Images", theme::TEXT_SEC, theme::BG);
-        }
-
-        let vis_rows = 2usize;
-        let vis_count = vis_rows * IMG_COLS;
-        let start = self.wp_scroll;
-        let end = (start + vis_count).min(self.wp.images.len());
+        // Section: Wallpaper Images
+        self.draw_sec_label(s, self.wp_section3_y(), "Wallpaper Images");
+        let start = self.wpscr;
+        let vis   = 2 * TCOLS;
+        let end   = (start + vis).min(self.wp.images.len());
         for idx in start..end {
-            let vis_i = idx - start;
-            let (ix, iy) = self.img_tile_rect(vis_i);
-            if iy + IMG_H > sh { continue; }
-            let info = &self.wp.images[idx];
-            let sel = matches!(&self.wp.selected, Some(WallpaperSource::Image { path }) if path == &info.path);
+            let vi = idx - start;
+            let (tx, ty) = self.tile_rect(vi);
+            if ty + TH > self.sh { continue; }
+            let img = &self.wp.images[idx];
+            let sel = matches!(&self.wp.selected, Some(WpSrc::Image { path: p }) if p == &img.path);
             let bg = if sel { theme::SEL_BG } else { theme::SURFACE };
-            s.fill_rect_rounded_aa(ix, iy, IMG_W, IMG_H, 6, bg);
-            s.draw_rect_rounded_aa(ix, iy, IMG_W, IMG_H, 6,
-                if sel { theme::ACCENT } else { theme::BORDER });
-            // Thumbnail preview area
-            let pw = IMG_W.saturating_sub(16);
-            let ph = IMG_H.saturating_sub(22);
-            let px = ix + 8; let py = iy + 6;
-            s.fill_rect_rounded_aa(px, py, pw, ph, 4, Color::new(35, 42, 60));
-            match info.thumb {
-                ThumbState::Loaded { width, height } => {
-                    let (dw, dh) = fit_within(width as u32, height as u32, pw - 4, ph - 4);
-                    let dx = px + (pw - dw) / 2; let dy = py + (ph - dh) / 2;
-                    s.fill_rect_rounded_aa(dx, dy, dw, dh, 3, theme::ACCENT_DIM);
-                    s.draw_rect_rounded_aa(dx, dy, dw, dh, 3, theme::ACCENT);
+            let brd= if sel { theme::ACCENT } else { theme::BORDER };
+            s.fill_rect_rounded_aa(tx, ty, TW, TH, 6, bg);
+            s.draw_rect_rounded_aa(tx, ty, TW, TH, 6, brd);
+            // Thumbnail placeholder
+            let ph = TH.saturating_sub(CH + 8);
+            let pw = TW.saturating_sub(12);
+            let px = tx + 6; let py = ty + 4;
+            s.fill_rect_rounded_aa(px, py, pw, ph, 4, Color::new(28,34,50));
+            match img.thumb {
+                ThumbSt::Loaded { w, h } => {
+                    let (dw, dh) = fit_in(w as u32, h as u32, pw-4, ph-4);
+                    let dx=px+(pw-dw)/2; let dy=py+(ph-dh)/2;
+                    s.fill_rect_rounded_aa(dx,dy,dw,dh,3,theme::ACCENT_DIM);
                 }
-                ThumbState::Failed => {
-                    s.draw_rect_rounded_aa(px + 8, py + 6, pw - 16, ph - 12, 3, theme::WARNING);
+                ThumbSt::Fail => {
+                    s.draw_rect_rounded_aa(px+6,py+4,pw-12,ph-8,3,theme::WARNING);
                 }
-                ThumbState::Unloaded => {
-                    let dw = pw / 2; let dh = ph / 2;
-                    s.fill_rect_rounded_aa(px + dw / 2, py + dh / 2, dw, dh, 3, theme::THUMB);
+                ThumbSt::Pending => {
+                    let dw=pw/3; let dh=ph/3;
+                    s.fill_rect_rounded_aa(px+dw,py+dh,dw,dh,3,theme::SB_THUMB);
                 }
             }
-            // Filename label (truncated)
-            let max_chars = (IMG_W / CHAR_W) as usize;
-            let label = if info.name.len() > max_chars { &info.name[..max_chars] } else { &info.name };
-            s.draw_string(ix + 4, iy + IMG_H - CHAR_H - 3, label, theme::TEXT_SEC, bg);
+            // Filename (truncated to tile width)
+            let max_c = (TW / CW) as usize;
+            let lbl = if img.name.len()>max_c { &img.name[..max_c] } else { &img.name };
+            s.draw_string(tx+4, ty+TH-CH-2, lbl, theme::TEXT_SEC, bg);
         }
-
-        if self.wp.discovering {
-            let load_y = img_sec_base_y + CHAR_H + 10;
-            if load_y + CHAR_H < sh {
-                s.draw_string(PAD, load_y, "Discovering wallpapers...", theme::TEXT_MUTED, theme::BG);
-            }
+        if self.wp.loading {
+            let y = self.wp_section3_y() + SEC_LBL_H + 4;
+            s.draw_string(cx + PAD, y, "Loading...", theme::TEXT_MUTED, theme::BG);
         } else if self.wp.images.is_empty() {
-            let msg_y = img_sec_base_y + CHAR_H + 10;
-            if msg_y + CHAR_H < sh {
-                s.draw_string(PAD, msg_y, "No images in /system/wallpapers/", theme::TEXT_MUTED, theme::BG);
-            }
+            let y = self.wp_section3_y() + SEC_LBL_H + 4;
+            s.draw_string(cx + PAD, y, "No images in /system/wallpapers/", theme::TEXT_MUTED, theme::BG);
         }
 
-        // Apply button – bottom of content area
-        let btn_h = 28u32;
-        let btn_w = 88u32;
-        let btn_y = self.sh - STATUS_H - btn_h - 10;
-        let btn_x = self.content_w().saturating_sub(PAD + btn_w);
-        s.fill_rect_rounded_aa(btn_x, btn_y, btn_w, btn_h, 6, theme::BTN_PRIMARY);
+        // Apply button (bottom-right of content)
+        let (ax, ay) = self.apply_btn();
+        s.fill_rect_rounded_aa(ax, ay, BTN_W, BTN_H, 7, theme::BTN_PRIMARY);
         let lbl = "Apply";
-        let lx = btn_x + (btn_w - lbl.len() as u32 * CHAR_W) / 2;
-        s.draw_string(lx, btn_y + (btn_h - CHAR_H) / 2, lbl, theme::BTN_TEXT, theme::BTN_PRIMARY);
+        let lx = ax + (BTN_W.saturating_sub(lbl.len() as u32 * CW)) / 2;
+        s.draw_string(lx, ay+(BTN_H-CH)/2, lbl, theme::BTN_TEXT, theme::BTN_PRIMARY);
     }
 
     // ── Display Resolution page ───────────────────────────────────────────────
 
-    fn render_display_res(&self, s: &SharedSurface) {
-        let by = self.body_y();
-        let cw = self.content_w();
+    fn draw_display_res(&self, s: &SharedSurface) {
+        let cx = self.cx();
+        let cw = self.cw();
 
-        // Page title
-        s.draw_string(PAD, by + PAD, "Display Resolution", theme::TEXT, theme::BG);
-        s.fill_rect(0, by + PAD + CHAR_H + 4, cw, 1, theme::DIVIDER);
-
-        let (list_top, list_h, list_w, sbx) = self.res_list_geom();
+        self.draw_page_title(s, "Display Resolution");
 
         // Subtitle
-        s.draw_string(PAD, by + PAD + CHAR_H + 8, "Available Resolutions", theme::TEXT_MUTED, theme::BG);
+        let sub_y = PTITLE_H + (SEC_LBL_H - CH) / 2;
+        s.draw_string(cx + PAD, sub_y, "Available Resolutions", theme::TEXT_MUTED, theme::BG);
 
-        // Mode rows
-        for i in 0..VISIBLE_ROWS {
+        let (ltop, lh, lw, sbx) = self.res_geom();
+
+        for i in 0..VIS_ROWS {
             let idx = self.scroll + i;
-            if idx >= self.mode_count { break; }
+            if idx >= self.mcnt { break; }
             let m = self.modes[idx];
-            let ry = list_top + i as u32 * ROW_H;
-            let sel = idx == self.selected;
-            let (row_bg, fg, dim) = if sel {
+            let ry = ltop + i as u32 * ROW_H;
+            let active = idx == self.sel;
+            let (rbg, fg, dim) = if active {
                 (theme::SEL_BG, theme::TEXT, theme::ACCENT)
             } else {
-                (theme::BG, theme::TEXT, theme::TEXT_MUTED)
+                (theme::BG, theme::TEXT_SEC, theme::TEXT_MUTED)
             };
-            s.fill_rect(PAD, ry, list_w, ROW_H - 1, row_bg);
-            if sel { s.fill_rect(PAD, ry, 3, ROW_H - 1, theme::ACCENT); }
-            let mut lbuf = [0u8; 24];
-            let label = fmt_resolution(&mut lbuf, m.width, m.height);
-            s.draw_string(PAD + 8, ry + (ROW_H - CHAR_H) / 2, label, fg, row_bg);
+            s.fill_rect(cx + PAD, ry, lw, ROW_H - 1, rbg);
+            if active {
+                s.fill_rect(cx + PAD, ry, 3, ROW_H-1, theme::ACCENT);
+            }
+            let mut lb = [0u8; 24];
+            let label = fmt_res(&mut lb, m.w, m.h);
+            s.draw_string(cx + PAD + 8, ry+(ROW_H-CH)/2, label, fg, rbg);
             let bpp = "32bpp";
-            let bx = PAD + list_w - bpp.len() as u32 * CHAR_W - 6;
-            s.draw_string(bx, ry + (ROW_H - CHAR_H) / 2, bpp, dim, row_bg);
-            if !sel {
-                s.fill_rect(PAD + 8, ry + ROW_H - 1, list_w - 16, 1, theme::DIVIDER);
+            let bx = cx + PAD + lw - bpp.len() as u32 * CW - 6;
+            s.draw_string(bx, ry+(ROW_H-CH)/2, bpp, dim, rbg);
+            if !active {
+                s.fill_rect(cx + PAD + 8, ry+ROW_H-1, lw-16, 1, theme::DIVIDER);
             }
         }
 
-        // Scrollbar
-        s.fill_rect(sbx, list_top, SB_W, list_h, theme::SCROLLBAR);
-        let (thy, thh, _) = self.scrollbar_geom();
-        let thumb_c = if self.sb_drag { theme::ACCENT } else { theme::THUMB };
-        s.fill_rect_rounded_aa(sbx + 1, thy, SB_W - 2, thh, 3, thumb_c);
+        // Scrollbar track + thumb
+        s.fill_rect(sbx, ltop, SBW, lh, theme::SB_TRACK);
+        let (ty, th, _) = self.sb_geom();
+        let tc = if self.sbdrag { theme::SB_THUMB_ACT } else { theme::SB_THUMB };
+        s.fill_rect_rounded_aa(sbx+1, ty, SBW-2, th, 3, tc);
 
-        // Info line
-        if self.mode_count > 0 {
-            let m = self.modes[self.selected];
-            let mut ibuf = [0u8; 44];
-            let info = fmt_info(&mut ibuf, m.width, m.height);
-            s.draw_string(PAD, list_top + list_h + 6, info, theme::TEXT_MUTED, theme::BG);
+        // Info line below list
+        if self.mcnt > 0 {
+            let m = self.modes[self.sel];
+            let mut ib = [0u8; 44];
+            let info = fmt_info(&mut ib, m.w, m.h);
+            s.draw_string(cx + PAD, ltop+lh+6, info, theme::TEXT_MUTED, theme::BG);
         }
 
         // Buttons
-        let btn_h = 28u32;
-        let btn_y = self.sh - STATUS_H - btn_h - 10;
-        let aw = 88u32;
-        let ax = self.content_w().saturating_sub(PAD + aw);
-        s.fill_rect_rounded_aa(ax, btn_y, aw, btn_h, 6, theme::BTN_PRIMARY);
+        let (ax, ay) = self.apply_btn();
+        let (rx, ry) = self.restore_btn();
+        s.fill_rect_rounded_aa(ax, ay, BTN_W, BTN_H, 7, theme::BTN_PRIMARY);
         let al = "Apply";
-        s.draw_string(ax + (aw - al.len() as u32 * CHAR_W) / 2,
-            btn_y + (btn_h - CHAR_H) / 2, al, theme::BTN_TEXT, theme::BTN_PRIMARY);
-        let rw = 128u32;
-        let rx = ax.saturating_sub(PAD + rw);
-        s.fill_rect_rounded_aa(rx, btn_y, rw, btn_h, 6, theme::BTN_RESTORE);
-        s.draw_rect_rounded_aa(rx, btn_y, rw, btn_h, 6, theme::BORDER);
+        s.draw_string(ax+(BTN_W-al.len() as u32*CW)/2, ay+(BTN_H-CH)/2, al, theme::BTN_TEXT, theme::BTN_PRIMARY);
+        s.fill_rect_rounded_aa(rx, ry, RBTN_W, BTN_H, 7, theme::BTN_GHOST);
+        s.draw_rect_rounded_aa(rx, ry, RBTN_W, BTN_H, 7, theme::BORDER);
         let rl = "Restore Default";
-        s.draw_string(rx + (rw - rl.len() as u32 * CHAR_W) / 2,
-            btn_y + (btn_h - CHAR_H) / 2, rl, theme::BTN_TEXT, theme::BTN_RESTORE);
+        s.draw_string(rx+(RBTN_W-rl.len() as u32*CW)/2, ry+(BTN_H-CH)/2, rl, theme::BTN_TEXT, theme::BTN_GHOST);
     }
 
     // ── About System page ─────────────────────────────────────────────────────
 
-    fn render_about(&self, s: &SharedSurface) {
-        const OS_NAME:    &str = "Atom OS";
-        const OS_VER:     &str = "0.2.0";
-        const OS_CODE:    &str = "Beryllium";
-        const KERNEL_VER: &str = "0.2.0-smp-microkernel";
+    fn draw_about(&self, s: &SharedSurface) {
+        const OS_NAME: &str = "Atom OS";
+        const OS_VER:  &str = "0.2.0";
+        const OS_CODE: &str = "Beryllium";
+        const KERN:    &str = "0.2.0-smp-microkernel";
 
-        let by = self.body_y();
-        let cw = self.content_w();
+        let cx = self.cx();
+        let cw = self.cw();
+        let kw = 100u32;       // key column width
+        let vx = cx + PAD + kw + 8;  // value column x
 
-        // Page title
-        s.draw_string(PAD, by + PAD, "About System", theme::TEXT, theme::BG);
-        s.fill_rect(0, by + PAD + CHAR_H + 4, cw, 1, theme::DIVIDER);
+        self.draw_page_title(s, "About System");
 
-        let label_x = PAD;
-        let value_x = PAD + 112;
-        let row_h = 20u32;
+        let row  = 22u32;
+        let mut y = PTITLE_H + 10;
 
-        let mut y = by + PAD + CHAR_H + 16;
-
-        // Helper: draw a row
-        macro_rules! row {
-            ($label:expr, $value:expr) => {
-                s.draw_string(label_x, y, $label, theme::INFO_LABEL, theme::BG);
-                s.draw_string(value_x, y, $value, theme::INFO_VALUE, theme::BG);
-                y += row_h;
-            };
+        macro_rules! kv {
+            ($k:expr, $v:expr) => {{
+                s.draw_string(cx + PAD, y, $k, theme::INFO_KEY, theme::BG);
+                s.draw_string(vx, y, $v, theme::INFO_VAL, theme::BG);
+                y += row;
+            }};
         }
-        macro_rules! divider {
-            () => {
-                y += 6;
-                s.fill_rect(0, y, cw, 1, theme::DIVIDER);
-                y += 10;
-            };
+        macro_rules! sep {
+            () => {{
+                y += 4;
+                s.fill_rect(cx + PAD, y, cw.saturating_sub(PAD*2), 1, theme::DIVIDER);
+                y += 8;
+            }};
         }
 
-        // OS section
-        row!("OS Name", OS_NAME);
-        let mut ver_buf = [0u8; 32];
-        let ver_len = build_ver_str(&mut ver_buf, OS_VER, OS_CODE);
-        let ver_str = core::str::from_utf8(&ver_buf[..ver_len]).unwrap_or(OS_VER);
-        row!("Version", ver_str);
-        row!("Kernel", KERNEL_VER);
-        row!("Architecture", "x86_64");
-
-        divider!();
-
-        // CPU section
-        let brand = if self.about.cpu_brand_len > 0 {
-            self.about.cpu_brand_str()
-        } else {
-            "x86_64 (Atom Core)"
+        kv!("OS Name",      OS_NAME);
+        let mut vb = [0u8; 32];
+        let vl = {
+            let mut p=0usize;
+            for b in OS_VER.bytes() { vb[p]=b; p+=1; }
+            vb[p]=b' '; p+=1; vb[p]=b'('; p+=1;
+            for b in OS_CODE.bytes() { if p<31 { vb[p]=b; p+=1; } }
+            if p<31 { vb[p]=b')'; p+=1; }
+            p
         };
-        // Truncate long brand string
-        let brand_disp = if brand.len() * CHAR_W as usize > (cw as usize).saturating_sub(value_x as usize + PAD as usize) {
-            let max = ((cw as usize).saturating_sub(value_x as usize + PAD as usize)) / CHAR_W as usize;
-            if max < brand.len() { &brand[..max] } else { brand }
-        } else { brand };
-        row!("Processor", brand_disp);
-        let mut cores_buf = [0u8; 16];
-        let cores_len = write_u64(&mut cores_buf, self.about.cpu_cores);
-        let cores_str = core::str::from_utf8(&cores_buf[..cores_len]).unwrap_or("?");
-        row!("CPU Cores", cores_str);
+        kv!("Version",       core::str::from_utf8(&vb[..vl]).unwrap_or(OS_VER));
+        kv!("Kernel",        KERN);
+        kv!("Architecture",  "x86_64");
+        sep!();
 
-        divider!();
+        // Processor – may be long, truncate to fit
+        let cpu_raw = self.sinfo.cpu();
+        let max_chars = ((cx + cw).saturating_sub(vx + PAD) / CW) as usize;
+        let cpu = if cpu_raw.len() > max_chars { &cpu_raw[..max_chars] } else { cpu_raw };
+        kv!("Processor",    cpu);
+        let mut cb=[0u8;8]; let cl=fmt_u64(&mut cb, self.sinfo.cores);
+        kv!("CPU Cores",    core::str::from_utf8(&cb[..cl]).unwrap_or("?"));
+        sep!();
 
-        // Memory section
-        let mut mem_buf = [0u8; 48];
-        let mem_len = build_mem_str(&mut mem_buf, self.about.mem_used_kb, self.about.mem_total_kb);
-        let mem_str = core::str::from_utf8(&mem_buf[..mem_len]).unwrap_or("?");
-        row!("Memory", mem_str);
-        row!("Uptime", self.about.uptime_str());
+        let mut mb=[0u8;48];
+        let ml=fmt_mem(&mut mb, self.sinfo.mem_used, self.sinfo.mem_total);
+        kv!("Memory",       core::str::from_utf8(&mb[..ml]).unwrap_or("?"));
+        kv!("Uptime",       self.sinfo.uptime());
+        sep!();
 
-        divider!();
+        kv!("IP Address",   self.sinfo.ip());
+    }
 
-        // Network section
-        row!("IP Address", self.about.ip_str());
+    // ── Status bar ────────────────────────────────────────────────────────────
+
+    fn draw_status(&self, s: &SharedSurface) {
+        let sy = self.sh.saturating_sub(STAT_H);
+        s.fill_rect(0, sy, self.sw, STAT_H, theme::HDR_BG);
+        s.fill_rect(0, sy, self.sw, 1, theme::BORDER);
+        let ty = sy + (STAT_H - CH) / 2;
+        if self.status.kind != StatusKind::None {
+            let col = if self.status.kind == StatusKind::Ok { theme::SUCCESS } else { theme::WARNING };
+            s.draw_string(SIDEBAR_W + 1 + PAD, ty, self.status.as_str(), col, theme::HDR_BG);
+        } else {
+            let hint = match self.page {
+                Page::DesktopBg  => "Select color or image, then Apply",
+                Page::DisplayRes => "Select resolution, then Apply  |  R to restore default",
+                Page::AboutSys   => "Atom OS System Information",
+            };
+            s.draw_string(SIDEBAR_W + 1 + PAD, ty, hint, theme::TEXT_MUTED, theme::HDR_BG);
+        }
     }
 
     // ── Input handling ────────────────────────────────────────────────────────
 
-    fn handle_key(&mut self, ev: &IpcKeyEvent) {
+    fn on_key(&mut self, ev: &IpcKeyEvent) {
         if ev.character == 0 {
-            match ev.scancode & 0x7F {
-                0x48 => { // Up
-                    if self.active_page == Page::DisplayResolution && self.selected > 0 {
-                        self.selected -= 1; self.clamp_scroll(); self.dirty = true;
-                    }
+            if self.page == Page::DisplayRes {
+                match ev.scancode & 0x7F {
+                    0x48 => { if self.sel>0 { self.sel-=1; self.clamp_scroll(); self.dirty=true; } }
+                    0x50 => { if self.sel+1<self.mcnt { self.sel+=1; self.clamp_scroll(); self.dirty=true; } }
+                    0x49 => { self.sel=self.sel.saturating_sub(VIS_ROWS); self.clamp_scroll(); self.dirty=true; }
+                    0x51 => { let l=self.mcnt.saturating_sub(1); self.sel=(self.sel+VIS_ROWS).min(l); self.clamp_scroll(); self.dirty=true; }
+                    _ => {}
                 }
-                0x50 => { // Down
-                    if self.active_page == Page::DisplayResolution
-                        && self.selected + 1 < self.mode_count {
-                        self.selected += 1; self.clamp_scroll(); self.dirty = true;
-                    }
-                }
-                0x49 => { // Page Up
-                    if self.active_page == Page::DisplayResolution {
-                        self.selected = self.selected.saturating_sub(VISIBLE_ROWS);
-                        self.clamp_scroll(); self.dirty = true;
-                    }
-                }
-                0x51 => { // Page Down
-                    if self.active_page == Page::DisplayResolution {
-                        let last = self.mode_count.saturating_sub(1);
-                        self.selected = (self.selected + VISIBLE_ROWS).min(last);
-                        self.clamp_scroll(); self.dirty = true;
-                    }
-                }
-                _ => {}
             }
             return;
         }
         match ev.character {
-            b'\n' | b'\r' => match self.active_page {
-                Page::DesktopBackground => self.apply_wallpaper(),
-                Page::DisplayResolution => self.apply_resolution(),
-                Page::AboutSystem       => {}
+            b'\n'|b'\r' => match self.page {
+                Page::DesktopBg  => self.apply_wallpaper(),
+                Page::DisplayRes => self.apply_resolution(),
+                Page::AboutSys   => {}
             },
-            b'r' | b'R' if self.active_page == Page::DisplayResolution => self.restore_default(),
+            b'r'|b'R' if self.page == Page::DisplayRes => self.restore_default(),
             _ => {}
         }
     }
 
-    fn handle_mouse_down(&mut self, x: i32, y: i32) {
-        // Sidebar click?
-        if let Some(page) = self.sidebar_page_at(x, y) {
-            self.switch_page(page);
-            return;
+    fn on_mouse_down(&mut self, mx: i32, my: i32) {
+        // Sidebar navigation
+        if let Some(pg) = self.nav_hit(mx, my) {
+            self.page = pg; self.dirty = true; return;
         }
-
         // Content area
-        match self.active_page {
-            Page::DesktopBackground => self.handle_wp_click(x, y),
-            Page::DisplayResolution => self.handle_res_click(x, y),
-            Page::AboutSystem       => {}
+        match self.page {
+            Page::DesktopBg  => self.on_wp_click(mx, my),
+            Page::DisplayRes => self.on_res_click(mx, my),
+            Page::AboutSys   => {}
         }
     }
 
-    fn handle_wp_click(&mut self, x: i32, y: i32) {
-        // Color tiles
+    fn on_wp_click(&mut self, mx: i32, my: i32) {
+        // Colour swatches
         for i in 0..8 {
-            let (tx, ty) = self.color_tile_rect(i);
-            if x >= tx as i32 && x < (tx + COLOR_SZ) as i32
-               && y >= ty as i32 && y < (ty + COLOR_SZ) as i32 {
-                self.wp.select_color(i);
-                self.dirty = true;
-                return;
+            let (sx, sy) = self.swatch_rect(i);
+            if in_rect(mx, my, sx, sy, CSZ, CSZ) {
+                self.wp.pick_color(i); self.dirty = true; return;
             }
         }
         // Scaling buttons
         let modes = [ScalingMode::Fill, ScalingMode::Fit, ScalingMode::Stretch,
                      ScalingMode::Center, ScalingMode::Tile];
         for (i, mode) in modes.iter().enumerate() {
-            let (bx, by) = self.scaling_btn_rect(i);
-            if x >= bx as i32 && x < (bx + SCALE_BTN_W) as i32
-               && y >= by as i32 && y < (by + SCALE_BTN_H) as i32 {
-                if self.wp.is_image_selected() {
-                    self.wp.scaling = *mode;
-                    self.dirty = true;
-                }
+            let (bx, by) = self.sbtn_rect(i);
+            if in_rect(mx, my, bx, by, SBTN_W, SBTN_H) {
+                if self.wp.is_image_sel() { self.wp.scaling = *mode; self.dirty = true; }
                 return;
             }
         }
         // Image tiles
-        let vis_count = 2 * IMG_COLS;
-        let start = self.wp_scroll;
-        let end = (start + vis_count).min(self.wp.images.len());
+        let start = self.wpscr;
+        let end = (start + 2*TCOLS).min(self.wp.images.len());
         for idx in start..end {
-            let vis_i = idx - start;
-            let (ix, iy) = self.img_tile_rect(vis_i);
-            if x >= ix as i32 && x < (ix + IMG_W) as i32
-               && y >= iy as i32 && y < (iy + IMG_H) as i32 {
-                self.wp.select_image(idx);
-                self.dirty = true;
-                return;
+            let (tx, ty) = self.tile_rect(idx - start);
+            if in_rect(mx, my, tx, ty, TW, TH) {
+                self.wp.pick_image(idx); self.dirty = true; return;
             }
         }
         // Apply button
-        let btn_h = 28u32; let btn_w = 88u32;
-        let btn_y = (self.sh - STATUS_H - btn_h - 10) as i32;
-        let btn_x = (self.content_w().saturating_sub(PAD + btn_w)) as i32;
-        if x >= btn_x && x < btn_x + btn_w as i32 && y >= btn_y && y < btn_y + btn_h as i32 {
-            self.apply_wallpaper();
-        }
+        let (ax, ay) = self.apply_btn();
+        if in_rect(mx, my, ax, ay, BTN_W, BTN_H) { self.apply_wallpaper(); }
     }
 
-    fn handle_res_click(&mut self, x: i32, y: i32) {
-        let (list_top, list_h, list_w, sbx) = self.res_list_geom();
-        let (thy, thh, _) = self.scrollbar_geom();
-        let btn_h = 28u32;
-        let btn_y = (self.sh - STATUS_H - btn_h - 10) as i32;
-        let aw = 88u32;
-        let ax = self.content_w().saturating_sub(PAD + aw) as i32;
-        let rw = 128u32;
-        let rx = (ax as u32).saturating_sub(PAD + rw) as i32;
+    fn on_res_click(&mut self, mx: i32, my: i32) {
+        let (ltop, lh, lw, sbx) = self.res_geom();
+        let (ty, th, _) = self.sb_geom();
+        let cx = self.cx();
 
-        // Apply button
-        if y >= btn_y && y < btn_y + btn_h as i32 {
-            if x >= ax && x < ax + aw as i32 { self.apply_resolution(); return; }
-            if x >= rx && x < rx + rw as i32 { self.restore_default(); return; }
-        }
+        // Apply / Restore buttons
+        let (ax, ay) = self.apply_btn();
+        let (rx, ry) = self.restore_btn();
+        if in_rect(mx, my, ax, ay, BTN_W, BTN_H) { self.apply_resolution(); return; }
+        if in_rect(mx, my, rx, ry, RBTN_W, BTN_H) { self.restore_default(); return; }
+
         // Scrollbar
-        if x >= sbx as i32 && x < (sbx + SB_W) as i32
-           && y >= list_top as i32 && y < (list_top + list_h) as i32 {
-            if y >= thy as i32 && y < (thy + thh) as i32 {
-                self.sb_drag = true;
-                self.sb_drag_off = y - thy as i32;
-            } else if (y as u32) < thy {
-                self.scroll = self.scroll.saturating_sub(VISIBLE_ROWS);
+        if in_rect(mx, my, sbx, ltop, SBW, lh) {
+            if in_rect(mx, my, sbx, ty, SBW, th) {
+                self.sbdrag = true; self.sboff = my - ty as i32;
+            } else if (my as u32) < ty {
+                self.scroll = self.scroll.saturating_sub(VIS_ROWS);
             } else {
-                let max_s = self.mode_count.saturating_sub(VISIBLE_ROWS);
-                self.scroll = (self.scroll + VISIBLE_ROWS).min(max_s);
+                self.scroll = (self.scroll + VIS_ROWS).min(self.mcnt.saturating_sub(VIS_ROWS));
             }
-            self.dirty = true;
-            return;
+            self.dirty = true; return;
         }
+
         // Mode rows
-        if x >= PAD as i32 && x < (PAD + list_w) as i32
-           && y >= list_top as i32 && y < (list_top + list_h) as i32 {
-            let row = ((y - list_top as i32) / ROW_H as i32) as usize;
+        if in_rect(mx, my, cx + PAD, ltop, lw, lh) {
+            let row = ((my - ltop as i32) / ROW_H as i32) as usize;
             let idx = self.scroll + row;
-            if idx < self.mode_count {
-                self.selected = idx;
-                self.clamp_scroll();
-                self.dirty = true;
-            }
+            if idx < self.mcnt { self.sel = idx; self.clamp_scroll(); self.dirty = true; }
         }
     }
 
-    fn handle_mouse_move(&mut self, y: i32) {
-        if self.sb_drag && self.active_page == Page::DisplayResolution {
-            self.set_scroll_from_y(y - self.sb_drag_off);
+    fn on_mouse_move(&mut self, my: i32) {
+        if self.sbdrag && self.page == Page::DisplayRes {
+            self.set_scroll_from_drag(my - self.sboff);
         }
     }
 
-    fn handle_mouse_up(&mut self) {
-        if self.sb_drag { self.sb_drag = false; self.dirty = true; }
+    fn on_mouse_up(&mut self) {
+        if self.sbdrag { self.sbdrag = false; self.dirty = true; }
     }
 
-    fn handle_scroll(&mut self, dz: i32) {
+    fn on_scroll(&mut self, dz: i32) {
         let steps = dz.unsigned_abs().max(1) as usize;
-        match self.active_page {
-            Page::DesktopBackground => {
-                if dz > 0 {
-                    self.wp_scroll = self.wp_scroll.saturating_sub(steps * IMG_COLS);
-                } else if dz < 0 {
-                    let max = self.wp.images.len().saturating_sub(2 * IMG_COLS);
-                    self.wp_scroll = (self.wp_scroll + steps * IMG_COLS).min(max);
-                }
+        match self.page {
+            Page::DesktopBg => {
+                if dz > 0 { self.wpscr = self.wpscr.saturating_sub(steps * TCOLS); }
+                else { let max = self.wp.images.len().saturating_sub(2*TCOLS); self.wpscr=(self.wpscr+steps*TCOLS).min(max); }
             }
-            Page::DisplayResolution => {
-                if dz > 0 {
-                    self.scroll = self.scroll.saturating_sub(steps);
-                } else if dz < 0 {
-                    let max = self.mode_count.saturating_sub(VISIBLE_ROWS);
-                    self.scroll = (self.scroll + steps).min(max);
-                }
+            Page::DisplayRes => {
+                if dz > 0 { self.scroll = self.scroll.saturating_sub(steps); }
+                else { let max=self.mcnt.saturating_sub(VIS_ROWS); self.scroll=(self.scroll+steps).min(max); }
             }
-            Page::AboutSystem => {}
+            Page::AboutSys => {}
         }
         self.dirty = true;
     }
 
-    // ── Event loop ────────────────────────────────────────────────────────────
+    // ── Message handling ──────────────────────────────────────────────────────
 
-    fn process_msg(&mut self, buf: &[u8], len: usize) {
+    fn on_msg(&mut self, buf: &[u8], len: usize) {
         if len < MessageHeader::SIZE { return; }
         let hdr = match MessageHeader::from_bytes(buf) { Some(h) => h, None => return };
-        let payload = &buf[MessageHeader::SIZE..len.min(buf.len())];
+        let pay = &buf[MessageHeader::SIZE..len.min(buf.len())];
         match hdr.msg_type {
-            MessageType::TerminateRequest => { self.running = false; }
+            MessageType::TerminateRequest => { self.alive = false; }
             MessageType::SurfaceAssign => {
-                if let Some(msg) = SurfaceAssignMsg::from_bytes(payload) {
-                    if let Ok(s) = SharedSurface::from_region(msg.region_id, msg.width, msg.height) {
-                        self.sw = msg.width; self.sh = msg.height;
-                        self.surface = Some(s); self.dirty = true;
+                if let Some(m) = SurfaceAssignMsg::from_bytes(pay) {
+                    if let Ok(s) = SharedSurface::from_region(m.region_id, m.width, m.height) {
+                        self.sw = m.width; self.sh = m.height; self.surf = Some(s); self.dirty = true;
                     }
                 }
             }
             MessageType::KeyPress => {
-                if let Some(ev) = IpcKeyEvent::from_bytes(payload) { self.handle_key(&ev); }
+                if let Some(ev) = IpcKeyEvent::from_bytes(pay) { self.on_key(&ev); }
             }
             MessageType::MouseButtonDown => {
-                if let Some(ev) = MouseButtonEvent::from_bytes(payload) {
-                    if ev.button == MouseButton::Left { self.handle_mouse_down(ev.x, ev.y); }
+                if let Some(ev) = MouseButtonEvent::from_bytes(pay) {
+                    if ev.button == MouseButton::Left { self.on_mouse_down(ev.x, ev.y); }
                 }
             }
             MessageType::MouseMove => {
-                if let Some(ev) = MouseMoveEvent::from_bytes(payload) { self.handle_mouse_move(ev.y); }
+                if let Some(ev) = MouseMoveEvent::from_bytes(pay) { self.on_mouse_move(ev.y); }
             }
             MessageType::MouseButtonUp => {
-                if let Some(ev) = MouseButtonEvent::from_bytes(payload) {
-                    if ev.button == MouseButton::Left { self.handle_mouse_up(); }
+                if let Some(ev) = MouseButtonEvent::from_bytes(pay) {
+                    if ev.button == MouseButton::Left { self.on_mouse_up(); }
                 }
             }
             MessageType::MouseScroll => {
-                if let Some(ev) = MouseScrollEvent::from_bytes(payload) { self.handle_scroll(ev.dz); }
+                if let Some(ev) = MouseScrollEvent::from_bytes(pay) { self.on_scroll(ev.dz); }
             }
             MessageType::OpenInTab => {
-                if let Some(msg) = OpenInTabMsg::from_bytes(payload) { self.handle_open_in_tab(&msg.tab_name); }
+                if let Some(m) = OpenInTabMsg::from_bytes(pay) {
+                    self.page = match m.tab_name.as_str() {
+                        "Desktop Background"|"Wallpaper"     => Page::DesktopBg,
+                        "Display Resolution"|"Resolution"    => Page::DisplayRes,
+                        "About System"                       => Page::AboutSys,
+                        _ => return,
+                    };
+                    self.dirty = true;
+                }
             }
             MessageType::WallpaperApplied => {
-                if WallpaperAppliedMsg::from_bytes(payload).is_some() {
-                    self.status.set(StatusKind::Ok, b"Background applied successfully.");
+                if WallpaperAppliedMsg::from_bytes(pay).is_some() {
+                    self.status.set(StatusKind::Ok, b"Background applied.");
                     self.dirty = true;
                 }
             }
             MessageType::WallpaperFailed => {
-                if let Some(msg) = WallpaperFailedMsg::from_bytes(payload) {
-                    let mut e = String::from("Failed: ");
-                    e.push_str(&msg.error_message);
+                if let Some(m) = WallpaperFailedMsg::from_bytes(pay) {
+                    let mut e = String::from("Error: ");
+                    e.push_str(&m.error_message);
                     self.status.set(StatusKind::Warn, e.as_bytes());
                     self.dirty = true;
                 }
@@ -1238,18 +1115,16 @@ impl SystemSettings {
     fn run(&mut self) {
         self.render();
         let mut buf = [0u8; 128];
-        let ports = [self.local_port];
-        while self.running {
-            while let Ok(Some(len)) = try_recv(self.local_port, &mut buf) {
-                self.process_msg(&buf, len);
-            }
+        let ports = [self.lport];
+        while self.alive {
+            while let Ok(Some(len)) = try_recv(self.lport, &mut buf) { self.on_msg(&buf, len); }
             self.status.tick();
             if self.dirty { self.render(); }
             let _ = wait_any(&ports, 16);
         }
     }
 
-    fn wait_for_surface(port: PortId) -> Option<SurfaceAssignMsg> {
+    fn wait_surface(port: PortId) -> Option<SurfaceAssignMsg> {
         let mut buf = [0u8; 128];
         let ports = [port];
         for _ in 0..200 {
@@ -1258,8 +1133,9 @@ impl SystemSettings {
                     if len >= MessageHeader::SIZE {
                         if let Some(hdr) = MessageHeader::from_bytes(&buf) {
                             if hdr.msg_type == MessageType::SurfaceAssign {
-                                if let Some(msg) = SurfaceAssignMsg::from_bytes(
-                                    &buf[MessageHeader::SIZE..]) { return Some(msg); }
+                                if let Some(m) = SurfaceAssignMsg::from_bytes(&buf[MessageHeader::SIZE..]) {
+                                    return Some(m);
+                                }
                             }
                         }
                     }
@@ -1270,76 +1146,67 @@ impl SystemSettings {
     }
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+// ── Small helpers ─────────────────────────────────────────────────────────────
 
-fn query_modes() -> ([Mode; VIDEO_MAX_MODES], usize) {
-    let count = video_mode_count().min(VIDEO_MAX_MODES);
-    if count == 0 { return ([Mode { width: 0, height: 0 }; VIDEO_MAX_MODES], 0); }
-    let mut raw = [VideoModeEntry::default(); VIDEO_MAX_MODES];
-    let written = get_video_modes(&mut raw[..count]);
-    let mut modes = [Mode { width: 0, height: 0 }; VIDEO_MAX_MODES];
-    for i in 0..written { modes[i] = Mode { width: raw[i].width as u16, height: raw[i].height as u16 }; }
-    (modes, written)
+fn in_rect(mx: i32, my: i32, x: u32, y: u32, w: u32, h: u32) -> bool {
+    mx >= x as i32 && mx < (x+w) as i32 && my >= y as i32 && my < (y+h) as i32
 }
 
-fn default_idx(modes: &[Mode], count: usize) -> usize {
-    for i in 0..count {
-        if modes[i].width == DEFAULT_W && modes[i].height == DEFAULT_H { return i; }
-    }
+fn default_mode(modes: &[Mode], cnt: usize) -> usize {
+    for i in 0..cnt { if modes[i].w == DEF_W && modes[i].h == DEF_H { return i; } }
     0
 }
 
-fn write_u64(buf: &mut [u8], mut n: u64) -> usize {
-    if n == 0 { if !buf.is_empty() { buf[0] = b'0'; } return 1; }
-    let mut tmp = [0u8; 20]; let mut i = 0usize;
-    while n > 0 { tmp[i] = b'0' + (n % 10) as u8; i += 1; n /= 10; }
-    if i > buf.len() { return 0; }
-    for j in 0..i { buf[j] = tmp[i - 1 - j]; }
-    i
+fn fmt_u64(buf: &mut [u8], mut n: u64) -> usize {
+    if buf.is_empty() { return 0; }
+    if n == 0 { buf[0] = b'0'; return 1; }
+    let mut tmp = [0u8; 20]; let mut cnt = 0;
+    while n > 0 { tmp[cnt] = b'0'+(n%10) as u8; cnt+=1; n/=10; }
+    if cnt > buf.len() { return 0; }
+    for i in 0..cnt { buf[i] = tmp[cnt-1-i]; }
+    cnt
 }
 
-fn fmt_resolution<'a>(buf: &'a mut [u8; 24], w: u16, h: u16) -> &'a str {
+fn fmt_res<'a>(buf: &'a mut [u8; 24], w: u16, h: u16) -> &'a str {
     let mut p = 0usize;
-    p += write_u64(&mut buf[p..], w as u64);
-    buf[p..p+3].copy_from_slice(b" x "); p += 3;
-    p += write_u64(&mut buf[p..], h as u64);
+    p += fmt_u64(&mut buf[p..], w as u64);
+    buf[p..p+3].copy_from_slice(b" x "); p+=3;
+    p += fmt_u64(&mut buf[p..], h as u64);
     core::str::from_utf8(&buf[..p]).unwrap_or("?")
 }
 
 fn fmt_info<'a>(buf: &'a mut [u8; 44], w: u16, h: u16) -> &'a str {
-    let pre = b"Selected: "; buf[..pre.len()].copy_from_slice(pre); let mut p = pre.len();
-    p += write_u64(&mut buf[p..], w as u64);
-    buf[p..p+3].copy_from_slice(b" x "); p += 3;
-    p += write_u64(&mut buf[p..], h as u64);
-    let suf = b" @ 32bpp  60Hz"; buf[p..p+suf.len()].copy_from_slice(suf); p += suf.len();
+    let pre = b"Selected: "; buf[..pre.len()].copy_from_slice(pre); let mut p=pre.len();
+    p += fmt_u64(&mut buf[p..], w as u64);
+    buf[p..p+3].copy_from_slice(b" x "); p+=3;
+    p += fmt_u64(&mut buf[p..], h as u64);
+    let suf = b" @ 32bpp  60Hz"; buf[p..p+suf.len()].copy_from_slice(suf); p+=suf.len();
     core::str::from_utf8(&buf[..p]).unwrap_or("?")
 }
 
-fn build_ver_str(buf: &mut [u8; 32], ver: &str, code: &str) -> usize {
-    let mut p = 0usize;
-    for b in ver.bytes() { if p < 31 { buf[p] = b; p += 1; } }
-    let sep = b" (";
-    for b in sep { if p < 31 { buf[p] = *b; p += 1; } }
-    for b in code.bytes() { if p < 31 { buf[p] = b; p += 1; } }
-    if p < 31 { buf[p] = b')'; p += 1; }
+fn fmt_mem(buf: &mut [u8; 48], used: u64, total: u64) -> usize {
+    let mut p=0;
+    p+=fmt_u64(&mut buf[p..], used/1024);
+    let mid=b" MB used / "; for b in mid { buf[p]=*b; p+=1; }
+    p+=fmt_u64(&mut buf[p..], total/1024);
+    let suf=b" MB total"; for b in suf { buf[p]=*b; p+=1; }
     p
 }
 
-fn build_mem_str(buf: &mut [u8; 48], used_kb: u64, total_kb: u64) -> usize {
-    let mut p = 0usize;
-    p += write_u64(&mut buf[p..], used_kb / 1024);
-    let mid = b" MB / "; for b in mid { buf[p] = *b; p += 1; }
-    p += write_u64(&mut buf[p..], total_kb / 1024);
-    let suf = b" MB"; for b in suf { buf[p] = *b; p += 1; }
-    p
+fn fit_in(sw: u32, sh: u32, mw: u32, mh: u32) -> (u32, u32) {
+    if sw==0||sh==0||mw==0||mh==0 { return (1,1); }
+    let s = ((mw as u64*1024)/sw as u64).min((mh as u64*1024)/sh as u64).max(1);
+    (((sw as u64*s)/1024).max(1) as u32, ((sh as u64*s)/1024).max(1) as u32)
 }
 
-fn fit_within(sw: u32, sh: u32, mw: u32, mh: u32) -> (u32, u32) {
-    if sw == 0 || sh == 0 || mw == 0 || mh == 0 { return (0, 0); }
-    let scale_w = (mw as u64 * 1024) / sw as u64;
-    let scale_h = (mh as u64 * 1024) / sh as u64;
-    let scale = scale_w.min(scale_h).max(1);
-    (((sw as u64 * scale) / 1024).max(1) as u32, ((sh as u64 * scale) / 1024).max(1) as u32)
+fn query_modes() -> ([Mode; VIDEO_MAX_MODES], usize) {
+    let cnt = video_mode_count().min(VIDEO_MAX_MODES);
+    if cnt == 0 { return ([Mode{w:0,h:0}; VIDEO_MAX_MODES], 0); }
+    let mut raw = [VideoModeEntry::default(); VIDEO_MAX_MODES];
+    let n = get_video_modes(&mut raw[..cnt]);
+    let mut modes = [Mode{w:0,h:0}; VIDEO_MAX_MODES];
+    for i in 0..n { modes[i] = Mode { w: raw[i].width as u16, h: raw[i].height as u16 }; }
+    (modes, n)
 }
 
 // ── Entry point ───────────────────────────────────────────────────────────────
@@ -1349,41 +1216,35 @@ pub extern "C" fn _start() -> ! { main() }
 
 fn main() -> ! {
     log("SystemSettings: starting");
-
     let port = match create_port() {
         Ok(p) => p,
         Err(_) => { log("SystemSettings: create_port failed"); exit(1); }
     };
     let _ = libipc::protocol::register_service("system_settings", port);
 
-    log("SystemSettings: looking up compositor.register");
-    let reg_port = loop {
+    let reg = loop {
         match libipc::protocol::lookup_service("compositor.register") {
             Ok(p) => break p,
             Err(_) => yield_now(),
         }
     };
-
     let mut rmsg = [0u8; MessageHeader::SIZE + 16];
     let hdr = MessageHeader::new(MessageType::AppRegister, 16);
     rmsg[..MessageHeader::SIZE].copy_from_slice(&hdr.to_bytes());
-    rmsg[MessageHeader::SIZE..MessageHeader::SIZE + 8].copy_from_slice(&port.to_le_bytes());
-    rmsg[MessageHeader::SIZE + 8..MessageHeader::SIZE + 16].copy_from_slice(&0u64.to_le_bytes());
-    let _ = send(reg_port, &rmsg[..MessageHeader::SIZE + 16]);
+    rmsg[MessageHeader::SIZE..MessageHeader::SIZE+8].copy_from_slice(&port.to_le_bytes());
+    rmsg[MessageHeader::SIZE+8..MessageHeader::SIZE+16].copy_from_slice(&0u64.to_le_bytes());
+    let _ = send(reg, &rmsg[..MessageHeader::SIZE+16]);
 
-    let sa = match SystemSettings::wait_for_surface(port) {
+    let sa = match App::wait_surface(port) {
         Some(sa) => sa,
         None => { log("SystemSettings: surface timeout"); exit(1); }
     };
-
-    let surface = match SharedSurface::from_region(sa.region_id, sa.width, sa.height) {
+    let surf = match SharedSurface::from_region(sa.region_id, sa.width, sa.height) {
         Ok(s) => s,
         Err(_) => { log("SystemSettings: surface map failed"); exit(1); }
     };
-
-    let (modes, mode_count) = query_modes();
-    let mut app = SystemSettings::new(sa.window_id, sa.compositor_port, port,
-                                      surface, modes, mode_count);
+    let (modes, mcnt) = query_modes();
+    let mut app = App::new(sa.window_id, sa.compositor_port, port, surf, modes, mcnt);
     app.run();
     exit(0);
 }

--- a/userspace/system_apps/system_settings/src/main.rs
+++ b/userspace/system_apps/system_settings/src/main.rs
@@ -140,20 +140,22 @@ const ROW_H:      u32 = 22;
 const VIS_ROWS:   usize = 12;
 const SBW:        u32 = 8;    // scrollbar width
 
-// Wallpaper page — fixed absolute y-positions from content top (y=0)
-// Page title + divider take  CH+6+4+2 = 20px baseline → section starts at 32
 const PTITLE_H:  u32 = CH + 14;  // 22 — page title block height
+const SEC_LBL_H: u32 = CH + 8;   // 16 — section label row height
 
-const SEC_LBL_H: u32 = CH + 8;  // 16 — section label row height
+// Desktop Background mode toggle
+const MTOG_H:  u32 = 26;   // toggle pill height
+const MTOG_W:  u32 = 118;  // each option width
+const MTOG_G:  u32 = 2;    // gap between options
 
-// Color swatches
-const CSZ:   u32 = 44;   // swatch size
-const CGAP:  u32 = 8;    // gap between swatches (4 per row × 2 rows)
+// Color swatches — 4 columns × 4 rows = 16 swatches
+const CSZ:   u32 = 40;   // swatch size
+const CGAP:  u32 = 8;    // gap
 
-// Scaling buttons
-const SBTN_W:  u32 = 56;
+// Scaling buttons — single row of 5
+const SBTN_W:  u32 = 58;
 const SBTN_H:  u32 = 22;
-const SBTN_G:  u32 = 8;
+const SBTN_G:  u32 = 6;
 
 // Wallpaper image tiles
 const TW:     u32 = 84;
@@ -174,6 +176,9 @@ const DEF_H: u16 = 768;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Page { DesktopBg, DisplayRes, AboutSys }
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum WpMode { Color, Image }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum StatusKind { None, Ok, Warn }
@@ -208,7 +213,8 @@ enum ThumbSt { Pending, Loaded { w: u16, h: u16 }, Fail }
 struct WpImage { name: String, path: String, thumb: ThumbSt }
 
 struct WpState {
-    swatches: [Color; 8],
+    mode:     WpMode,
+    swatches: [Color; 16],
     images:   Vec<WpImage>,
     selected: Option<WpSrc>,
     scaling:  ScalingMode,
@@ -217,11 +223,20 @@ struct WpState {
 impl WpState {
     fn new() -> Self {
         Self {
+            mode: WpMode::Color,
             swatches: [
-                Color::new(18,20,28), Color::new(12,14,22),
-                Color::new(24,28,42), Color::new(16,24,40),
-                Color::new(22,36,52), Color::new(28,18,36),
-                Color::new(20,30,24), Color::new(34,20,20),
+                // Row 1: deep darks
+                Color::new(0x0B,0x0E,0x13), Color::new(0x11,0x11,0x11),
+                Color::new(0x1A,0x1A,0x2E), Color::new(0x16,0x21,0x3E),
+                // Row 2: mid-dark tones
+                Color::new(0x1F,0x2D,0x4E), Color::new(0x2C,0x1A,0x3E),
+                Color::new(0x0F,0x2F,0x27), Color::new(0x3D,0x1A,0x1A),
+                // Row 3: medium / warm
+                Color::new(0x4A,0x4A,0x5A), Color::new(0x5A,0x46,0x3A),
+                Color::new(0x3A,0x4E,0x3A), Color::new(0x6A,0x55,0x44),
+                // Row 4: light
+                Color::new(0xC8,0xCC,0xD8), Color::new(0xE8,0xE4,0xD8),
+                Color::new(0xC4,0xDC,0xF4), Color::new(0xF4,0xF4,0xF4),
             ],
             images: Vec::new(),
             selected: None,
@@ -229,16 +244,17 @@ impl WpState {
             loading: false,
         }
     }
-    fn is_image_sel(&self) -> bool { matches!(self.selected, Some(WpSrc::Image { .. })) }
     fn pick_color(&mut self, i: usize) {
-        if i >= 8 { return; }
+        if i >= 16 { return; }
         let c = self.swatches[i];
         let rgb = ((c.r as u32) << 16) | ((c.g as u32) << 8) | c.b as u32;
         self.selected = Some(WpSrc::Color { rgb });
+        self.mode = WpMode::Color;
     }
     fn pick_image(&mut self, i: usize) {
         if let Some(img) = self.images.get(i) {
             self.selected = Some(WpSrc::Image { path: img.path.clone() });
+            self.mode = WpMode::Image;
         }
     }
     fn discover(&mut self) {
@@ -409,48 +425,42 @@ impl App {
     }
 
     // ── Wallpaper page element positions (absolute) ───────────────────────────
+    //
+    // y layout:
+    //   0              : page title
+    //   PTITLE_H+8     : mode toggle  [Solid Color | Wallpaper Image]
+    //   +MTOG_H+12     : body start — colour swatches (Color mode)
+    //                                 OR scale picker + image tiles (Image mode)
+    //   sh-STAT_H-BTN_H-10 : Apply button
 
-    // Content y layout (from y=0 at the top of the surface):
-    //   0  .. PTITLE_H        : page title block
-    //   PTITLE_H .. PTITLE_H+2: thin divider
-    //   — section "Background Color"
-    //   — 4×2 color swatches
-    //   — section "Image Scaling"
-    //   — scaling buttons
-    //   — section "Wallpaper Images"
-    //   — image tiles
-    //   sh-STAT_H-BTN_H-12   : Apply button
+    fn wp_toggle_y(&self) -> u32 { PTITLE_H + 8 }
+    fn wp_body_y(&self)   -> u32 { self.wp_toggle_y() + MTOG_H + 12 }
 
-    fn wp_section1_y(&self) -> u32 { PTITLE_H + 4 }
+    // Color mode: 4×4 swatch grid (label at wp_body_y, swatches below it)
     fn wp_swatch_row_y(&self, row: u32) -> u32 {
-        self.wp_section1_y() + SEC_LBL_H + row * (CSZ + CGAP)
+        self.wp_body_y() + SEC_LBL_H + row * (CSZ + CGAP)
     }
-    fn wp_section2_y(&self) -> u32 { self.wp_swatch_row_y(2) + 4 }
-    fn wp_sbtn_row_y(&self, row: u32) -> u32 {
-        self.wp_section2_y() + SEC_LBL_H + row * (SBTN_H + SBTN_G)
-    }
-    fn wp_section3_y(&self) -> u32 { self.wp_sbtn_row_y(2) + 6 }
-    fn wp_tile_row_y(&self, row: u32) -> u32 {
-        self.wp_section3_y() + SEC_LBL_H + row * (TH + TG)
-    }
-
     fn swatch_rect(&self, i: usize) -> (u32, u32) {
-        let cx = self.cx();
         let col = (i % 4) as u32;
         let row = (i / 4) as u32;
-        (cx + PAD + col * (CSZ + CGAP), self.wp_swatch_row_y(row))
+        (self.cx() + PAD + col * (CSZ + CGAP), self.wp_swatch_row_y(row))
+    }
+
+    // Image mode: scale row then tiles
+    fn wp_scale_y(&self)    -> u32 { self.wp_body_y() }
+    fn wp_sbtn_y(&self)     -> u32 { self.wp_scale_y() + SEC_LBL_H }
+    fn wp_tiles_label_y(&self) -> u32 { self.wp_sbtn_y() + SBTN_H + 12 }
+    fn wp_tile_row_y(&self, row: u32) -> u32 {
+        self.wp_tiles_label_y() + SEC_LBL_H + row * (TH + TG)
     }
     fn sbtn_rect(&self, i: usize) -> (u32, u32) {
-        let cx = self.cx();
-        let col = (i % 3) as u32;
-        let row = (i / 3) as u32;
-        (cx + PAD + col * (SBTN_W + SBTN_G), self.wp_sbtn_row_y(row))
+        // All 5 scaling options in a single row
+        (self.cx() + PAD + i as u32 * (SBTN_W + SBTN_G), self.wp_sbtn_y())
     }
     fn tile_rect(&self, vis: usize) -> (u32, u32) {
-        let cx = self.cx();
         let col = (vis % TCOLS) as u32;
         let row = (vis / TCOLS) as u32;
-        (cx + PAD + col * (TW + TG), self.wp_tile_row_y(row))
+        (self.cx() + PAD + col * (TW + TG), self.wp_tile_row_y(row))
     }
 
     fn apply_btn(&self) -> (u32, u32) {
@@ -669,44 +679,89 @@ impl App {
 
     // ── Desktop Background page ───────────────────────────────────────────────
 
+    fn draw_wp_toggle(&self, s: &SharedSurface) {
+        let cx  = self.cx();
+        let y   = self.wp_toggle_y();
+        let x0  = cx + PAD;
+        let tw  = MTOG_W * 2 + MTOG_G + 4;
+        // Outer track
+        s.fill_rect_rounded_aa(x0, y, tw, MTOG_H, MTOG_H / 2, theme::SURFACE);
+        s.draw_rect_rounded_aa(x0, y, tw, MTOG_H, MTOG_H / 2, theme::BORDER);
+        // Active pill
+        let pill_x = if self.wp.mode == WpMode::Color { x0 + 2 }
+                     else { x0 + 2 + MTOG_W + MTOG_G };
+        s.fill_rect_rounded_aa(pill_x, y + 2, MTOG_W, MTOG_H - 4, (MTOG_H - 4) / 2, theme::ACCENT);
+        // Labels
+        let labels = ["Solid Color", "Wallpaper Image"];
+        for (i, lbl) in labels.iter().enumerate() {
+            let lx = x0 + 2 + i as u32 * (MTOG_W + MTOG_G);
+            let active = (i == 0 && self.wp.mode == WpMode::Color)
+                      || (i == 1 && self.wp.mode == WpMode::Image);
+            let fg = if active { theme::BTN_TEXT } else { theme::TEXT_SEC };
+            let bg = if active { theme::ACCENT } else { theme::SURFACE };
+            let tx = lx + (MTOG_W.saturating_sub(lbl.len() as u32 * CW)) / 2;
+            s.draw_string(tx, y + (MTOG_H - CH) / 2, lbl, fg, bg);
+        }
+    }
+
     fn draw_desktop_bg(&self, s: &SharedSurface) {
-        let cx = self.cx();
-        let cw = self.cw();
-
         self.draw_page_title(s, "Desktop Background");
+        self.draw_wp_toggle(s);
 
-        // Section: Background Color
-        self.draw_sec_label(s, self.wp_section1_y(), "Background Color");
+        match self.wp.mode {
+            WpMode::Color => self.draw_wp_color_section(s),
+            WpMode::Image => self.draw_wp_image_section(s),
+        }
 
-        // 4×2 colour swatches
-        for i in 0..8 {
+        // Apply button (bottom-right)
+        let (ax, ay) = self.apply_btn();
+        s.fill_rect_rounded_aa(ax, ay, BTN_W, BTN_H, 7, theme::BTN_PRIMARY);
+        let lbl = "Apply";
+        let lx = ax + (BTN_W.saturating_sub(lbl.len() as u32 * CW)) / 2;
+        s.draw_string(lx, ay + (BTN_H - CH) / 2, lbl, theme::BTN_TEXT, theme::BTN_PRIMARY);
+    }
+
+    fn draw_wp_color_section(&self, s: &SharedSurface) {
+        let cx = self.cx();
+        self.draw_sec_label(s, self.wp_body_y(), "Background Color");
+        // 4×4 swatch grid (16 colours: 4 dark, 4 mid-dark, 4 medium/warm, 4 light)
+        for i in 0..16 {
             let (sx, sy) = self.swatch_rect(i);
             let c = self.wp.swatches[i];
             let rgb = ((c.r as u32) << 16) | ((c.g as u32) << 8) | c.b as u32;
             let active = matches!(&self.wp.selected, Some(WpSrc::Color { rgb: r }) if *r == rgb);
-            s.fill_rect_rounded_aa(sx, sy, CSZ, CSZ, 8, c);
+            s.fill_rect_rounded_aa(sx, sy, CSZ, CSZ, 7, c);
             if active {
-                // Double ring highlight
-                s.draw_rect_rounded_aa(sx.saturating_sub(2), sy.saturating_sub(2), CSZ+4, CSZ+4, 9, theme::ACCENT);
-                s.draw_rect_rounded_aa(sx.saturating_sub(3), sy.saturating_sub(3), CSZ+6, CSZ+6, 10, theme::ACCENT_DIM);
+                s.draw_rect_rounded_aa(sx.saturating_sub(2), sy.saturating_sub(2), CSZ+4, CSZ+4, 8, theme::ACCENT);
+                s.draw_rect_rounded_aa(sx.saturating_sub(3), sy.saturating_sub(3), CSZ+6, CSZ+6, 9, theme::ACCENT_DIM);
             } else {
-                s.draw_rect_rounded_aa(sx, sy, CSZ, CSZ, 8, theme::BORDER);
+                // Subtle border — brighter for light swatches so they don't vanish on light bg
+                let border = if c.r > 0xB0 { theme::TEXT_MUTED } else { theme::BORDER };
+                s.draw_rect_rounded_aa(sx, sy, CSZ, CSZ, 7, border);
             }
         }
+        // Row labels on the left
+        let row_labels = ["Dark", "Deep", "Mid", "Light"];
+        for (r, lbl) in row_labels.iter().enumerate() {
+            let ry = self.wp_swatch_row_y(r as u32) + (CSZ - CH) / 2;
+            let lx = cx + PAD + 4 * (CSZ + CGAP) + 10;
+            s.draw_string(lx, ry, lbl, theme::TEXT_MUTED, theme::BG);
+        }
+    }
 
-        // Section: Image Scaling
-        self.draw_sec_label(s, self.wp_section2_y(), "Image Scaling");
+    fn draw_wp_image_section(&self, s: &SharedSurface) {
+        let cx = self.cx();
+
+        // Scaling picker
+        self.draw_sec_label(s, self.wp_scale_y(), "Image Scaling");
         let modes = [ScalingMode::Fill, ScalingMode::Fit, ScalingMode::Stretch,
                      ScalingMode::Center, ScalingMode::Tile];
         for (i, mode) in modes.iter().enumerate() {
             let (bx, by) = self.sbtn_rect(i);
-            let enabled = self.wp.is_image_sel();
-            let is_sel  = self.wp.scaling == *mode;
-            let bg = if is_sel && enabled { theme::SEL_BG }
-                     else if enabled      { theme::SURFACE }
-                     else                 { theme::SURFACE_ALT };
-            let fg = if enabled { theme::TEXT } else { theme::TEXT_MUTED };
-            let border = if is_sel && enabled { theme::ACCENT } else { theme::BORDER };
+            let is_sel = self.wp.scaling == *mode;
+            let bg     = if is_sel { theme::SEL_BG } else { theme::SURFACE };
+            let fg     = theme::TEXT;
+            let border = if is_sel { theme::ACCENT } else { theme::BORDER };
             s.fill_rect_rounded_aa(bx, by, SBTN_W, SBTN_H, 5, bg);
             s.draw_rect_rounded_aa(bx, by, SBTN_W, SBTN_H, 5, border);
             let lbl = mode.to_str();
@@ -714,8 +769,8 @@ impl App {
             s.draw_string(lx, by + (SBTN_H - CH) / 2, lbl, fg, bg);
         }
 
-        // Section: Wallpaper Images
-        self.draw_sec_label(s, self.wp_section3_y(), "Wallpaper Images");
+        // Wallpaper image tiles
+        self.draw_sec_label(s, self.wp_tiles_label_y(), "Wallpaper Images");
         let start = self.wpscr;
         let vis   = 2 * TCOLS;
         let end   = (start + vis).min(self.wp.images.len());
@@ -725,55 +780,45 @@ impl App {
             if ty + TH > self.sh { continue; }
             let img = &self.wp.images[idx];
             let sel = matches!(&self.wp.selected, Some(WpSrc::Image { path: p }) if p == &img.path);
-            let bg = if sel { theme::SEL_BG } else { theme::SURFACE };
-            let brd= if sel { theme::ACCENT } else { theme::BORDER };
+            let bg  = if sel { theme::SEL_BG } else { theme::SURFACE };
+            let brd = if sel { theme::ACCENT  } else { theme::BORDER };
             s.fill_rect_rounded_aa(tx, ty, TW, TH, 6, bg);
             s.draw_rect_rounded_aa(tx, ty, TW, TH, 6, brd);
-            // Thumbnail placeholder
             let ph = TH.saturating_sub(CH + 8);
             let pw = TW.saturating_sub(12);
             let px = tx + 6; let py = ty + 4;
-            s.fill_rect_rounded_aa(px, py, pw, ph, 4, Color::new(28,34,50));
+            s.fill_rect_rounded_aa(px, py, pw, ph, 4, Color::new(28, 34, 50));
             match img.thumb {
                 ThumbSt::Loaded { w, h } => {
-                    let (dw, dh) = fit_in(w as u32, h as u32, pw-4, ph-4);
-                    let dx=px+(pw-dw)/2; let dy=py+(ph-dh)/2;
-                    s.fill_rect_rounded_aa(dx,dy,dw,dh,3,theme::ACCENT_DIM);
+                    let (dw, dh) = fit_in(w as u32, h as u32, pw - 4, ph - 4);
+                    let dx = px + (pw - dw) / 2; let dy = py + (ph - dh) / 2;
+                    s.fill_rect_rounded_aa(dx, dy, dw, dh, 3, theme::ACCENT_DIM);
                 }
                 ThumbSt::Fail => {
-                    s.draw_rect_rounded_aa(px+6,py+4,pw-12,ph-8,3,theme::WARNING);
+                    s.draw_rect_rounded_aa(px + 6, py + 4, pw - 12, ph - 8, 3, theme::WARNING);
                 }
                 ThumbSt::Pending => {
-                    let dw=pw/3; let dh=ph/3;
-                    s.fill_rect_rounded_aa(px+dw,py+dh,dw,dh,3,theme::SB_THUMB);
+                    let dw = pw / 3; let dh = ph / 3;
+                    s.fill_rect_rounded_aa(px + dw, py + dh, dw, dh, 3, theme::SB_THUMB);
                 }
             }
-            // Filename (truncated to tile width)
             let max_c = (TW / CW) as usize;
-            let lbl = if img.name.len()>max_c { &img.name[..max_c] } else { &img.name };
-            s.draw_string(tx+4, ty+TH-CH-2, lbl, theme::TEXT_SEC, bg);
+            let lbl = if img.name.len() > max_c { &img.name[..max_c] } else { &img.name };
+            s.draw_string(tx + 4, ty + TH - CH - 2, lbl, theme::TEXT_SEC, bg);
         }
         if self.wp.loading {
-            let y = self.wp_section3_y() + SEC_LBL_H + 4;
-            s.draw_string(cx + PAD, y, "Loading...", theme::TEXT_MUTED, theme::BG);
+            s.draw_string(cx + PAD, self.wp_tiles_label_y() + SEC_LBL_H + 4,
+                          "Loading...", theme::TEXT_MUTED, theme::BG);
         } else if self.wp.images.is_empty() {
-            let y = self.wp_section3_y() + SEC_LBL_H + 4;
-            s.draw_string(cx + PAD, y, "No images in /system/wallpapers/", theme::TEXT_MUTED, theme::BG);
+            s.draw_string(cx + PAD, self.wp_tiles_label_y() + SEC_LBL_H + 4,
+                          "No images in /system/wallpapers/", theme::TEXT_MUTED, theme::BG);
         }
-
-        // Apply button (bottom-right of content)
-        let (ax, ay) = self.apply_btn();
-        s.fill_rect_rounded_aa(ax, ay, BTN_W, BTN_H, 7, theme::BTN_PRIMARY);
-        let lbl = "Apply";
-        let lx = ax + (BTN_W.saturating_sub(lbl.len() as u32 * CW)) / 2;
-        s.draw_string(lx, ay+(BTN_H-CH)/2, lbl, theme::BTN_TEXT, theme::BTN_PRIMARY);
     }
 
     // ── Display Resolution page ───────────────────────────────────────────────
 
     fn draw_display_res(&self, s: &SharedSurface) {
         let cx = self.cx();
-        let cw = self.cw();
 
         self.draw_page_title(s, "Display Resolution");
 
@@ -961,35 +1006,50 @@ impl App {
     }
 
     fn on_wp_click(&mut self, mx: i32, my: i32) {
-        // Colour swatches
-        for i in 0..8 {
-            let (sx, sy) = self.swatch_rect(i);
-            if in_rect(mx, my, sx, sy, CSZ, CSZ) {
-                self.wp.pick_color(i); self.dirty = true; return;
-            }
-        }
-        // Scaling buttons
-        let modes = [ScalingMode::Fill, ScalingMode::Fit, ScalingMode::Stretch,
-                     ScalingMode::Center, ScalingMode::Tile];
-        for (i, mode) in modes.iter().enumerate() {
-            let (bx, by) = self.sbtn_rect(i);
-            if in_rect(mx, my, bx, by, SBTN_W, SBTN_H) {
-                if self.wp.is_image_sel() { self.wp.scaling = *mode; self.dirty = true; }
-                return;
-            }
-        }
-        // Image tiles
-        let start = self.wpscr;
-        let end = (start + 2*TCOLS).min(self.wp.images.len());
-        for idx in start..end {
-            let (tx, ty) = self.tile_rect(idx - start);
-            if in_rect(mx, my, tx, ty, TW, TH) {
-                self.wp.pick_image(idx); self.dirty = true; return;
-            }
-        }
         // Apply button
         let (ax, ay) = self.apply_btn();
-        if in_rect(mx, my, ax, ay, BTN_W, BTN_H) { self.apply_wallpaper(); }
+        if in_rect(mx, my, ax, ay, BTN_W, BTN_H) { self.apply_wallpaper(); return; }
+
+        // Mode toggle
+        let ty = self.wp_toggle_y();
+        let x0 = self.cx() + PAD;
+        if in_rect(mx, my, x0 + 2, ty, MTOG_W, MTOG_H) {
+            self.wp.mode = WpMode::Color; self.dirty = true; return;
+        }
+        if in_rect(mx, my, x0 + 2 + MTOG_W + MTOG_G, ty, MTOG_W, MTOG_H) {
+            self.wp.mode = WpMode::Image; self.dirty = true; return;
+        }
+
+        match self.wp.mode {
+            WpMode::Color => {
+                for i in 0..16 {
+                    let (sx, sy) = self.swatch_rect(i);
+                    if in_rect(mx, my, sx, sy, CSZ, CSZ) {
+                        self.wp.pick_color(i); self.dirty = true; return;
+                    }
+                }
+            }
+            WpMode::Image => {
+                // Scaling buttons
+                let smodes = [ScalingMode::Fill, ScalingMode::Fit, ScalingMode::Stretch,
+                              ScalingMode::Center, ScalingMode::Tile];
+                for (i, mode) in smodes.iter().enumerate() {
+                    let (bx, by) = self.sbtn_rect(i);
+                    if in_rect(mx, my, bx, by, SBTN_W, SBTN_H) {
+                        self.wp.scaling = *mode; self.dirty = true; return;
+                    }
+                }
+                // Image tiles
+                let start = self.wpscr;
+                let end = (start + 2 * TCOLS).min(self.wp.images.len());
+                for idx in start..end {
+                    let (tx, tiy) = self.tile_rect(idx - start);
+                    if in_rect(mx, my, tx, tiy, TW, TH) {
+                        self.wp.pick_image(idx); self.dirty = true; return;
+                    }
+                }
+            }
+        }
     }
 
     fn on_res_click(&mut self, mx: i32, my: i32) {

--- a/userspace/system_apps/ui_shell/src/main.rs
+++ b/userspace/system_apps/ui_shell/src/main.rs
@@ -721,7 +721,7 @@ fn window_title_for(executable: &str) -> &str {
     match executable {
         "fileman" => "File Manager",
         "terminal" => "Terminal",
-        "display_settings" => "Display Settings",
+        "system_settings" => "System Settings",
         "tinygl_demo" => "TinyGL Gears",
         other => other,
     }
@@ -1498,7 +1498,7 @@ impl Compositor {
     fn build_dock_apps() -> Vec<DockApp> {
         let candidates: [(&str, &str, Color); 4] = [
             ("fileman", "Files", atom_theme::colors::ATOM_COLOR_ACCENT_GLOW),
-            ("display_settings", "Settings", atom_theme::colors::ATOM_COLOR_ACCENT),
+            ("system_settings", "Settings", atom_theme::colors::ATOM_COLOR_ACCENT),
             ("tinygl_demo", "TinyGL", atom_theme::colors::ATOM_COLOR_SUCCESS),
             ("terminal", "Terminal", atom_theme::colors::ATOM_GRADIENT_PRIMARY_END),
         ];
@@ -2685,13 +2685,13 @@ impl Compositor {
     }
 
     fn open_display_settings_wallpaper_tab(&mut self) {
-        let port = match libipc::protocol::lookup_service("display_settings") {
+        let port = match libipc::protocol::lookup_service("system_settings") {
             Ok(port) => port,
             Err(_) => {
                 self.spawn_display_settings();
                 let mut found = None;
                 for _ in 0..80 {
-                    if let Ok(port) = libipc::protocol::lookup_service("display_settings") {
+                    if let Ok(port) = libipc::protocol::lookup_service("system_settings") {
                         found = Some(port);
                         break;
                     }
@@ -2708,7 +2708,7 @@ impl Compositor {
             .wm
             .windows
             .iter()
-            .find(|w| w.title == "Display Settings")
+            .find(|w| w.title == "System Settings")
             .map(|w| w.id)
         {
             self.wm.focus_window(id);
@@ -2716,8 +2716,8 @@ impl Compositor {
         }
 
         let msg = OpenInTabMsg {
-            target_app: String::from("display_settings"),
-            tab_name: String::from("Wallpaper"),
+            target_app: String::from("system_settings"),
+            tab_name: String::from("Desktop Background"),
         };
         let payload = msg.to_bytes();
         let header = MessageHeader::new(MessageType::OpenInTab, payload.len() as u32);
@@ -2729,7 +2729,7 @@ impl Compositor {
     }
 
     fn send_wallpaper_applied(&mut self) {
-        if let Ok(port) = libipc::protocol::lookup_service("display_settings") {
+        if let Ok(port) = libipc::protocol::lookup_service("system_settings") {
             let msg = WallpaperAppliedMsg {};
             let header =
                 MessageHeader::new(MessageType::WallpaperApplied, WallpaperAppliedMsg::SIZE as u32);
@@ -2741,7 +2741,7 @@ impl Compositor {
     }
 
     fn send_wallpaper_failed(&mut self, error: &str) {
-        if let Ok(port) = libipc::protocol::lookup_service("display_settings") {
+        if let Ok(port) = libipc::protocol::lookup_service("system_settings") {
             let msg = WallpaperFailedMsg { error_message: String::from(error) };
             let payload = msg.to_bytes();
             let header = MessageHeader::new(MessageType::WallpaperFailed, payload.len() as u32);
@@ -3258,7 +3258,7 @@ impl Compositor {
         match name {
             "terminal" => return self.spawn_terminal(),
             "fileman" => return self.spawn_fileman(),
-            "display_settings" => return self.spawn_display_settings(),
+            "system_settings" => return self.spawn_display_settings(),
             _ => {}
         }
 
@@ -3315,10 +3315,10 @@ impl Compositor {
     }
 
     fn spawn_display_settings(&mut self) {
-        if !self.request_app_launch("/apps/system/display_settings.atxf") {
+        if !self.request_app_launch("/apps/system/system_settings.atxf") {
             return;
         }
-        self.spawn_hosted_window("Display Settings", 200, 100, 20, 480, 420);
+        self.spawn_hosted_window("System Settings", 160, 80, 20, 700, 520);
     }
 
     fn draw_all(&mut self) {

--- a/userspace/system_apps/ui_shell/src/main.rs
+++ b/userspace/system_apps/ui_shell/src/main.rs
@@ -387,6 +387,14 @@ const PANEL_HEIGHT: u32 = atom_theme::shell::TOP_BAR_HEIGHT;
 const DOCK_HEIGHT: u32 = atom_theme::shell::DOCK_HEIGHT;
 const CLOSE_GRACE_TICKS: u32 = 200;
 
+/// Maximum number of independent damage rectangles tracked per frame before
+/// they are collapsed into a single bounding box. Keeping damage as a list of
+/// disjoint rects (instead of one union) is what stops a continuously-animating
+/// window in one screen corner from forcing a full-screen recomposite — and a
+/// re-blit of every other open window — on every frame. The cap bounds the
+/// per-frame intersection work when damage is genuinely scattered.
+const MAX_DIRTY_RECTS: usize = 16;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Rect {
     pub x: i32,
@@ -1364,7 +1372,7 @@ struct Compositor {
     pending_windows: Vec<PendingWindow>,
     pending_close: Vec<PendingClose>,
     dirty: bool,
-    dirty_rect: Option<Rect>,
+    dirty_rects: Vec<Rect>,
     mouse_left_down: bool,
     mouse_right_down: bool,
     drag_op: DragOperation,
@@ -1433,7 +1441,7 @@ impl Compositor {
             pending_windows: Vec::new(),
             pending_close: Vec::new(),
             dirty: true,
-            dirty_rect: None,
+            dirty_rects: Vec::new(),
             mouse_left_down: false,
             mouse_right_down: false,
             drag_op: DragOperation::None,
@@ -2483,10 +2491,9 @@ impl Compositor {
     }
 
     /// Mark a window's full on-screen footprint (frame + drop shadow) dirty so
-    /// the next `draw_all` actually repaints it. The redraw is otherwise bounded
-    /// by whatever stale `dirty_rect` the last cursor move left behind, which is
-    /// why a freshly presented or freshly raised window could stay invisible
-    /// until unrelated damage happened to cross it.
+    /// the next `draw_all` actually repaints it. Without an explicit footprint,
+    /// a freshly presented or freshly raised window could stay invisible until
+    /// unrelated damage happened to cross it.
     fn mark_window_dirty(&mut self, window_id: WindowId) {
         if let Some(w) = self.wm.get_window(window_id) {
             let rect = Rect::new(w.x - 4, w.y - 4, w.width + 8, w.height + 12);
@@ -2528,12 +2535,13 @@ impl Compositor {
     }
 
     /// Mark the entire screen dirty so the next `draw_all` repaints everything.
-    /// Setting `dirty = true` alone is NOT enough for a full redraw: `draw_all`
-    /// honours any pending `dirty_rect`, so a stale cursor-sized rect would
-    /// silently clip the intended full repaint down to a few pixels (black
-    /// screen / trails that only heal where the mouse happens to move).
+    /// Clears any accumulated damage rects first: a stale cursor-sized rect left
+    /// in the list would otherwise clip the intended full repaint down to a few
+    /// pixels (black screen / trails that only heal where the mouse moves).
     fn mark_dirty_all(&mut self) {
-        self.dirty_rect = Some(Rect::new(0, 0, self.fb.width(), self.fb.height()));
+        self.dirty_rects.clear();
+        self.dirty_rects
+            .push(Rect::new(0, 0, self.fb.width(), self.fb.height()));
         self.dirty = true;
     }
 
@@ -2549,10 +2557,31 @@ impl Compositor {
         }
         let clamped = Rect::new(x1, y1, (x2 - x1) as u32, (y2 - y1) as u32);
 
-        if let Some(existing) = self.dirty_rect {
-            self.dirty_rect = Some(existing.union(&clamped));
+        // Coalesce only with rects we already overlap. A window that presents
+        // the same footprint every frame (an animation) keeps merging into its
+        // own existing entry, so the list stays tiny and disjoint instead of
+        // unioning unrelated corners of the screen into one near-full-screen
+        // box. Non-overlapping damage stays a separate region and is composited
+        // independently in `draw_all`.
+        for existing in self.dirty_rects.iter_mut() {
+            if existing.intersects(&clamped) {
+                *existing = existing.union(&clamped);
+                self.dirty = true;
+                return;
+            }
+        }
+
+        if self.dirty_rects.len() >= MAX_DIRTY_RECTS {
+            // Too much scattered damage to track individually: fall back to a
+            // single bounding box (the previous behaviour) to bound per-frame
+            // bookkeeping. Correctness is preserved; only locality is lost.
+            let mut acc = clamped;
+            for existing in self.dirty_rects.drain(..) {
+                acc = acc.union(&existing);
+            }
+            self.dirty_rects.push(acc);
         } else {
-            self.dirty_rect = Some(clamped);
+            self.dirty_rects.push(clamped);
         }
         self.dirty = true;
     }
@@ -2618,10 +2647,10 @@ impl Compositor {
 
         self.wallpaper_cache_valid = false;
 
-        // The fresh backbuffer is uninitialised and any pending dirty_rect is in
-        // the old resolution's coordinates — repaint the whole new screen, or it
+        // The fresh backbuffer is uninitialised and any pending damage is in the
+        // old resolution's coordinates — repaint the whole new screen, or it
         // stays black except where later damage (e.g. the cursor) happens to land.
-        self.dirty_rect = None;
+        self.dirty_rects.clear();
         self.mark_dirty_all();
         true
     }
@@ -3322,11 +3351,46 @@ impl Compositor {
     }
 
     fn draw_all(&mut self) {
-        let draw_rect = self
-            .dirty_rect
-            .take()
-            .unwrap_or(Rect::new(0, 0, self.fb.width(), self.fb.height()));
+        let rects = core::mem::take(&mut self.dirty_rects);
+        let rects = if rects.is_empty() {
+            // `dirty` was set without an explicit rect: repaint everything.
+            [Rect::new(0, 0, self.fb.width(), self.fb.height())].to_vec()
+        } else {
+            rects
+        };
 
+        // Composite every damaged region into the backbuffer. Each region only
+        // touches the wallpaper, icons and windows that actually intersect it,
+        // so a small animating window no longer drags the whole window stack
+        // into every frame.
+        for rect in &rects {
+            self.composite_region(*rect);
+        }
+
+        // Overlays that always sit on top, drawn once after all regions so they
+        // are never clipped away by a region that excludes them.
+        if self.context_menu.visible {
+            self.draw_context_menu();
+        }
+        self.draw_cursor();
+
+        // Publish each damaged region to the visible framebuffer.
+        for rect in &rects {
+            self.backbuffer_fb.blit_rect(
+                &self.fb,
+                rect.x as u32,
+                rect.y as u32,
+                rect.w,
+                rect.h,
+            );
+        }
+    }
+
+    /// Composite a single damage rectangle into the backbuffer: wallpaper (or
+    /// background), desktop icons, windows, the top panel and the dock — each
+    /// clipped to `draw_rect`. Overlays (context menu, cursor) and the blit to
+    /// the visible framebuffer are handled once by `draw_all`.
+    fn composite_region(&mut self, draw_rect: Rect) {
         if self.wallpaper_cache_valid && !self.wallpaper_cache_ptr.is_null() {
             let sw = self.fb.width();
             let stride = self.backbuffer_fb.stride();
@@ -3389,20 +3453,6 @@ impl Compositor {
                 self.draw_dock();
             }
         }
-
-        if self.context_menu.visible {
-            self.draw_context_menu();
-        }
-
-        self.draw_cursor();
-
-        self.backbuffer_fb.blit_rect(
-            &self.fb,
-            draw_rect.x as u32,
-            draw_rect.y as u32,
-            draw_rect.w,
-            draw_rect.h,
-        );
     }
 
     fn draw_panel(&self) {

--- a/userspace/system_apps/ui_shell/src/main.rs
+++ b/userspace/system_apps/ui_shell/src/main.rs
@@ -18,7 +18,7 @@ use atom_syscall::graphics::{
 };
 use atom_syscall::ipc::{create_port, send, try_recv, wait_any, PortId};
 use atom_syscall::interrupts::register_irq_handler;
-use atom_syscall::thread::{exit, yield_now};
+use atom_syscall::thread::{exit, get_ticks, yield_now};
 use atom_syscall::debug::log;
 use atom_syscall::input::{MouseDriver, keyboard_poll, scancode_to_ascii, scancodes};
 use atom_syscall::fs;
@@ -394,6 +394,14 @@ const CLOSE_GRACE_TICKS: u32 = 200;
 /// re-blit of every other open window — on every frame. The cap bounds the
 /// per-frame intersection work when damage is genuinely scattered.
 const MAX_DIRTY_RECTS: usize = 16;
+
+/// Minimum number of scheduler ticks between composites (frame pacing). The
+/// compositor is single-threaded, so without a cap a client presenting in a
+/// tight loop — or several animating windows — drives it to recomposite
+/// back-to-back and pegs its CPU core. At the 100Hz scheduler tick (10ms),
+/// 2 ticks ≈ 50fps, the closest cap at or below ~60fps the tick granularity
+/// allows. Damage accumulates between slots and drains in a single composite.
+const MIN_FRAME_TICKS: u64 = 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Rect {
@@ -1373,6 +1381,7 @@ struct Compositor {
     pending_close: Vec<PendingClose>,
     dirty: bool,
     dirty_rects: Vec<Rect>,
+    last_composite_tick: u64,
     mouse_left_down: bool,
     mouse_right_down: bool,
     drag_op: DragOperation,
@@ -1442,6 +1451,7 @@ impl Compositor {
             pending_close: Vec::new(),
             dirty: true,
             dirty_rects: Vec::new(),
+            last_composite_tick: 0,
             mouse_left_down: false,
             mouse_right_down: false,
             drag_op: DragOperation::None,
@@ -1568,11 +1578,21 @@ impl Compositor {
 
             self.reap_pending_closes();
             self.flush_deferred_desktop_work();
-            self.flush_pending_snapshots();
 
             if self.dirty {
-                self.draw_all();
-                self.dirty = false;
+                // Frame pacing: only composite once per MIN_FRAME_TICKS. A
+                // present flood still wakes us (to accumulate damage), but the
+                // expensive snapshot+composite work is bounded to the frame
+                // rate instead of running back-to-back at 100% CPU. Snapshots
+                // are taken here, coalesced with the draw, since a pending
+                // snapshot always implies dirty.
+                let now = get_ticks();
+                if now.wrapping_sub(self.last_composite_tick) >= MIN_FRAME_TICKS {
+                    self.flush_pending_snapshots();
+                    self.draw_all();
+                    self.dirty = false;
+                    self.last_composite_tick = now;
+                }
             }
 
             let _ = wait_any(&ports, 10);


### PR DESCRIPTION
## Summary by Sourcery

Introduz um aplicativo unificado de Configurações do Sistema e integra-o em todo o shell, enquanto melhora a eficiência do compositor, o suporte a estatísticas de sistema de arquivos, a introspecção de rede/sistema e reduz o uso de CPU em idle em aplicativos e threads do kernel.

New Features:
- Adiciona um novo app de Configurações do Sistema com navegação baseada em barra lateral para plano de fundo da área de trabalho, rede, resolução de tela e informações do sistema.
- Expõe estatísticas de espaço do sistema de arquivos via um novo caminho `statvfs` desde a syscall do kernel até o backend FSD FAT32.
- Fornece coleta de informações de rede e sistema (CPU, memória, armazenamento, uptime) para suportar as páginas Sobre e Rede em Configurações do Sistema.

Bug Fixes:
- Impede o compositor de renderizar em excesso ao ritmar a composição de frames e rastrear múltiplos retângulos de dano em vez de uma única região “suja”.
- Elimina tearing e flicker em animações de GUI ao introduzir buffers de back por janela e apresentar frames completos de forma atômica.
- Corrige alto uso de CPU em idle em apps e threads SMP smoke substituindo loops ocupados baseados em `yield` por esperas bloqueantes ou `sleep`s temporizados.

Enhancements:
- Substitui a integração do app `display_settings` pelo novo binário `system_settings`, incluindo capacidades de app confiável, integração com o shell e roteamento de IPC de papel de parede.
- Refina o pipeline de desenho do compositor para compor e fazer blit apenas das regiões danificadas e para lidar melhor com redesenhos em tela cheia e mudanças de resolução.
- Estende o protocolo de IPC do daemon de sistema de arquivos e o trait de backend para suportar consultas `statvfs` e respostas em formato de wire.
- Melhora os loops de eventos de Application e File Manager para bloquear na entrada com timeouts em vez de ficar em spinning, preservando a responsividade com menor uso de CPU.

Build:
- Atualiza o script de build para compilar o novo app de sistema `system_settings` em vez do app legado `display_settings`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a unified System Settings application and integrate it across the shell, while improving compositor efficiency, filesystem statistics support, networking/system introspection, and reducing idle CPU usage in apps and kernel threads.

New Features:
- Add a new System Settings app with sidebar-based navigation for desktop background, network, display resolution, and system information.
- Expose filesystem space statistics via a new statvfs path from kernel syscall through the FSD FAT32 backend.
- Provide network and system info gathering (CPU, memory, storage, uptime) to support the About and Network pages in System Settings.

Bug Fixes:
- Prevent compositor from over-rendering by pacing frame composites and tracking multiple damage rectangles instead of a single dirty region.
- Eliminate tearing and flicker in GUI animations by introducing per-window back buffers and presenting complete frames atomically.
- Fix high idle CPU usage in apps and SMP smoke threads by replacing yield-based busy loops with blocking waits or timed sleeps.

Enhancements:
- Replace the display_settings app wiring with the new system_settings binary, including trusted app capabilities, shell integration, and wallpaper IPC routing.
- Refine the compositor’s drawing pipeline to composite and blit only damaged regions and to better handle full-screen redraws and resolution changes.
- Extend the filesystem daemon IPC protocol and backend trait to support statvfs queries and wire-format responses.
- Improve Application and File Manager event loops to block on input with timeouts instead of spinning, preserving responsiveness with lower CPU usage.

Build:
- Update build script to build the new system_settings system app instead of the legacy display_settings app.

</details>